### PR TITLE
Validate Edition#state values

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -9,6 +9,7 @@ class Edition < ActiveRecord::Base
   scope :published, -> { where(state: 'published') }
 
   validates_presence_of [:state, :phase, :description, :title, :update_type, :body, :publisher_title, :publisher_href]
+  validates_inclusion_of :state, in: %w(draft published)
 
   before_validation :assign_publisher_href
 

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Edition, type: :model do
+  describe "validations" do
+    it "allows 'draft' state" do
+      edition = Edition.new(state: 'draft')
+
+      edition.valid?
+
+      expect(edition.errors.full_messages_for(:state).size).to eq 0
+    end
+
+    it "allows 'published' state" do
+      edition = Edition.new(state: 'published')
+
+      edition.valid?
+
+      expect(edition.errors.full_messages_for(:state).size).to eq 0
+    end
+
+    it "does not allow arbitrary values" do
+      edition = Edition.new(state: 'supercharged')
+
+      edition.valid?
+
+      expect(edition.errors.full_messages_for(:state).size).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
They can currently be 'draft' or 'published' only.

As suggested in [another PR](https://github.com/alphagov/service-manual-publisher/pull/17#discussion_r42493630).