### PR TITLE
Fix flash message styling

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,9 @@
 module ApplicationHelper
+  def alert_css_class(flash_type)
+    {
+      notice: 'alert-success',
+      alert: 'alert-warning',
+      error: 'alert-danger'
+    }[flash_type.to_sym]
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,12 +14,8 @@
 
 <% content_for :content do %>
   <% [:notice, :alert, :error].select { |k| flash[k].present? }.each do |k| %>
-    <div class="main-alert <%= k %>">
+    <div class="alert <%= alert_css_class(k) %>">
       <%= flash[k] %>
-      <% if flash[:need_id] %>
-        <%= link_to "#{flash[:need_id]}: #{flash[:goal]}",
-                    need_path(flash[:need_id]) %>
-      <% end %>
     </div>
   <% end %>
   <%= yield %>

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "creating guides", type: :feature do
 
     click_button "Save Draft"
 
-    within ".main-alert" do
+    within ".alert" do
       expect(page).to have_content('created')
     end
 
@@ -45,7 +45,7 @@ RSpec.describe "creating guides", type: :feature do
     fill_in "Title", with: "Second Edition Title"
     click_button "Save Draft"
 
-    within ".main-alert" do
+    within ".alert" do
       expect(page).to have_content('updated')
     end
 
@@ -67,7 +67,7 @@ RSpec.describe "creating guides", type: :feature do
 
     click_button "Publish"
 
-    within ".main-alert" do
+    within ".alert" do
       expect(page).to have_content('created')
     end
 
@@ -81,7 +81,7 @@ RSpec.describe "creating guides", type: :feature do
     fill_in "Title", with: "Second Edition Title"
     click_button "Publish"
 
-    within ".main-alert" do
+    within ".alert" do
       expect(page).to have_content('updated')
     end
 


### PR DESCRIPTION
The old markup was copied from another application and didn't really work with
the bootstrap version we're using. It also had extra marlup we're not using.