### PR TITLE
Prepend /service-manual/ to all guide slugs

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -4,7 +4,10 @@ class GuidesController < ApplicationController
   end
 
   def new
-    @guide = Guide.new(latest_edition: Edition.new)
+    @guide = Guide.new(
+      latest_edition: Edition.new,
+      slug:           "/service-manual/",
+    )
   end
 
   def create

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -4,6 +4,10 @@ class Guide < ActiveRecord::Base
   validates :content_id, presence: true, uniqueness: true
   validates :slug, presence: true
   validates_associated :latest_edition
+  validates :slug, format: {
+    with: /\A\/service-manual\//,
+    message: "must be be prefixed with /service-manual/"
+  }
 
   has_many :editions
   has_one :latest_edition, -> { order(created_at: :desc) }, class_name: "Edition"

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -42,7 +42,7 @@ private
     edition = Generators.valid_edition
     edition.state = state
     edition.title = 'Sample Published Edition'
-    Guide.create!(latest_edition: edition, slug: "/test/slug_published")
+    Guide.create!(latest_edition: edition, slug: "/service-manual/test/slug_published")
   end
 
   def there_should_be_a_control_link(link_text, document:)

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -7,16 +7,19 @@ RSpec.describe "creating guides", type: :feature do
   before do
     visit root_path
     click_link "Create a Guide"
+  end
 
-    expect(GdsApi::PublishingApi).to receive(:new).and_return(api_double).twice # save and update
+  it "has a prepopulated slug field" do
+    expect(find_field('Slug').value).to eq "/service-manual/"
   end
 
   it "saves draft guide editions" do
     fill_in_guide_form
 
+    expect(GdsApi::PublishingApi).to receive(:new).and_return(api_double).twice # save and update
     expect(api_double).to receive(:put_draft_content_item)
                             .twice
-                            .with("/the/path", be_valid_against_schema('service_manual_guide'))
+                            .with("/service-manual/the/path", be_valid_against_schema('service_manual_guide'))
 
     click_button "Save Draft"
 
@@ -24,7 +27,7 @@ RSpec.describe "creating guides", type: :feature do
       expect(page).to have_content('created')
     end
 
-    guide = Guide.find_by_slug("/the/path")
+    guide = Guide.find_by_slug("/service-manual/the/path")
     edition = guide.latest_edition
     content_id = guide.content_id
     expect(content_id).to be_present
@@ -46,7 +49,7 @@ RSpec.describe "creating guides", type: :feature do
       expect(page).to have_content('updated')
     end
 
-    guide = Guide.find_by_slug("/the/path")
+    guide = Guide.find_by_slug("/service-manual/the/path")
     edition = guide.latest_edition
     expect(guide.content_id).to eq content_id
     expect(edition.title).to eq "Second Edition Title"
@@ -57,9 +60,10 @@ RSpec.describe "creating guides", type: :feature do
   it "publishes guide editions" do
     fill_in_guide_form
 
+    expect(GdsApi::PublishingApi).to receive(:new).and_return(api_double).twice # save and update
     expect(api_double).to receive(:put_content_item)
                             .twice
-                            .with("/the/path", be_valid_against_schema('service_manual_guide'))
+                            .with("/service-manual/the/path", be_valid_against_schema('service_manual_guide'))
 
     click_button "Publish"
 
@@ -67,7 +71,7 @@ RSpec.describe "creating guides", type: :feature do
       expect(page).to have_content('created')
     end
 
-    guide = Guide.find_by_slug("/the/path")
+    guide = Guide.find_by_slug("/service-manual/the/path")
     edition = guide.latest_edition
     expect(edition.title).to eq "First Edition Title"
     expect(edition.draft?).to eq false
@@ -81,7 +85,7 @@ RSpec.describe "creating guides", type: :feature do
       expect(page).to have_content('updated')
     end
 
-    guide = Guide.find_by_slug("/the/path")
+    guide = Guide.find_by_slug("/service-manual/the/path")
     edition = guide.latest_edition
     expect(edition.title).to eq "Second Edition Title"
     expect(edition.draft?).to eq false
@@ -91,7 +95,7 @@ RSpec.describe "creating guides", type: :feature do
 private
 
   def fill_in_guide_form
-    fill_in "Slug", with: "/the/path"
+    fill_in "Slug", with: "/service-manual/the/path"
     fill_in "Related discussion title", with: "Discussion on HackPad"
     fill_in "Link to related discussion", with: "https://designpatterns.hackpad.com/"
     select "Design Community", from: "Published by"

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Guide do
   describe "on create callbacks" do
     it "generates and sets content_id on create" do
       edition = Generators.valid_edition(title: "something", state: "published")
-      guide = Guide.create!(slug: "/slug", content_id: nil, latest_edition: edition)
+      guide = Guide.create!(slug: "/service-manual/slug", content_id: nil, latest_edition: edition)
       expect(guide.content_id).to be_present
     end
   end
@@ -12,7 +12,7 @@ RSpec.describe Guide do
   describe "#update_attributes_from_params" do
     it "updates latest_edition if it's currently draft" do
       edition = Generators.valid_edition(title: "something", state: "draft")
-      guide = Guide.create!(slug: "/slug", latest_edition: edition)
+      guide = Guide.create!(slug: "/service-manual/slug", latest_edition: edition)
 
       guide.update_attributes_from_params({ latest_edition_attributes: edition.attributes.merge(title: "New title") }, state: 'draft')
 
@@ -22,11 +22,21 @@ RSpec.describe Guide do
 
     it "creates a new edition if the current latest_edition is published" do
       edition = Generators.valid_edition(title: "something", state: "published")
-      guide = Guide.create!(slug: "/slug", latest_edition: edition)
+      guide = Guide.create!(slug: "/service-manual/slug", latest_edition: edition)
 
       guide.update_attributes_from_params({ latest_edition_attributes: edition.attributes.merge(title: "New title") }, state: 'draft')
 
       expect(guide.editions.count).to eq 2
     end
   end
+
+  describe "validations" do
+    it "doesn't allow slugs without /service-manual/ prefix" do
+      edition = Generators.valid_edition(title: "something", state: "published")
+      edition = Guide.new(slug: "/something", latest_edition: edition)
+      edition.valid?
+      expect(edition.errors.full_messages_for(:slug)).to eq ["Slug must be be prefixed with /service-manual/"]
+    end
+  end
+
 end


### PR DESCRIPTION
In order to avoid conflicts with paths used by other applications, ensure that
each published document slug is prefixed with /service-manual/.

This is an alternative to #21