### PR TITLE
Migrate to publishing-api V2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'plek', '~> 1.10'
 gem 'airbrake', '~> 4.2.1'
 gem 'govuk_admin_template', '~> 3.0.0'
 gem 'gds-sso', '~> 11.0.0'
-gem 'gds-api-adapters', '~> 24.4.0'
+gem 'gds-api-adapters', '~> 24.6.0'
 gem 'govspeak', '~> 3.4.0'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
     execjs (2.6.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (24.4.0)
+    gds-api-adapters (24.6.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -166,7 +166,7 @@ GEM
     rack (1.6.4)
     rack-accept (0.4.5)
       rack (>= 0.4)
-    rack-cache (1.3.0)
+    rack-cache (1.5.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -274,7 +274,7 @@ DEPENDENCIES
   bullet
   byebug
   capybara
-  gds-api-adapters (~> 24.4.0)
+  gds-api-adapters (~> 24.6.0)
   gds-sso (~> 11.0.0)
   govspeak (~> 3.4.0)
   govuk-content-schema-test-helpers (~> 1.3.0)

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -12,7 +12,7 @@ class GuidesController < ApplicationController
     @guide = Guide.new(guide_params)
     @edition = build_new_edition_version_for(@guide)
     if @guide.save
-      GuidePublisher.new(guide: @guide, edition: @edition).publish!
+      GuidePublisher.new(guide: @guide, edition: @edition).process
       redirect_to root_path, notice: "Guide has been created"
     else
       render action: :new
@@ -28,7 +28,7 @@ class GuidesController < ApplicationController
     @guide = Guide.find(params[:id])
     @edition = build_new_edition_version_for(@guide)
     if @guide.update_attributes(guide_params)
-      GuidePublisher.new(guide: @guide, edition: @edition).publish!
+      GuidePublisher.new(guide: @guide, edition: @edition).process
       redirect_to root_path, notice: "Guide has been updated"
     else
       render action: :edit

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -1,5 +1,3 @@
-require "gds_api/publishing_api"
-
 class Guide < ActiveRecord::Base
   validates :content_id, presence: true, uniqueness: true
   validates :slug, presence: true

--- a/app/models/guide_publisher.rb
+++ b/app/models/guide_publisher.rb
@@ -6,7 +6,7 @@ class GuidePublisher
     @edition = edition
   end
 
-  def publish!
+  def process
     publishing_api = GdsApi::PublishingApiV2.new(Plek.new.find('publishing-api'))
 
     data = GuidePresenter.new(@guide, @edition).exportable_attributes

--- a/app/models/guide_publisher.rb
+++ b/app/models/guide_publisher.rb
@@ -1,3 +1,5 @@
+require "gds_api/publishing_api_v2"
+
 class GuidePublisher
   def initialize(guide:, edition:)
     @guide = guide
@@ -5,13 +7,13 @@ class GuidePublisher
   end
 
   def publish!
-    data = GuidePresenter.new(@guide, @edition).exportable_attributes
+    publishing_api = GdsApi::PublishingApiV2.new(Plek.new.find('publishing-api'))
 
-    publishing_api = GdsApi::PublishingApi.new(Plek.new.find('publishing-api'))
-    if @edition.draft?
-      publishing_api.put_draft_content_item(@guide.slug, data)
-    elsif @edition.published?
-      publishing_api.put_content_item(@guide.slug, data)
+    data = GuidePresenter.new(@guide, @edition).exportable_attributes
+    publishing_api.put_content(@guide.content_id, data)
+
+    if @edition.published?
+      publishing_api.publish(@guide.content_id, @edition.update_type)
     end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -49,7 +49,7 @@ if Rails.env.development?
         user:            author
       )
       guide = Guide.create!(slug: object[:url], content_id: nil, latest_edition: edition)
-      GuidePublisher.new(guide: guide, edition: edition).publish!
+      GuidePublisher.new(guide: guide, edition: edition).process
     end
   end
 end

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -4,7 +4,7 @@ require 'capybara/rails'
 RSpec.describe "Taking a guide through the publishing process", type: :feature do
 
   before do
-    allow_any_instance_of(GuidePublisher).to receive(:publish!)
+    allow_any_instance_of(GuidePublisher).to receive(:process)
   end
 
   it "should create a new edition if there are no drafts" do

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -16,10 +16,10 @@ RSpec.describe "creating guides", type: :feature do
   it "saves draft guide editions" do
     fill_in_guide_form
 
-    expect(GdsApi::PublishingApi).to receive(:new).and_return(api_double).twice # save and update
-    expect(api_double).to receive(:put_draft_content_item)
+    expect(GdsApi::PublishingApiV2).to receive(:new).and_return(api_double).twice # save and update
+    expect(api_double).to receive(:put_content)
                             .twice
-                            .with("/service-manual/the/path", be_valid_against_schema('service_manual_guide'))
+                            .with(an_instance_of(String), be_valid_against_schema('service_manual_guide'))
 
     click_button "Save Draft"
 
@@ -60,10 +60,13 @@ RSpec.describe "creating guides", type: :feature do
   it "publishes guide editions" do
     fill_in_guide_form
 
-    expect(GdsApi::PublishingApi).to receive(:new).and_return(api_double).twice # save and update
-    expect(api_double).to receive(:put_content_item)
+    expect(GdsApi::PublishingApiV2).to receive(:new).and_return(api_double).twice # save and update
+    expect(api_double).to receive(:put_content)
                             .twice
-                            .with("/service-manual/the/path", be_valid_against_schema('service_manual_guide'))
+                            .with(an_instance_of(String), be_valid_against_schema('service_manual_guide'))
+    expect(api_double).to receive(:publish)
+                            .twice
+                            .with(an_instance_of(String), 'minor')
 
     click_button "Publish"
 

--- a/spec/models/guide_publisher_spec.rb
+++ b/spec/models/guide_publisher_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe GuidePublisher do
                                          .and_return(double_api)
       expect(double_api).to receive(:put_content)
                               .with(guide.content_id, expected_json)
-      publisher.publish!
+      publisher.process
     end
   end
 
@@ -53,7 +53,7 @@ RSpec.describe GuidePublisher do
 
       expect(double_api).to receive(:publish)
                               .with(guide.content_id, 'major')
-      publisher.publish!
+      publisher.process
     end
   end
 end

--- a/spec/models/guide_publisher_spec.rb
+++ b/spec/models/guide_publisher_spec.rb
@@ -1,45 +1,59 @@
 require 'rails_helper'
 
 RSpec.describe GuidePublisher do
-  it "saves published items" do
-    guide = Guide.new(slug: "/test/slug", latest_edition: Generators.valid_edition(state: 'published'))
-    publisher = GuidePublisher.new(guide: guide, edition: guide.latest_edition)
+  context "when a guide is of state 'draft'" do
+    let(:guide) do
+      Guide.create(latest_edition: Generators.valid_edition(state: 'draft'), slug: "/test/slug")
+    end
 
-    double_api = double(:publishing_api)
-    expected_plek = Plek.new.find('publishing-api')
-    expected_json = {test: :json}
-    double_guide_presenter = double(:guide_presenter)
-    expect(double_guide_presenter).to receive(:exportable_attributes)
-                                        .and_return(expected_json)
-    expect(GuidePresenter).to receive(:new)
-                                .with(guide, guide.latest_edition)
-                                .and_return(double_guide_presenter)
-    expect(GdsApi::PublishingApi).to receive(:new)
-                                      .with(expected_plek)
-                                      .and_return(double_api)
-    expect(double_api).to receive(:put_content_item)
-                            .with(guide.slug, expected_json)
-    publisher.publish!
+    it "saves draft items" do
+      publisher = GuidePublisher.new(guide: guide, edition: guide.latest_edition)
+
+      double_api = double(:publishing_api)
+      expected_plek = Plek.new.find('publishing-api')
+      expected_json = {test: :json}
+      double_guide_presenter = double(:guide_presenter)
+      expect(double_guide_presenter).to receive(:exportable_attributes)
+                                          .and_return(expected_json)
+      expect(GuidePresenter).to receive(:new)
+                                  .with(guide, guide.latest_edition)
+                                  .and_return(double_guide_presenter)
+      expect(GdsApi::PublishingApiV2).to receive(:new)
+                                         .with(expected_plek)
+                                         .and_return(double_api)
+      expect(double_api).to receive(:put_content)
+                              .with(guide.content_id, expected_json)
+      publisher.publish!
+    end
   end
 
-  it "saves draft items" do
-    guide = Guide.new(latest_edition: Generators.valid_edition, slug: "/test/slug")
-    publisher = GuidePublisher.new(guide: guide, edition: guide.latest_edition)
+  context "when a guide is of state 'published'" do
+    let(:guide) do
+      edition = Generators.valid_edition(state: 'published', update_type: 'major')
+      Guide.create(slug: "/test/slug", latest_edition: edition)
+    end
 
-    double_api = double(:publishing_api)
-    expected_plek = Plek.new.find('publishing-api')
-    expected_json = {test: :json}
-    double_guide_presenter = double(:guide_presenter)
-    expect(double_guide_presenter).to receive(:exportable_attributes)
-                                        .and_return(expected_json)
-    expect(GuidePresenter).to receive(:new)
-                                .with(guide, guide.latest_edition)
-                                .and_return(double_guide_presenter)
-    expect(GdsApi::PublishingApi).to receive(:new)
-                                       .with(expected_plek)
-                                       .and_return(double_api)
-    expect(double_api).to receive(:put_draft_content_item)
-                            .with(guide.slug, expected_json)
-    publisher.publish!
+    it "saves draft then publishes it" do
+      publisher = GuidePublisher.new(guide: guide, edition: guide.latest_edition)
+
+      double_api = double(:publishing_api)
+      expected_plek = Plek.new.find('publishing-api')
+      payload_double = { test: :json }
+      double_guide_presenter = double(:guide_presenter)
+      expect(double_guide_presenter).to receive(:exportable_attributes)
+                                          .and_return(payload_double)
+      expect(GuidePresenter).to receive(:new)
+                                  .with(guide, guide.latest_edition)
+                                  .and_return(double_guide_presenter)
+      expect(GdsApi::PublishingApiV2).to receive(:new)
+                                        .with(expected_plek)
+                                        .and_return(double_api)
+      expect(double_api).to receive(:put_content)
+                              .with(guide.content_id, payload_double)
+
+      expect(double_api).to receive(:publish)
+                              .with(guide.content_id, 'major')
+      publisher.publish!
+    end
   end
 end


### PR DESCRIPTION
The V2 version of publishing-api adds separate endpoints for tagging. We'll need to use them for creating Service Manual Categories ("Topics"). In preparation I've migrated the current process to publishing-api V2 without modifying behaviour.

However, the V2 has a significant difference in the way content gets published: the `publish` endpoint only accepts content_id and publishes the latest version of the document stored via `put_content`. I hesitated modifying the process we currently have in place knowing that @AndrewVos is currently working on changing it (you might want to rebase once this gets merged, Andrew). 