### PR TITLE
Disable monkey patching in RSpec

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,6 +34,8 @@ RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
+  config.disable_monkey_patching!
+
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.


### PR DESCRIPTION
This change
- stops exposing DSL globally
- disables should and should_not syntax for rspec-expectations
- disables stub, should_receive, and should_not_receive syntax for rspec-mocks

I'm making this change mainly to enforce more consistent syntax in our specs

More: https://www.relishapp.com/rspec/rspec-core/v/3-0/docs/configuration/zero-monkey-patching-mode