### PR TITLE
Handle API errors more gracefully

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -17,6 +17,9 @@ class GuidesController < ApplicationController
     else
       render action: :new
     end
+  rescue GdsApi::HTTPClientError => e
+    flash[:error] = e.error_details["error"]["message"]
+    render template: 'guides/new'
   end
 
   def edit
@@ -33,6 +36,9 @@ class GuidesController < ApplicationController
     else
       render action: :edit
     end
+  rescue GdsApi::HTTPClientError => e
+    flash[:error] = e.error_details["error"]["message"]
+    render template: 'guides/edit'
   end
 
 private

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -95,6 +95,19 @@ RSpec.describe "creating guides", type: :feature do
     expect(edition.published?).to eq true
   end
 
+  it "shows api errors" do
+    fill_in_guide_form
+
+    api_error = GdsApi::HTTPClientError.new(422, "Error message stub", "error" => { "message" => "Error message stub" })
+    expect_any_instance_of(GdsApi::PublishingApiV2).to receive(:put_content).and_raise(api_error)
+
+    click_button "Save Draft"
+
+    within ".alert" do
+      expect(page).to have_content('Error message stub')
+    end
+  end
+
 private
 
   def fill_in_guide_form


### PR DESCRIPTION
We were not handling errors returned by publishing API. This adds a flash
message to display to the user if publishing API returns an error instead of
showing a generic 500 page.