### PR TITLE
Stop using the govuk-content-schemas service_manual_publisher branch (do not merge)

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -44,9 +44,6 @@ bundle exec rake db:drop db:create db:schema:load
 # Clone govuk-content-schemas depedency for tests
 rm -rf tmp/govuk-content-schemas
 git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
-cd tmp/govuk-content-schemas
-git checkout service_manual_publisher
-cd ../../
 export GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas
 
 if bundle exec rake ${TEST_TASK:-"default"}; then


### PR DESCRIPTION
~~We needed to use this branch until it was merged. It is now merged.~~

https://github.com/alphagov/govuk-content-schemas/pull/135

Turns out this branch hasn't been merged yet, but I'm keeping this around as a reminder.