### PR TITLE
Drop and create database for tests

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -39,8 +39,7 @@ git merge --no-commit origin/master || git merge --abort
 export RAILS_ENV=test
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment --without development
 
-# Uncomment if this app uses a database
-# bundle exec rake db:drop db:create db:schema:load
+bundle exec rake db:drop db:create db:schema:load
 
 if bundle exec rake ${TEST_TASK:-"default"}; then
   github_status "$REPO_NAME" success "succeeded on Jenkins"


### PR DESCRIPTION
This application needs a database to be present for the tests to run
cleanly.

Do this as part of the pre-test build up.