### PR TITLE
Replace web-console with better_errors and binding_of_caller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,8 @@ gem 'airbrake', '~> 4.2.1'
 gem 'govuk_admin_template', '~> 3.0.0'
 
 group :development do
-  gem 'web-console', '~> 2.0'
+  gem 'better_errors'
+  gem 'binding_of_caller'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,10 @@ GEM
     autoprefixer-rails (6.0.3)
       execjs
       json
+    better_errors (2.1.1)
+      coderay (>= 1.0.0)
+      erubis (>= 2.6.6)
+      rack (>= 0.9.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     bootstrap-sass (3.3.5.1)
@@ -50,6 +54,7 @@ GEM
       sass (>= 3.3.0)
     builder (3.2.2)
     byebug (6.0.2)
+    coderay (1.1.0)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
@@ -162,17 +167,14 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
-    web-console (2.2.1)
-      activemodel (>= 4.0)
-      binding_of_caller (>= 0.7.2)
-      railties (>= 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   airbrake (~> 4.2.1)
+  better_errors
+  binding_of_caller
   byebug
   govuk_admin_template (~> 3.0.0)
   logstasher (= 0.6.2)
@@ -185,7 +187,6 @@ DEPENDENCIES
   simplecov-rcov (= 0.2.3)
   uglifier (>= 1.3.0)
   unicorn (~> 4.9.0)
-  web-console (~> 2.0)
 
 BUNDLED WITH
    1.10.6


### PR DESCRIPTION
This provides a more pry-like console in the browser when an error occurs. It
is rather useful for exploring code when developing within a VM, that does not
allow to create a pry session easily.