### PR TITLE
Disallow guide slug clashes

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -13,11 +13,13 @@ class GuidesController < ApplicationController
   def create
     @guide = Guide.new(guide_params)
     @edition = build_new_edition_version_for(@guide)
-    if @guide.save
-      GuidePublisher.new(guide: @guide, edition: @edition).process
-      redirect_to root_path, notice: "Guide has been created"
-    else
-      render action: :new
+    ActiveRecord::Base.transaction do
+      if @guide.save
+        GuidePublisher.new(guide: @guide, edition: @edition).process
+        redirect_to root_path, notice: "Guide has been created"
+      else
+        render action: :new
+      end
     end
   rescue GdsApi::HTTPClientError => e
     flash[:error] = e.error_details["error"]["message"]
@@ -32,11 +34,13 @@ class GuidesController < ApplicationController
   def update
     @guide = Guide.find(params[:id])
     @edition = build_new_edition_version_for(@guide)
-    if @guide.update_attributes(guide_params)
-      GuidePublisher.new(guide: @guide, edition: @edition).process
-      redirect_to root_path, notice: "Guide has been updated"
-    else
-      render action: :edit
+    ActiveRecord::Base.transaction do
+      if @guide.update_attributes(guide_params)
+        GuidePublisher.new(guide: @guide, edition: @edition).process
+        redirect_to root_path, notice: "Guide has been updated"
+      else
+        render action: :edit
+      end
     end
   rescue GdsApi::HTTPClientError => e
     flash[:error] = e.error_details["error"]["message"]

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -95,16 +95,66 @@ RSpec.describe "creating guides", type: :feature do
     expect(edition.published?).to eq true
   end
 
-  it "shows api errors" do
-    fill_in_guide_form
+  context "when creating a new guide" do
+    context "when publishing raises an exception" do
+      before do
+        api_error = GdsApi::HTTPClientError.new(422, "Error message stub", "error" => { "message" => "Error message stub" })
+        expect_any_instance_of(GdsApi::PublishingApiV2).to receive(:put_content).and_raise(api_error)
+      end
 
-    api_error = GdsApi::HTTPClientError.new(422, "Error message stub", "error" => { "message" => "Error message stub" })
-    expect_any_instance_of(GdsApi::PublishingApiV2).to receive(:put_content).and_raise(api_error)
+      it "shows api errors" do
+        fill_in_guide_form
+        click_button "Save Draft"
 
-    click_button "Save Draft"
+        within ".alert" do
+          expect(page).to have_content('Error message stub')
+        end
+      end
 
-    within ".alert" do
-      expect(page).to have_content('Error message stub')
+      it "does not store a guide" do
+        fill_in_guide_form
+        click_button "Save Draft"
+
+        expect(Guide.count).to eq 0
+        expect(Edition.count).to eq 0
+      end
+    end
+  end
+
+  context "when updating a guide" do
+    context "when publishing raises an exception" do
+      let :api_error do
+        GdsApi::HTTPClientError.new(422, "Error message stub", "error" => { "message" => "Error message stub" })
+      end
+
+      it "shows api errors" do
+        edition = Generators.valid_edition(title: "something")
+        guide = Guide.create!(slug: "/service-manual/something", latest_edition: edition)
+
+        expect_any_instance_of(GuidePublisher).to receive(:process).once.and_raise(api_error)
+
+        visit edit_guide_path(guide)
+        click_button "Save Draft"
+
+        within ".alert" do
+          expect(page).to have_content('Error message stub')
+        end
+      end
+
+      it "does persist an extra edition" do
+        edition = Generators.valid_edition(title: "Original Title")
+        guide = Guide.create!(slug: "/service-manual/something", latest_edition: edition)
+
+        expect_any_instance_of(GuidePublisher).to receive(:process).once.and_raise(api_error)
+
+        visit edit_guide_path(guide)
+        fill_in "Title", with: "Changed Title"
+        click_button "Save Draft"
+
+        expect(Guide.count).to eq 1
+        expect(Guide.first.latest_edition.title).to_not eq "Changed Title"
+        expect(Edition.count).to eq 1
+      end
     end
   end
 


### PR DESCRIPTION
Wrap the saving of guides in a transaction, so that if publishing to the
draft content store fails, then we do not store an object in the
database.