### PR TITLE
Add bullet gem for N+1 query detection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'govspeak', '~> 3.4.0'
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
+  gem 'bullet'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,9 @@ GEM
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.3.0)
     builder (3.2.2)
+    bullet (4.14.9)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.9.0)
     byebug (6.0.2)
     capybara (2.5.0)
       mime-types (>= 1.16)
@@ -251,6 +254,7 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    uniform_notifier (1.9.0)
     warden (1.2.3)
       rack (>= 1.0)
     warden-oauth2 (0.0.1)
@@ -265,6 +269,7 @@ DEPENDENCIES
   airbrake (~> 4.2.1)
   better_errors
   binding_of_caller
+  bullet
   byebug
   capybara
   gds-api-adapters (~> 24.4.0)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,4 +38,11 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.alert = true
+    Bullet.console = true
+    Bullet.bullet_logger = true
+  end
 end


### PR DESCRIPTION
As suggested in #17 enable bullet in development environment only. It detects N+1 queries and notifies developers about them.
https://github.com/flyerhzm/bullet

Configuration explained:

```
Bullet.enable - when false the gem does nothing
Bullet.alert - shows a JS alert in a browser window if the page has N+1 problem
Bullet.console - shows a more readable version of above in browser's dev console
Bullet.bullet_logger - logs N+1 to /log/bullet.log
```
Regarding the last option: I figured there is a lot of noise in bowl output on
dev machines so it's better to keep it isolated and easy to follow.