### PR TITLE
Record the author of each guide edition

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -1,6 +1,6 @@
 class GuidesController < ApplicationController
   def index
-    @guides = Guide.includes(:latest_edition)
+    @guides = Guide.includes(latest_edition: :user)
   end
 
   def new
@@ -38,10 +38,11 @@ class GuidesController < ApplicationController
 private
 
   def guide_params
+    params[:guide][:latest_edition_attributes].merge!(user_id: current_user.id)
     params.require(:guide).permit(
       :slug,
       latest_edition_attributes: [
-        :title, :body, :description, :publisher_title, :phase,
+        :title, :body, :description, :publisher_title, :phase, :user_id,
         :related_discussion_href, :related_discussion_title, :update_type
       ])
   end

--- a/app/helpers/guide_helper.rb
+++ b/app/helpers/guide_helper.rb
@@ -6,4 +6,8 @@ module GuideHelper
       'Create new edition'
     end
   end
+
+  def latest_editor_name(guide)
+    guide.latest_edition.user.try(:name).to_s
+  end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -5,6 +5,8 @@ class Edition < ActiveRecord::Base
   }.freeze
 
   belongs_to :guide
+  belongs_to :user
+
   scope :draft, -> { where(state: 'draft') }
   scope :published, -> { where(state: 'published') }
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -10,7 +10,7 @@ class Edition < ActiveRecord::Base
   scope :draft, -> { where(state: 'draft') }
   scope :published, -> { where(state: 'published') }
 
-  validates_presence_of [:state, :phase, :description, :title, :update_type, :body, :publisher_title, :publisher_href]
+  validates_presence_of [:state, :phase, :description, :title, :update_type, :body, :publisher_title, :publisher_href, :user]
   validates_inclusion_of :state, in: %w(draft published)
 
   before_validation :assign_publisher_href

--- a/app/views/guides/index.html.erb
+++ b/app/views/guides/index.html.erb
@@ -8,6 +8,7 @@
   <thead>
     <tr class='table-header'>
       <th>Title</th>
+      <th>Last updated by</th>
       <th>Controls</th>
     </tr>
   </thead>
@@ -17,6 +18,9 @@
         <td>
           <%= guide.latest_edition.title %>
           <span class='text-muted'><%= guide.slug %></span>
+        </td>
+        <td class='last-edited-by'>
+          <%= latest_editor_name(guide) %>
         </td>
         <td class='content-controls'>
           <%= link_to edit_action_label(guide), edit_guide_path(guide), class: 'btn btn-default btn-xs' %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,6 +18,8 @@ if Rails.env.development?
   # https://github.com/jekyll/jekyll/blob/2807b8a012ead8b8fe7ed30f1a8ad1f6f9de7ba4/lib/jekyll/document.rb
   YAML_FRONT_MATTER_REGEXP = /\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)/m
 
+  author = User.first || User.create!(name: "Unknown")
+
   objects.each do |object|
     content = File.read(object[:path])
     title = ""
@@ -43,7 +45,8 @@ if Rails.env.development?
         description:     "Description",
         update_type:     "major",
         body:            body,
-        publisher_title: Edition::PUBLISHERS.keys.first
+        publisher_title: Edition::PUBLISHERS.keys.first,
+        user:            author
       )
       guide = Guide.create!(slug: object[:url], content_id: nil, latest_edition: edition)
       GuidePublisher.new(guide).publish!

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -36,6 +36,18 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     expect(guide.editions.map(&:title)).to match_array ["Sample Published Edition 2"]
   end
 
+  it "should record who's the last editor" do
+    stub_user.update_attribute :name, "John Smith"
+    guide = given_a_guide_exists state: 'draft'
+    visit edit_guide_path(guide)
+    fill_in "Title", with: "An amended title"
+    click_button "Save Draft"
+    visit guides_path
+    within ".last-edited-by" do
+      expect(page).to have_content "John Smith"
+    end
+  end
+
 private
 
   def given_a_guide_exists(state:)

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -2,6 +2,14 @@ require 'rails_helper'
 
 RSpec.describe Edition, type: :model do
   describe "validations" do
+    it "requires user to be present" do
+      edition = Edition.new(user: nil)
+
+      expect(edition).to be_invalid
+
+      expect(edition.errors.full_messages_for(:user).size).to eq 1
+    end
+
     it "allows 'draft' state" do
       edition = Edition.new(state: 'draft')
 

--- a/spec/support/generators.rb
+++ b/spec/support/generators.rb
@@ -7,7 +7,8 @@ class Generators
       description:     "Description",
       update_type:     "major",
       body:            "# Heading",
-      publisher_title: Edition::PUBLISHERS.keys.first
+      publisher_title: Edition::PUBLISHERS.keys.first,
+      user:            User.new(name: "Generated User")
     }.merge(attributes)
 
     Edition.new(attributes)


### PR DESCRIPTION
Assign current user id as user_id on an edition. This is in order to keep track
of who's made changes to a guide over time. The latest editor is shown in the
list table of all guides.