### PR TITLE
Prepend /service-manual/ to all guide slugs (for discussion, don't merge)

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -16,6 +16,7 @@ class GuidesController < ApplicationController
 
   def edit
     @guide = Guide.find(params[:id])
+    @guide.slug = @guide.slug.gsub(/^\/service-manual\//, '')
   end
 
   def update
@@ -33,6 +34,7 @@ class GuidesController < ApplicationController
 private
 
   def guide_params
+    params[:guide][:slug] = File.join("/service-manual/", params[:guide][:slug])
     params.require(:guide).permit(
       :slug,
       latest_edition_attributes: [

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -4,7 +4,10 @@
       <legend>Meta</legend>
       <div class='form-group'>
         <%= f.label :slug %>
-        <%= f.text_field :slug, class: 'input-md-12 form-control' %>
+        <div class="input-group">
+          <span class="input-group-addon">/service-manual/</span>
+          <%= f.text_field :slug, class: 'form-control' %>
+        </div>
       </div>
 
       <%= f.fields_for :latest_edition, guide.latest_edition do |editions_form| %>

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "creating guides", type: :feature do
 
     expect(api_double).to receive(:put_draft_content_item)
                             .twice
-                            .with("/the/path", be_valid_against_schema('service_manual_guide'))
+                            .with("/service-manual/the/path", be_valid_against_schema('service_manual_guide'))
 
     click_button "Save Draft"
 
@@ -24,7 +24,7 @@ RSpec.describe "creating guides", type: :feature do
       expect(page).to have_content('created')
     end
 
-    guide = Guide.find_by_slug("/the/path")
+    guide = Guide.find_by_slug("/service-manual/the/path")
     edition = guide.latest_edition
     content_id = guide.content_id
     expect(content_id).to be_present
@@ -46,7 +46,7 @@ RSpec.describe "creating guides", type: :feature do
       expect(page).to have_content('updated')
     end
 
-    guide = Guide.find_by_slug("/the/path")
+    guide = Guide.find_by_slug("/service-manual/the/path")
     edition = guide.latest_edition
     expect(guide.content_id).to eq content_id
     expect(edition.title).to eq "Second Edition Title"
@@ -59,7 +59,7 @@ RSpec.describe "creating guides", type: :feature do
 
     expect(api_double).to receive(:put_content_item)
                             .twice
-                            .with("/the/path", be_valid_against_schema('service_manual_guide'))
+                            .with("/service-manual/the/path", be_valid_against_schema('service_manual_guide'))
 
     click_button "Publish"
 
@@ -67,7 +67,7 @@ RSpec.describe "creating guides", type: :feature do
       expect(page).to have_content('created')
     end
 
-    guide = Guide.find_by_slug("/the/path")
+    guide = Guide.find_by_slug("/service-manual/the/path")
     edition = guide.latest_edition
     expect(edition.title).to eq "First Edition Title"
     expect(edition.draft?).to eq false
@@ -81,7 +81,7 @@ RSpec.describe "creating guides", type: :feature do
       expect(page).to have_content('updated')
     end
 
-    guide = Guide.find_by_slug("/the/path")
+    guide = Guide.find_by_slug("/service-manual/the/path")
     edition = guide.latest_edition
     expect(edition.title).to eq "Second Edition Title"
     expect(edition.draft?).to eq false
@@ -91,7 +91,7 @@ RSpec.describe "creating guides", type: :feature do
 private
 
   def fill_in_guide_form
-    fill_in "Slug", with: "/the/path"
+    fill_in "Slug", with: "the/path"
     fill_in "Related discussion title", with: "Discussion on HackPad"
     fill_in "Link to related discussion", with: "https://designpatterns.hackpad.com/"
     select "Design Community", from: "Published by"


### PR DESCRIPTION
https://trello.com/c/viKuy1Z4/23-make-sure-all-published-documents-live-under-the-same-base-path


I'm very much in favour of replacing this entire pull request with:
```ruby
validates_format_of :slug, :with => /^\/service-manual\//
```

At the moment it looks like this:

![https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-20-10-2015-16-47-55-shisiiho.png](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-20-10-2015-16-47-55-shisiiho.png)