### PR TITLE
Show the most recently edited Guides on top of the index page

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -2,6 +2,7 @@ class GuidesController < ApplicationController
   def index
     @guides = Guide
                 .includes(latest_edition: :user)
+                .order(updated_at: :desc)
                 .page(params[:page])
   end
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -4,7 +4,7 @@ class Edition < ActiveRecord::Base
     "Agile Community" => "http://sm-11.herokuapp.com/agile-delivery/agile-community"
   }.freeze
 
-  belongs_to :guide
+  belongs_to :guide, touch: true
   belongs_to :user
 
   has_many :approvals

--- a/db/migrate/20151102145752_add_timestamps_to_guides.rb
+++ b/db/migrate/20151102145752_add_timestamps_to_guides.rb
@@ -1,0 +1,20 @@
+class AddTimestampsToGuides < ActiveRecord::Migration
+  def up
+    change_table :guides do |t|
+      t.timestamps
+    end
+
+    Guide.all.each do |guide|
+      if guide.latest_edition
+        guide.update_columns(created_at: guide.latest_edition.created_at, updated_at: guide.latest_edition.updated_at)
+      else
+        guide.touch(:created_at, :updated_at)
+      end
+    end
+  end
+
+  def down
+    remove_column :guides, :created_at
+    remove_column :guides, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151027095557) do
+ActiveRecord::Schema.define(version: 20151102145752) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,8 +39,10 @@ ActiveRecord::Schema.define(version: 20151027095557) do
   end
 
   create_table "guides", force: :cascade do |t|
-    t.string "slug"
-    t.string "content_id"
+    t.string   "slug"
+    t.string   "content_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
We used to rely on default Rails ordering which is ordering Guides based on
their ids. I believe it is more natural to show the most recently updated
Guides on top, because they are usually the ones requiring attention.