### PR TITLE
Improvements to previewing of drafts

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -19,7 +19,7 @@ class GuidesController < ApplicationController
     ActiveRecord::Base.transaction do
       if @guide.save
         GuidePublisher.new(guide: @guide).process
-        redirect_to root_path, notice: "Guide has been created"
+        redirect_to success_url(@guide), notice: "Guide has been created"
       else
         render action: :new
       end
@@ -43,7 +43,7 @@ class GuidesController < ApplicationController
     ActiveRecord::Base.transaction do
       if @guide.update_attributes(guide_params({latest_edition_attributes: {state: edition_state_from_params, user_id: current_user.id}}))
         GuidePublisher.new(guide: @guide).process
-        redirect_to root_path, notice: "Guide has been updated"
+        redirect_to success_url(@guide), notice: "Guide has been updated"
       else
         render action: :edit
       end
@@ -54,6 +54,15 @@ class GuidesController < ApplicationController
   end
 
 private
+
+  def success_url(guide)
+    if params[:save_draft_and_preview]
+      frontend_host = Rails.env.production? ? Plek.find('draft-origin') : Plek.find('government-frontend')
+      [frontend_host, guide.slug].join
+    else
+      root_url
+    end
+  end
 
   def comments_list(guide)
     guide.latest_edition.comments
@@ -77,10 +86,10 @@ private
   end
 
   def edition_state_from_params
-    if params[:save_draft]
-      'draft'
-    elsif params[:publish]
+    if params[:publish]
       'published'
+    else
+      'draft'
     end
   end
 end

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -59,6 +59,8 @@ private
     if params[:save_draft_and_preview]
       frontend_host = Rails.env.production? ? Plek.find('draft-origin') : Plek.find('government-frontend')
       [frontend_host, guide.slug].join
+    elsif request.referrer.present? && request.referrer != request.url
+      request.referrer
     else
       root_url
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,4 +6,12 @@ module ApplicationHelper
       error: 'alert-danger'
     }[flash_type.to_sym]
   end
+
+  def disable_if_new_record(record)
+    if record.new_record?
+      { disable: true }
+    else
+      {}
+    end
+  end
 end

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -75,8 +75,8 @@
         <% end %>
       </div>
       <div class='form-group'>
-        <%= f.submit "Save Draft", class: 'btn btn-success', name: :save_draft %>
-        <%= f.submit "Save Draft and Preview", class: 'btn btn-default', name: :save_draft_and_preview %>
+        <%= f.submit "Save Draft", class: 'btn btn-success', name: :save_draft, data: disable_if_new_record(guide) %>
+        <%= f.submit "Save Draft and Preview", class: 'btn btn-default', name: :save_draft_and_preview, data: disable_if_new_record(guide) %>
         <% if guide.latest_edition.present? && guide.latest_edition.approved? %>
           <%= f.submit "Publish", class: 'btn btn-success', name: :publish %>
         <% end %>

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -76,7 +76,7 @@
       </div>
       <div class='form-group'>
         <%= f.submit "Save Draft", class: 'btn btn-success', name: :save_draft %>
-        <%= link_to "Preview", document_preview_url(guide), class: 'btn btn-default' %>
+        <%= f.submit "Save Draft and Preview", class: 'btn btn-default', name: :save_draft_and_preview %>
         <% if guide.latest_edition.present? && guide.latest_edition.approved? %>
           <%= f.submit "Publish", class: 'btn btn-success', name: :publish %>
         <% end %>

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     click_link "Continue editing"
     fill_in "Title", with: "Agile"
     click_button "Save Draft"
-    expect(current_path).to eq root_path
+    expect(current_path).to eq edit_guide_path guide
 
     expect(guide.editions.draft.size).to eq 1
     expect(guide.editions.map(&:title)).to match_array ["Agile"]


### PR DESCRIPTION
An issue has been reported by our team member who noticed that the "Preview" button is not working on new guides. I've researched this and uncovered some more problems, that I've written up [on trello](https://trello.com/c/dIVi531R/35-improve-draft-previewing-functionality) and in commit messages in this PR. 

In short: make sure no work is lost when previewing and content designers always see the latest draft version by saving all work before previewing.