### PR TITLE
Review Requests

### DIFF
--- a/app/controllers/approvals_controller.rb
+++ b/app/controllers/approvals_controller.rb
@@ -1,0 +1,9 @@
+class ApprovalsController < ApplicationController
+  def create
+    edition = Edition.find(params[:approval][:edition_id])
+    edition.approvals.build(user: current_user)
+    edition.state = "approved"
+    edition.save!
+    redirect_to root_path, notice: "Thanks for approving this guide"
+  end
+end

--- a/app/controllers/review_requests_controller.rb
+++ b/app/controllers/review_requests_controller.rb
@@ -1,0 +1,8 @@
+class ReviewRequestsController < ApplicationController
+  def create
+    edition = Edition.find(params[:edition_id])
+    edition.state = 'review_requested'
+    edition.save!
+    redirect_to root_path, notice: "A review has been requested"
+  end
+end

--- a/app/helpers/guide_helper.rb
+++ b/app/helpers/guide_helper.rb
@@ -7,6 +7,21 @@ module GuideHelper
     end
   end
 
+  STATE_CSS_CLASSES = {
+    "new"              => "default",
+    "draft"            => "danger",
+    "review_requested" => "warning",
+    "approved"         => "success",
+    "published"        => "info",
+  }
+
+  def state_label(guide)
+    state     = guide.latest_edition.try(:state) || "new"
+    title     = state.titleize
+    css_class = STATE_CSS_CLASSES[state]
+    content_tag :span, title, title: 'State', class: "label label-#{css_class}"
+  end
+
   def latest_editor_name(guide)
     guide.latest_edition.user.try(:name).to_s
   end

--- a/app/models/approval.rb
+++ b/app/models/approval.rb
@@ -1,0 +1,3 @@
+class Approval < ActiveRecord::Base
+  belongs_to :user
+end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -7,12 +7,14 @@ class Edition < ActiveRecord::Base
   belongs_to :guide
   belongs_to :user
 
+  has_many :approvals
+
   scope :draft, -> { where(state: 'draft') }
   scope :published, -> { where(state: 'published') }
   scope :review_requested, -> { where(state: 'review_requested') }
 
   validates_presence_of [:state, :phase, :description, :title, :update_type, :body, :publisher_title, :publisher_href, :user]
-  validates_inclusion_of :state, in: %w(draft published review_requested)
+  validates_inclusion_of :state, in: %w(draft published review_requested approved)
 
   before_validation :assign_publisher_href
 
@@ -26,6 +28,10 @@ class Edition < ActiveRecord::Base
 
   def review_requested?
     state == 'review_requested'
+  end
+
+  def approved?
+    state == 'approved'
   end
 
   def copyable_attributes(extra_attributes = {})

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -9,9 +9,10 @@ class Edition < ActiveRecord::Base
 
   scope :draft, -> { where(state: 'draft') }
   scope :published, -> { where(state: 'published') }
+  scope :review_requested, -> { where(state: 'review_requested') }
 
   validates_presence_of [:state, :phase, :description, :title, :update_type, :body, :publisher_title, :publisher_href, :user]
-  validates_inclusion_of :state, in: %w(draft published)
+  validates_inclusion_of :state, in: %w(draft published review_requested)
 
   before_validation :assign_publisher_href
 
@@ -21,6 +22,10 @@ class Edition < ActiveRecord::Base
 
   def published?
     state == 'published'
+  end
+
+  def review_requested?
+    state == 'review_requested'
   end
 
   def copyable_attributes(extra_attributes = {})

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -16,7 +16,7 @@ class Guide < ActiveRecord::Base
   end
 
   def work_in_progress_edition?
-    latest_edition.try(:state) == 'draft'
+    latest_edition.try(:published?) == false
   end
 
   def can_request_review?
@@ -24,6 +24,13 @@ class Guide < ActiveRecord::Base
     return false if !latest_edition.persisted?
     return false if latest_edition.review_requested?
     return false if latest_edition.published?
+    return false if latest_edition.approved?
     true
+  end
+
+  def can_mark_as_approved?
+    return false if latest_edition.nil?
+    return false if !latest_edition.persisted?
+    latest_edition.review_requested?
   end
 end

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -18,4 +18,12 @@ class Guide < ActiveRecord::Base
   def work_in_progress_edition?
     latest_edition.try(:state) == 'draft'
   end
+
+  def can_request_review?
+    return false if latest_edition.nil?
+    return false if !latest_edition.persisted?
+    return false if latest_edition.review_requested?
+    return false if latest_edition.published?
+    true
+  end
 end

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -76,4 +76,11 @@
       </div>
     </fieldset>
   <% end %>
+
+  <% if guide.can_request_review? %>
+    <%= form_for :review_request, url: edition_review_requests_path(edition_id: guide.latest_edition.id) do |f| %>
+      <%= f.submit "Send for review", class: 'btn btn-success' %>
+    <% end %>
+  <% end %>
+
 </div>

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -1,3 +1,8 @@
+<h1>
+  <%= guide.latest_edition.try(:title) || "Create a Guide" %>
+  <%= state_label(guide) %>
+</h1>
+
 <div class='well'>
   <%= form_for guide do |f| %>
     <fieldset class='meta'>

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -72,7 +72,9 @@
       <div class='form-group'>
         <%= f.submit "Save Draft", class: 'btn btn-success', name: :save_draft %>
         <%= link_to "Preview", document_preview_url(guide), class: 'btn btn-default' %>
-        <%= f.submit "Publish", class: 'btn btn-success', name: :publish %>
+        <% if guide.latest_edition.present? && guide.latest_edition.approved? %>
+          <%= f.submit "Publish", class: 'btn btn-success', name: :publish %>
+        <% end %>
       </div>
     </fieldset>
   <% end %>
@@ -80,6 +82,15 @@
   <% if guide.can_request_review? %>
     <%= form_for :review_request, url: edition_review_requests_path(edition_id: guide.latest_edition.id) do |f| %>
       <%= f.submit "Send for review", class: 'btn btn-success' %>
+    <% end %>
+  <% end %>
+  <% if guide.can_mark_as_approved? %>
+    <%= form_for Approval.new do |f| %>
+      <fieldset class='meta'>
+        <legend>Approve</legend>
+        <%= f.hidden_field :edition_id, value: guide.latest_edition.id %>
+        <%= f.submit "Mark as Approved", class: 'btn btn-success' %>
+      </fieldset>
     <% end %>
   <% end %>
 

--- a/app/views/guides/index.html.erb
+++ b/app/views/guides/index.html.erb
@@ -1,9 +1,5 @@
 <h1>Guides</h1>
 
-<p>
-  <%= link_to "Create a Guide" , new_guide_path, class: 'btn btn-primary' %>
-</p>
-
 <table class='table table-bordered'>
   <thead>
     <tr class='table-header'>
@@ -36,3 +32,6 @@
 </table>
 
 <%= paginate @guides %>
+<p>
+  <%= link_to "Create a Guide" , new_guide_path, class: 'btn btn-primary' %>
+</p>

--- a/app/views/guides/index.html.erb
+++ b/app/views/guides/index.html.erb
@@ -20,7 +20,7 @@
           <%= latest_editor_name(guide) %>
         </td>
         <td>
-          <%= guide.latest_edition.state.titleize %>
+          <%= state_label(guide) %>
         </td>
         <td class='content-controls'>
           <%= link_to edit_action_label(guide), edit_guide_path(guide), class: 'btn btn-default btn-xs' %>

--- a/app/views/guides/index.html.erb
+++ b/app/views/guides/index.html.erb
@@ -9,6 +9,7 @@
     <tr class='table-header'>
       <th>Title</th>
       <th>Last updated by</th>
+      <th>State</th>
       <th>Controls</th>
     </tr>
   </thead>
@@ -21,6 +22,9 @@
         </td>
         <td class='last-edited-by'>
           <%= latest_editor_name(guide) %>
+        </td>
+        <td>
+          <%= guide.latest_edition.state.titleize %>
         </td>
         <td class='content-controls'>
           <%= link_to edit_action_label(guide), edit_guide_path(guide), class: 'btn btn-default btn-xs' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
     resources :review_requests
   end
 
+  resources :approvals
+
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,10 @@ Rails.application.routes.draw do
     resources :editions, only: :index
   end
 
+  resources :editions, only: [] do
+    resources :review_requests
+  end
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/db/migrate/20151027095557_create_approvals.rb
+++ b/db/migrate/20151027095557_create_approvals.rb
@@ -1,0 +1,8 @@
+class CreateApprovals < ActiveRecord::Migration
+  def change
+    create_table :approvals do |t|
+      t.references :user
+      t.references :edition
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151013135813) do
+ActiveRecord::Schema.define(version: 20151027095557) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "approvals", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "edition_id"
+  end
 
   create_table "editions", force: :cascade do |t|
     t.integer  "guide_id"

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -61,12 +61,32 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     end
   end
 
+  context "with a review requested" do
+    it "lists editions that need a review" do
+      edition = Generators.valid_edition
+      guide = Guide.create!(latest_edition: edition, slug: "/service-manual/something")
+
+      visit edit_guide_path(guide)
+      click_button "Send for review"
+      visit guides_path
+      expect(page).to have_content "Review Requested"
+    end
+  end
+
 private
 
+  def given_a_published_guide_exists
+    edition = Generators.valid_published_edition(
+      title: 'Sample Published Edition',
+    )
+    Guide.create!(latest_edition: edition, slug: "/service-manual/test/slug_published")
+  end
+
   def given_a_guide_exists(state:)
-    edition = Generators.valid_edition
-    edition.state = state
-    edition.title = 'Sample Published Edition'
+    edition = Generators.valid_edition(
+      state: state,
+      title: 'Sample Published Edition',
+    )
     Guide.create!(latest_edition: edition, slug: "/service-manual/test/slug_published")
   end
 

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -37,16 +37,29 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
 
   it "should create a new edition when publishing a draft" do
     guide = given_a_guide_exists state: 'draft'
-    visit guides_path
-    link = there_should_be_a_control_link "Continue editing", document: guide
-    link.click
+
+    visit edit_guide_path(guide)
     fill_in "Title", with: "Sample Published Edition 2"
+    click_button "Save Draft"
+
+    visit edit_guide_path(guide)
+    click_button "Send for review"
+
+    visit edit_guide_path(guide)
+    click_button "Mark as Approved"
+
+    visit edit_guide_path(guide)
     click_button "Publish"
+
     expect(current_path).to eq root_path
 
     expect(guide.editions.published.size).to eq 1
     expect(guide.editions.draft.size).to eq 1
-    expect(guide.editions.map(&:title)).to match_array ["Sample Published Edition", "Sample Published Edition 2"]
+    expect(guide.editions.map(&:title)).to match_array [
+      "Sample Published Edition",
+      "Sample Published Edition 2",
+      "Sample Published Edition 2",
+    ]
   end
 
   it "should record who's the last editor" do
@@ -71,6 +84,31 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       visit guides_path
       expect(page).to have_content "Review Requested"
     end
+
+    context "approved by another user" do
+      it "lists editions that are approved" do
+        edition = Generators.valid_edition(state: "review_requested", approvals: [])
+        guide = Guide.create!(latest_edition: edition, slug: "/service-manual/something")
+
+        reviewer = User.new(name: "Some User")
+        login_as reviewer
+        visit guides_path
+        click_link "Continue editing"
+        click_button "Mark as Approved"
+        expect(page).to have_content "Thanks for approving this guide"
+        expect(page).to have_content "Approved"
+      end
+    end
+
+    context "without approval" do
+      it "does not allow guides to be published" do
+        edition = Generators.valid_edition(state: "review_requested")
+        guide = Guide.create!(latest_edition: edition, slug: "/service-manual/something")
+        visit edit_guide_path(guide)
+        expect(page).to_not have_button "Publish"
+      end
+    end
+
   end
 
 private

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
   end
 
   it "should create a new edition if there are no drafts" do
-    guide = given_a_guide_exists state: 'published'
+    guide = given_a_published_guide_exists
     visit guides_path
     link = there_should_be_a_control_link "Create new edition", document: guide
     link.click
@@ -87,7 +87,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
 
     context "approved by another user" do
       it "lists editions that are approved" do
-        edition = Generators.valid_edition(state: "review_requested", approvals: [])
+        edition = Generators.valid_edition(state: "review_requested")
         guide = Guide.create!(latest_edition: edition, slug: "/service-manual/something")
 
         reviewer = User.new(name: "Some User")

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -109,6 +109,9 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       end
     end
 
+    context "approved by the same user" do
+      it "does not allow the same user to approve it"
+    end
   end
 
 private

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -10,27 +10,24 @@ RSpec.describe Edition, type: :model do
       expect(edition.errors.full_messages_for(:user).size).to eq 1
     end
 
-    it "allows 'draft' state" do
-      edition = Edition.new(state: 'draft')
-
+    it "allows 'published' state" do
+      edition = Generators.valid_published_edition
       edition.valid?
-
       expect(edition.errors.full_messages_for(:state).size).to eq 0
     end
 
-    it "allows 'published' state" do
-      edition = Edition.new(state: 'published')
-
-      edition.valid?
-
-      expect(edition.errors.full_messages_for(:state).size).to eq 0
+    valid_states = %w(draft review_requested approved)
+    valid_states.each do |valid_state|
+      it "allows '#{valid_state}' state" do
+        edition = Generators.valid_edition(state: valid_state)
+        edition.valid?
+        expect(edition.errors.full_messages_for(:state).size).to eq 0
+      end
     end
 
     it "does not allow arbitrary values" do
-      edition = Edition.new(state: 'supercharged')
-
+      edition = Generators.valid_edition(state: 'invalid state')
       edition.valid?
-
       expect(edition.errors.full_messages_for(:state).size).to eq 1
     end
   end

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -3,10 +3,8 @@ require 'rails_helper'
 RSpec.describe Edition, type: :model do
   describe "validations" do
     it "requires user to be present" do
-      edition = Edition.new(user: nil)
-
+      edition = Generators.valid_edition(user: nil)
       expect(edition).to be_invalid
-
       expect(edition.errors.full_messages_for(:user).size).to eq 1
     end
 

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe Guide do
 
   describe "validations" do
     it "doesn't allow slugs without /service-manual/ prefix" do
-      edition = Generators.valid_edition(title: "something", state: "published")
+      edition = Generators.valid_published_edition(title: "something", state: "published")
       edition = Guide.new(slug: "/something", latest_edition: edition)
       edition.valid?
       expect(edition.errors.full_messages_for(:slug)).to eq ["Slug must be be prefixed with /service-manual/"]
     end
   end
 
-  context "review" do
+  context "review and approval" do
     let :edition do
       edition = Generators.valid_edition
       allow(edition).to receive(:persisted?) { true }
@@ -27,6 +27,24 @@ RSpec.describe Guide do
 
     let :guide do
       Guide.new(slug: "/service-manual/something", latest_edition: edition)
+    end
+
+    describe "#can_mark_as_approved?" do
+      it "returns true when a review has been requested" do
+        edition.state = "review_requested"
+        edition.save!
+        expect(guide.can_mark_as_approved?).to be true
+      end
+
+      it "returns false when there's no edition" do
+        guide.latest_edition = nil
+        expect(guide.can_mark_as_approved?).to be false
+      end
+
+      it "returns false when latest_edition has not been saved" do
+        allow(edition).to receive(:persisted?) { false }
+        expect(guide.can_mark_as_approved?).to be false
+      end
     end
 
     describe "#can_request_review?" do
@@ -51,6 +69,11 @@ RSpec.describe Guide do
 
       it "returns false when a review has been published" do
         edition.state = "published"
+        expect(guide.can_request_review?).to be false
+      end
+
+      it "returns false when a review has been approved" do
+        edition.state = "approved"
         expect(guide.can_request_review?).to be false
       end
     end

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Guide do
   describe "on create callbacks" do
     it "generates and sets content_id on create" do
-      edition = Generators.valid_edition(title: "something", state: "published")
+      edition = Generators.valid_published_edition
       guide = Guide.create!(slug: "/service-manual/slug", content_id: nil, latest_edition: edition)
       expect(guide.content_id).to be_present
     end
@@ -11,7 +11,7 @@ RSpec.describe Guide do
 
   describe "validations" do
     it "doesn't allow slugs without /service-manual/ prefix" do
-      edition = Generators.valid_published_edition(title: "something", state: "published")
+      edition = Generators.valid_published_edition
       edition = Guide.new(slug: "/something", latest_edition: edition)
       edition.valid?
       expect(edition.errors.full_messages_for(:slug)).to eq ["Slug must be be prefixed with /service-manual/"]

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -18,4 +18,43 @@ RSpec.describe Guide do
     end
   end
 
+  context "review" do
+    let :edition do
+      edition = Generators.valid_edition
+      allow(edition).to receive(:persisted?) { true }
+      edition
+    end
+
+    let :guide do
+      Guide.new(slug: "/service-manual/something", latest_edition: edition)
+    end
+
+    describe "#can_request_review?" do
+      it "returns true when a review can be requested" do
+        expect(guide.can_request_review?).to be true
+      end
+
+      it "returns false when there's no edition" do
+        guide.latest_edition = nil
+        expect(guide.can_request_review?).to be false
+      end
+
+      it "returns false when latest_edition has not been saved" do
+        allow(edition).to receive(:persisted?) { false }
+        expect(guide.can_request_review?).to be false
+      end
+
+      it "returns false when a review has been requested" do
+        edition.state = "review_requested"
+        expect(guide.can_request_review?).to be false
+      end
+
+      it "returns false when a review has been published" do
+        edition.state = "published"
+        expect(guide.can_request_review?).to be false
+      end
+    end
+
+  end
+
 end

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -6,6 +6,17 @@ module AuthenticationHelpers
   def login_as_stub_user
     GDS::SSO.test_user = stub_user
   end
+
+  def login_as(user)
+    if block_given?
+      old_user = GDS::SSO.test_user
+      GDS::SSO.test_user = user
+      yield
+      GDS::SSO.test_user = old_user
+    else
+      GDS::SSO.test_user = user
+    end
+  end
 end
 
 module AuthenticationControllerHelpers

--- a/spec/support/generators.rb
+++ b/spec/support/generators.rb
@@ -13,4 +13,11 @@ class Generators
 
     Edition.new(attributes)
   end
+
+  def self.valid_published_edition(attributes = {})
+    attributes = {state: "published"}.merge(attributes)
+    edition = valid_edition(attributes)
+    edition.approvals << Approval.new(user: User.first)
+    edition
+  end
 end


### PR DESCRIPTION
Users can request a review on guide editions. When a review is requested, a user can mark the edition as approved. Only then can the edition be published.

This stops users publishing content without a second pair of eyes looking over it.

![https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-30-10-2015-12-05-17-eepaothu.png
](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-30-10-2015-12-05-17-eepaothu.png)

At the moment we don't ensure that a user cannot approve their own
edition. This is to allow easier UI testing. There is a pending test for
it, so we don't forget.