### PR TITLE
Use postgres instead of sqlite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,7 @@ source 'https://rubygems.org'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.4'
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+gem 'pg', '~> 0.18'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
     multi_json (1.11.2)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
+    pg (0.18.3)
     plek (1.11.0)
     rack (1.6.4)
     rack-test (0.6.3)
@@ -143,7 +144,6 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    sqlite3 (1.3.10)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.1)
@@ -170,6 +170,7 @@ DEPENDENCIES
   byebug
   jbuilder (~> 2.0)
   logstasher (= 0.6.2)
+  pg (~> 0.18)
   plek (~> 1.10)
   rails (= 4.2.4)
   rspec-rails (~> 3.3)
@@ -177,7 +178,6 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   simplecov (= 0.10.0)
   simplecov-rcov (= 0.2.3)
-  sqlite3
   uglifier (>= 1.3.0)
   unicorn (~> 4.9.0)
   web-console (~> 2.0)

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,25 +1,22 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
+# This file overwritten on deploy
+
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
+  encoding: unicode
+  # For details on connection pooling, see rails configuration guide
+  # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: 5
-  timeout: 5000
+  # Necessary to allow creating a db with different encodings.
+  # See http://www.postgresql.org/docs/9.1/static/manage-ag-templatedbs.html for details
+  template: template0
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: service-manual-publisher_development
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
-test:
+test: &test
   <<: *default
-  database: db/test.sqlite3
+  database: service-manual-publisher_test
 
-production:
-  <<: *default
-  database: db/production.sqlite3
+cucumber:
+  <<: *test

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,19 @@
+# encoding: UTF-8
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 0) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+end


### PR DESCRIPTION
We're planning to use postgres for storing things in this application, change sqlite gem to pg, update database.yml (borrowed from [here](https://github.com/alphagov/policy-publisher/blob/c50215bc48a8e5894bd905e58b99a12abf2a5922/config/database.yml)) and add an empty db/schema.rb