### PR TITLE
Display validation errors for guides

### DIFF
--- a/app/helpers/error_list_helper.rb
+++ b/app/helpers/error_list_helper.rb
@@ -1,0 +1,22 @@
+module ErrorListHelper; end
+
+class ActionView::Helpers::FormBuilder
+  include ActionView::Context
+  include ActionView::Helpers::TagHelper
+  include ActionView::Helpers::FormTagHelper
+  include ActionView::Helpers::FormOptionsHelper
+  include ActionView::Helpers::CaptureHelper
+  include ActionView::Helpers::AssetTagHelper
+
+  def error_list(field)
+    return nil if object.errors.messages[field].nil?
+
+    content_tag :ul do
+      object.errors.messages[field].map do |error|
+        content_tag :li, class: "text-danger" do
+          error
+        end
+      end.join("").html_safe
+    end
+  end
+end

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -3,7 +3,6 @@ require "gds_api/publishing_api"
 class Guide < ActiveRecord::Base
   validates :content_id, presence: true, uniqueness: true
   validates :slug, presence: true
-  validates_associated :latest_edition
   validates :slug, format: {
     with: /\A\/service-manual\//,
     message: "must be be prefixed with /service-manual/"

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -3,7 +3,8 @@
     <fieldset class='meta'>
       <legend>Meta</legend>
       <div class='form-group'>
-        <%= f.label :slug %>
+        <%= f.label :slug  %>
+        <%= f.error_list :slug  %>
         <%= f.text_field :slug, class: 'input-md-12 form-control' %>
       </div>
 
@@ -11,26 +12,31 @@
 
         <div class='form-group'>
           <%= editions_form.label :related_discussion_title %>
+          <%= editions_form.error_list :related_discussion_title %>
           <%= editions_form.text_field :related_discussion_title, class: 'input-md-12 form-control' %>
         </div>
 
         <div class='form-group'>
           <%= editions_form.label :related_discussion_href, "Link to related discussion" %>
+          <%= editions_form.error_list :related_discussion_href %>
           <%= editions_form.text_field :related_discussion_href, class: 'input-md-12 form-control' %>
         </div>
 
         <div class='form-group'>
-          <%= editions_form.label :publisher_title, 'Published by' %>
+          <%= editions_form.label :publisher_title, "Published by" %>
+          <%= editions_form.error_list :publisher_title %>
           <%= editions_form.select :publisher_title, Edition::PUBLISHERS.keys, class: 'input-md-12 form-control' %>
         </div>
 
         <div class='form-group'>
-          <%= editions_form.label :phase, 'Phase' %>
+          <%= editions_form.label :phase %>
+          <%= editions_form.error_list :phase %>
           <%= editions_form.select :phase, [['Alpha', 'alpha'], ['Beta', 'beta'], ['Live', 'live']], class: 'input-md-12 form-control' %>
         </div>
 
         <div class='form-group'>
           <%= editions_form.label :description %>
+          <%= editions_form.error_list :description %>
           <%= editions_form.text_area :description, rows: 4, class: 'input-md-12 form-control' %>
         </div>
       <% end %>
@@ -41,10 +47,12 @@
       <%= f.fields_for :latest_edition, guide.latest_edition do |editions_form| %>
         <div class="form-group">
           <%= editions_form.label :title %>
+          <%= editions_form.error_list :title %>
           <%= editions_form.text_field :title, class: 'input-md-12 form-control' %>
         </div>
         <div class="form-group">
           <%= editions_form.label :body %>
+          <%= editions_form.error_list :body %>
           <%= editions_form.text_area :body, class: 'input-md-12 form-control', rows: 14 %>
         </div>
       <% end %>
@@ -56,6 +64,7 @@
         <%= f.fields_for :latest_edition, guide.latest_edition do |editions_form| %>
           <div class='form-group'>
             <%= editions_form.label :update_type %>
+            <%= editions_form.error_list :update_type %>
             <%= editions_form.select :update_type, [["Major", "major"], ["Minor", "minor"], ["Republish", "republish"]], include_blank: true, class: 'input-md-12 form-control' %>
           </div>
         <% end %>


### PR DESCRIPTION
Show users what went wrong when they attempt to create or edit a guide
page.
Attempt to follow the guidance here: http://govuk-elements.herokuapp.com/errors/

This is a conversation starter for now. I'm interested in hearing how @tadast
thinks we could refactor this.

For now I have removed the anchor links to inputs, because it's quite hard to do in rails.

Whoever merges this branch should rebase the commits into one.