### PR TITLE
Add a very basic preview link functionality

### DIFF
--- a/app/helpers/public_routes_helper.rb
+++ b/app/helpers/public_routes_helper.rb
@@ -1,0 +1,6 @@
+module PublicRoutesHelper
+  def document_preview_url(document)
+    frontend_host = Rails.env.production? ? Plek.find('draft-origin') : Plek.find('government-frontend')
+    [frontend_host, document.slug].join
+  end
+end

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -62,6 +62,7 @@
       </div>
       <div class='form-group'>
         <%= f.submit "Save Draft", class: 'btn btn-success', name: :save_draft %>
+        <%= link_to "Preview", document_preview_url(guide), class: 'btn btn-default' %>
         <%= f.submit "Publish", class: 'btn btn-success', name: :publish %>
       </div>
     </fieldset>

--- a/spec/helpers/public_routes_helper_spec.rb
+++ b/spec/helpers/public_routes_helper_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe PublicRoutesHelper do
+  describe "#document_preview_url" do
+    it "concatenates frontend host and document slug" do
+      expect(Plek).to receive(:find).once.and_return("http://frontend-host.dev.gov.uk")
+      guide = Guide.new(slug: "/guide/slug")
+
+      expect(document_preview_url(guide)).to eq "http://frontend-host.dev.gov.uk/guide/slug"
+    end
+  end
+end


### PR DESCRIPTION
Add a link to the guide form controls that allows a content designer to preview
a version of a guide that is currently saved in draft content store. UI is not
great as it does not explain that content needs to be saved before previewing,
but it works as a quick helper for demos and development purposes.

@KushalP is there a better way of doing this?