### PR TITLE
Granular versioning for Guides

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -1,0 +1,6 @@
+class EditionsController < ApplicationController
+  def index
+    @guide = Guide.find(params[:guide_id])
+    @editions = @guide.editions.includes(:user).order(updated_at: :desc)
+  end
+end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -23,6 +23,14 @@ class Edition < ActiveRecord::Base
     state == 'published'
   end
 
+  def copyable_attributes(extra_attributes = {})
+    attributes.with_indifferent_access.except('id', 'updated_at', 'created_at').merge(extra_attributes)
+  end
+
+  def unsaved_copy
+    self.class.new(copyable_attributes)
+  end
+
 private
 
   def assign_publisher_href

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -21,16 +21,4 @@ class Guide < ActiveRecord::Base
   def work_in_progress_edition?
     latest_edition.try(:state) == 'draft'
   end
-
-  def update_attributes_from_params(params, state:)
-    if work_in_progress_edition?
-      self.attributes = params
-      self.latest_edition.state = state
-    else
-      self.attributes = params.except(:latest_edition_attributes)
-      edition_attributes = params[:latest_edition_attributes].with_indifferent_access
-      self.editions.build(edition_attributes.except(:id, :updated_at, :created_at).merge(state: state))
-    end
-    save
-  end
 end

--- a/app/models/guide_publisher.rb
+++ b/app/models/guide_publisher.rb
@@ -1,15 +1,16 @@
 class GuidePublisher
-  def initialize guide
+  def initialize(guide:, edition:)
     @guide = guide
+    @edition = edition
   end
 
   def publish!
-    data = GuidePresenter.new(@guide, @guide.latest_edition).exportable_attributes
+    data = GuidePresenter.new(@guide, @edition).exportable_attributes
 
     publishing_api = GdsApi::PublishingApi.new(Plek.new.find('publishing-api'))
-    if @guide.latest_edition.draft?
+    if @edition.draft?
       publishing_api.put_draft_content_item(@guide.slug, data)
-    elsif @guide.latest_edition.published?
+    elsif @edition.published?
       publishing_api.put_content_item(@guide.slug, data)
     end
   end

--- a/app/views/editions/index.html.erb
+++ b/app/views/editions/index.html.erb
@@ -1,0 +1,30 @@
+<h1>Change History: <%= @guide.editions.first.title %></h1>
+
+<p>
+  <%= link_to "New draft" , edit_guide_path(@guide), class: 'btn btn-primary' %>
+</p>
+
+<table class='table table-bordered'>
+  <thead>
+    <tr class='table-header'>
+      <th>Updated by</th>
+      <th>State</th>
+      <th>Updated at</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @editions.each do |edition| %>
+      <tr>
+        <td>
+          <%= edition.user.name %>
+        </td>
+        <td>
+          <%= edition.state %>
+        </td>
+        <td>
+          <%= edition.updated_at.to_s %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -7,7 +7,7 @@
         <%= f.text_field :slug, class: 'input-md-12 form-control' %>
       </div>
 
-      <%= f.fields_for :latest_edition, guide.latest_edition do |editions_form| %>
+      <%= f.fields_for :edition, edition do |editions_form| %>
 
         <div class='form-group'>
           <%= editions_form.label :related_discussion_title %>
@@ -38,7 +38,7 @@
 
     <fieldset class='inputs'>
       <legend>Content</legend>
-      <%= f.fields_for :latest_edition, guide.latest_edition do |editions_form| %>
+      <%= f.fields_for :edition, edition do |editions_form| %>
         <div class="form-group">
           <%= editions_form.label :title %>
           <%= editions_form.text_field :title, class: 'input-md-12 form-control' %>
@@ -53,7 +53,7 @@
 
     <fieldset class='update'>
       <div class='form-group'>
-        <%= f.fields_for :latest_edition, guide.latest_edition do |editions_form| %>
+        <%= f.fields_for :edition, edition do |editions_form| %>
           <div class='form-group'>
             <%= editions_form.label :update_type %>
             <%= editions_form.select :update_type, [["Major", "major"], ["Minor", "minor"], ["Republish", "republish"]], include_blank: true, class: 'input-md-12 form-control' %>

--- a/app/views/guides/edit.html.erb
+++ b/app/views/guides/edit.html.erb
@@ -1,1 +1,1 @@
-<%= render 'form', guide: @guide %>
+<%= render 'form', guide: @guide, edition: @edition%>

--- a/app/views/guides/index.html.erb
+++ b/app/views/guides/index.html.erb
@@ -24,6 +24,7 @@
         </td>
         <td class='content-controls'>
           <%= link_to edit_action_label(guide), edit_guide_path(guide), class: 'btn btn-default btn-xs' %>
+          <%= link_to "View history", guide_editions_path(guide), class: 'btn btn-default btn-xs' %>
         </td>
       </tr>
     <% end %>

--- a/app/views/guides/new.html.erb
+++ b/app/views/guides/new.html.erb
@@ -1,1 +1,1 @@
-<%= render 'form', guide: @guide %>
+<%= render 'form', guide: @guide, edition: @edition%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,9 @@ Rails.application.routes.draw do
 
   root 'guides#index'
 
-  resources :guides
+  resources :guides do
+    resources :editions, only: :index
+  end
 
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -49,7 +49,7 @@ if Rails.env.development?
         user:            author
       )
       guide = Guide.create!(slug: object[:url], content_id: nil, latest_edition: edition)
-      GuidePublisher.new(guide).publish!
+      GuidePublisher.new(guide: guide, edition: edition).publish!
     end
   end
 end

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -22,7 +22,20 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     expect(guide.editions.map(&:title)).to match_array ["Sample Published Edition", "Sample Published Edition 2"]
   end
 
-  it "should allow editing an existing draft" do
+  it "should create a new edition even when saving a draft" do
+    guide = given_a_guide_exists state: 'draft'
+    visit guides_path
+    link = there_should_be_a_control_link "Continue editing", document: guide
+    link.click
+    fill_in "Title", with: "Sample Published Edition 2"
+    click_button "Save Draft"
+    expect(current_path).to eq root_path
+
+    expect(guide.editions.draft.size).to eq 2
+    expect(guide.editions.map(&:title)).to match_array ["Sample Published Edition", "Sample Published Edition 2"]
+  end
+
+  it "should create a new edition when publishing a draft" do
     guide = given_a_guide_exists state: 'draft'
     visit guides_path
     link = there_should_be_a_control_link "Continue editing", document: guide
@@ -32,8 +45,8 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     expect(current_path).to eq root_path
 
     expect(guide.editions.published.size).to eq 1
-    expect(guide.editions.draft.size).to eq 0
-    expect(guide.editions.map(&:title)).to match_array ["Sample Published Edition 2"]
+    expect(guide.editions.draft.size).to eq 1
+    expect(guide.editions.map(&:title)).to match_array ["Sample Published Edition", "Sample Published Edition 2"]
   end
 
   it "should record who's the last editor" do

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -34,4 +34,46 @@ RSpec.describe Edition, type: :model do
       expect(edition.errors.full_messages_for(:state).size).to eq 1
     end
   end
+
+  describe "#copyable_attributes" do
+    it "returns a hash with attributes excluding fields that get populated on save" do
+      saved_edition = Generators.valid_edition
+      saved_edition.save!
+
+      attributes = saved_edition.copyable_attributes
+
+      expect(attributes['title']).to eq saved_edition.title
+      expect(attributes['body']).to eq saved_edition.body
+
+      expect(attributes['id']).to eq nil
+      expect(attributes['created_at']).to eq nil
+      expect(attributes['updated_at']).to eq nil
+    end
+
+    it "allows to add/override attributes" do
+      edition = Generators.valid_edition
+      edition.state = 'draft'
+      attributes = edition.copyable_attributes(state: 'published', title: 'Teams')
+
+      expect(attributes['title']).to eq 'Teams'
+      expect(attributes['state']).to eq 'published'
+    end
+  end
+
+  describe "#unsaved_copy" do
+    it "returns a copy without fields that get populated on save" do
+      saved_edition = Generators.valid_edition
+      saved_edition.save!
+
+      unsaved = saved_edition.unsaved_copy
+
+      expect(unsaved.title).to eq saved_edition.title
+      expect(unsaved.body).to eq saved_edition.body
+
+      expect(unsaved).to be_a_new_record
+      expect(unsaved.id).to eq nil
+      expect(unsaved.created_at).to eq nil
+      expect(unsaved.updated_at).to eq nil
+    end
+  end
 end

--- a/spec/models/guide_publisher_spec.rb
+++ b/spec/models/guide_publisher_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe GuidePublisher do
   it "saves published items" do
     guide = Guide.new(slug: "/test/slug", latest_edition: Generators.valid_edition(state: 'published'))
-    publisher = GuidePublisher.new(guide)
+    publisher = GuidePublisher.new(guide: guide, edition: guide.latest_edition)
 
     double_api = double(:publishing_api)
     expected_plek = Plek.new.find('publishing-api')
@@ -24,7 +24,7 @@ RSpec.describe GuidePublisher do
 
   it "saves draft items" do
     guide = Guide.new(latest_edition: Generators.valid_edition, slug: "/test/slug")
-    publisher = GuidePublisher.new(guide)
+    publisher = GuidePublisher.new(guide: guide, edition: guide.latest_edition)
 
     double_api = double(:publishing_api)
     expected_plek = Plek.new.find('publishing-api')

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -9,27 +9,6 @@ RSpec.describe Guide do
     end
   end
 
-  describe "#update_attributes_from_params" do
-    it "updates latest_edition if it's currently draft" do
-      edition = Generators.valid_edition(title: "something", state: "draft")
-      guide = Guide.create!(slug: "/service-manual/slug", latest_edition: edition)
-
-      guide.update_attributes_from_params({ latest_edition_attributes: edition.attributes.merge(title: "New title") }, state: 'draft')
-
-      expect(guide.editions.count).to eq 1
-      expect(guide.editions.last.title).to eq "New title"
-    end
-
-    it "creates a new edition if the current latest_edition is published" do
-      edition = Generators.valid_edition(title: "something", state: "published")
-      guide = Guide.create!(slug: "/service-manual/slug", latest_edition: edition)
-
-      guide.update_attributes_from_params({ latest_edition_attributes: edition.attributes.merge(title: "New title") }, state: 'draft')
-
-      expect(guide.editions.count).to eq 2
-    end
-  end
-
   describe "validations" do
     it "doesn't allow slugs without /service-manual/ prefix" do
       edition = Generators.valid_edition(title: "something", state: "published")


### PR DESCRIPTION
Record each draft save/publication as a separate edition.

Whenever changes are made, create a new guide edition. We used to do that for
currently published guides, but not for guides in draft state. Recording each
edition save aligns us with the Performance Platform team (responsible for
publishing-api) future plans for versioning. It also gives us better
accountability tracking as author of each change is now recorder.

Note that I opted to "clone" the previous edition before applying attributes
sent from the form. This is to ensure that we will not loose any data if it is
not passed from the form due to any potential changes in future.

This PR does not deal with versioning and optimistic-locking as the publishing-api changes to deal with that are still in development. We'll need to update this process a bit once the mentioned changes go live.

This PR also adds a minimalistic view for Guide history with aim to make it easier to demo, develop and design upcoming features.
