### PR TITLE
Allow users to comment on editions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'gds-sso', '~> 11.0.0'
 gem 'gds-api-adapters', '~> 24.6.0'
 gem 'govspeak', '~> 3.4.0'
 gem 'kaminari', '~> 0.16.3'
+gem 'acts_as_commentable', '~> 4.0.2'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    acts_as_commentable (4.0.2)
     addressable (2.3.7)
     airbrake (4.2.1)
       builder
@@ -271,6 +272,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts_as_commentable (~> 4.0.2)
   airbrake (~> 4.2.1)
   better_errors
   binding_of_caller

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,11 @@
+class CommentsController < ApplicationController
+  def create
+    edition = Edition.find(params[:comment][:edition_id])
+    edition.comments.create!(
+      user: current_user,
+      comment: params[:comment][:comment],
+    )
+
+    redirect_to root_path, notice: "Comment has been created"
+  end
+end

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -30,11 +30,19 @@ class GuidesController < ApplicationController
   def edit
     @guide = Guide.find(params[:id])
     @edition = @guide.latest_edition.unsaved_copy
+    @comments = @guide.latest_edition.comments
+      .order(created_at: :asc)
+      .includes(:user)
+    @new_comment = @guide.latest_edition.comments.build
   end
 
   def update
     @guide = Guide.find(params[:id])
     @edition = build_new_edition_version_for(@guide)
+    @comments = @guide.latest_edition.comments
+      .order(created_at: :asc)
+      .includes(:user)
+    @new_comment = @guide.latest_edition.comments.build
     ActiveRecord::Base.transaction do
       if @guide.update_attributes(guide_params)
         GuidePublisher.new(guide: @guide, edition: @edition).process

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,7 @@
+class Comment < ActiveRecord::Base
+  include ActsAsCommentable::Comment
+
+  belongs_to :commentable, :polymorphic => true
+
+  belongs_to :user
+end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -1,4 +1,6 @@
 class Edition < ActiveRecord::Base
+  acts_as_commentable
+
   PUBLISHERS = {
     "Design Community" => "http://sm-11.herokuapp.com/designing-services/design-community/",
     "Agile Community" => "http://sm-11.herokuapp.com/agile-delivery/agile-community"

--- a/app/views/guides/edit.html.erb
+++ b/app/views/guides/edit.html.erb
@@ -1,1 +1,32 @@
 <%= render 'form', guide: @guide, edition: @edition%>
+
+<div class='well comments'>
+  <fieldset class='meta'>
+    <legend>Comments</legend>
+
+    <% @comments.each do |comment| %>
+      <div class="comment panel panel-default">
+        <div class="panel-heading">
+          <h3 class="panel-title">
+            <%= comment.user.name %>
+          </h3>
+        </div>
+        <div class="panel-body">
+          <%= comment.comment %>
+        </div>
+      </div>
+    <% end %>
+
+    <%= form_for @new_comment do |f| %>
+      <%= f.hidden_field :edition_id, value: @guide.latest_edition.id %>
+
+      <div class='form-group'>
+        <%= f.label :comment %>
+        <%= f.text_area :comment, class: "form-control", rows: 3 %>
+      </div>
+      <div class='form-group'>
+        <%= f.submit "Comment", class: "btn btn-success" %>
+      </div>
+    <% end %>
+  </fieldset>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
 
   resources :approvals
 
+  resources :comments
 
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".

--- a/db/migrate/20151103120443_create_comments.rb
+++ b/db/migrate/20151103120443_create_comments.rb
@@ -1,0 +1,19 @@
+class CreateComments < ActiveRecord::Migration
+  def self.up
+    create_table :comments do |t|
+      t.text :comment
+      t.references :commentable, :polymorphic => true
+      t.references :user
+      t.string :role, :default => "comments"
+      t.timestamps
+    end
+
+    add_index :comments, :commentable_type
+    add_index :comments, :commentable_id
+    add_index :comments, :user_id
+  end
+
+  def self.down
+    drop_table :comments
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151102145752) do
+ActiveRecord::Schema.define(version: 20151103120443) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,20 @@ ActiveRecord::Schema.define(version: 20151102145752) do
     t.integer "user_id"
     t.integer "edition_id"
   end
+
+  create_table "comments", force: :cascade do |t|
+    t.text     "comment"
+    t.integer  "commentable_id"
+    t.string   "commentable_type"
+    t.integer  "user_id"
+    t.string   "role",             default: "comments"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "comments", ["commentable_id"], name: "index_comments_on_commentable_id", using: :btree
+  add_index "comments", ["commentable_type"], name: "index_comments_on_commentable_type", using: :btree
+  add_index "comments", ["user_id"], name: "index_comments_on_user_id", using: :btree
 
   create_table "editions", force: :cascade do |t|
     t.integer  "guide_id"

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -155,6 +155,26 @@ RSpec.describe "creating guides", type: :feature do
     end
   end
 
+  it "allows discourse" do
+    edition = Generators.valid_edition
+    guide = Guide.create!(
+      latest_edition: edition,
+      slug: "/service-manual/test/slug_published"
+    )
+
+    visit edit_guide_path(guide)
+    within ".comments" do
+      fill_in "Comment", with: "This is my comment"
+      click_button "Comment"
+    end
+
+    visit edit_guide_path(guide)
+    within ".comments .comment" do
+      expect(page).to have_content "Stub User"
+      expect(page).to have_content "This is my comment"
+    end
+  end
+
 private
 
   def fill_in_guide_form

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -1,6 +1,9 @@
 module AuthenticationHelpers
   def stub_user
-    @stub_user ||= User.create!(uid: SecureRandom.hex)
+    @stub_user ||= User.create!(
+      uid: SecureRandom.hex,
+      name: "Stub User",
+    )
   end
 
   def login_as_stub_user


### PR DESCRIPTION
At the moment, we only see comments for the latest edition. We might
want to change this at some point.

![https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-03-11-2015-13-25-48-ohdoodie.png](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-03-11-2015-13-25-48-ohdoodie.png)