### PR TITLE
Remove javascript include tag

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,6 @@
 <%# blocks for govuk_admin_template %>
 <% content_for :head do %>
   <%= stylesheet_link_tag "application", media: "all" %>
-  <%= javascript_include_tag "application" %>
   <%= csrf_meta_tag %>
 <% end %>
 <% content_for :app_title do %>GOV.UK Service Manual Publisher<% end %>


### PR DESCRIPTION
It was added in c0a322cd62492ff8342dd6a95e1795e042467dde by copying an example
markup. However, our application does not have any JS yet and this results in a
404 when it's requested on each page load.