### PR TITLE
Only duplicate editions when creating a new draft

### DIFF
--- a/app/controllers/drafts_controller.rb
+++ b/app/controllers/drafts_controller.rb
@@ -3,7 +3,14 @@ class DraftsController < ApplicationController
     guide = Guide.find(params[:guide_id])
     duplicated_edition = guide.latest_edition.dup
     duplicated_edition.state = "draft"
-    guide.editions << duplicated_edition
-    redirect_to edit_guide_path(guide)
+
+    ActiveRecord::Base.transaction do
+      guide.editions << duplicated_edition
+      GuidePublisher.new(guide: guide).process
+      redirect_to edit_guide_path(guide)
+    end
+  rescue GdsApi::HTTPClientError => e
+    flash[:error] = e.error_details["error"]["message"]
+    redirect_to root_path
   end
 end

--- a/app/controllers/drafts_controller.rb
+++ b/app/controllers/drafts_controller.rb
@@ -1,0 +1,9 @@
+class DraftsController < ApplicationController
+  def create
+    guide = Guide.find(params[:guide_id])
+    duplicated_edition = guide.latest_edition.dup
+    duplicated_edition.state = "draft"
+    guide.editions << duplicated_edition
+    redirect_to edit_guide_path(guide)
+  end
+end

--- a/app/controllers/drafts_controller.rb
+++ b/app/controllers/drafts_controller.rb
@@ -1,6 +1,11 @@
 class DraftsController < ApplicationController
   def create
     guide = Guide.find(params[:guide_id])
+
+    if guide.latest_edition.published? == false
+      return redirect_to edit_guide_path(guide)
+    end
+
     duplicated_edition = guide.latest_edition.dup
     duplicated_edition.state = "draft"
 

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -18,7 +18,7 @@ class GuidesController < ApplicationController
 
     ActiveRecord::Base.transaction do
       if @guide.save
-        GuidePublisher.new(guide: @guide, edition: @guide.latest_edition).process
+        GuidePublisher.new(guide: @guide).process
         redirect_to root_path, notice: "Guide has been created"
       else
         render action: :new
@@ -42,7 +42,7 @@ class GuidesController < ApplicationController
 
     ActiveRecord::Base.transaction do
       if @guide.update_attributes(guide_params({latest_edition_attributes: {state: edition_state_from_params, user_id: current_user.id}}))
-        GuidePublisher.new(guide: @guide, edition: @guide.latest_edition).process
+        GuidePublisher.new(guide: @guide).process
         redirect_to root_path, notice: "Guide has been updated"
       else
         render action: :edit

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -55,13 +55,13 @@ class GuidesController < ApplicationController
 
 private
 
-  def comments_list guide
+  def comments_list(guide)
     guide.latest_edition.comments
       .order(created_at: :asc)
       .includes(:user)
   end
 
-  def guide_params with={}
+  def guide_params(with={})
     params
       .require(:guide)
       .permit(:slug, latest_edition_attributes: [

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -39,14 +39,6 @@ class GuidesController < ApplicationController
 
   def update
     @guide = Guide.find(params[:id])
-
-    if @guide.latest_edition.published?
-      duplicated_edition = @guide.latest_edition.dup
-      duplicated_edition.state = "draft"
-      @guide.editions << duplicated_edition
-      @guide.reload
-    end
-
     @comments = @guide.latest_edition.comments
       .order(created_at: :asc)
       .includes(:user)

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -31,17 +31,13 @@ class GuidesController < ApplicationController
 
   def edit
     @guide = Guide.find(params[:id])
-    @comments = @guide.latest_edition.comments
-      .order(created_at: :asc)
-      .includes(:user)
+    @comments = comments_list(@guide)
     @new_comment = @guide.latest_edition.comments.build
   end
 
   def update
     @guide = Guide.find(params[:id])
-    @comments = @guide.latest_edition.comments
-      .order(created_at: :asc)
-      .includes(:user)
+    @comments = comments_list(@guide)
     @new_comment = @guide.latest_edition.comments.build
 
     ActiveRecord::Base.transaction do
@@ -58,6 +54,12 @@ class GuidesController < ApplicationController
   end
 
 private
+
+  def comments_list guide
+    guide.latest_edition.comments
+      .order(created_at: :asc)
+      .includes(:user)
+  end
 
   def guide_params with={}
     params

--- a/app/helpers/guide_helper.rb
+++ b/app/helpers/guide_helper.rb
@@ -1,12 +1,4 @@
 module GuideHelper
-  def edit_action_label(guide)
-    if guide.work_in_progress_edition?
-      'Continue editing'
-    else
-      'Create new edition'
-    end
-  end
-
   STATE_CSS_CLASSES = {
     "new"              => "default",
     "draft"            => "danger",

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -36,14 +36,6 @@ class Edition < ActiveRecord::Base
     state == 'approved'
   end
 
-  def copyable_attributes(extra_attributes = {})
-    attributes.with_indifferent_access.except('id', 'updated_at', 'created_at').merge(extra_attributes)
-  end
-
-  def unsaved_copy
-    self.class.new(copyable_attributes)
-  end
-
 private
 
   def assign_publisher_href

--- a/app/models/guide_publisher.rb
+++ b/app/models/guide_publisher.rb
@@ -1,19 +1,20 @@
 require "gds_api/publishing_api_v2"
 
 class GuidePublisher
-  def initialize(guide:, edition:)
+  def initialize(guide:)
     @guide = guide
-    @edition = edition
   end
 
   def process
     publishing_api = GdsApi::PublishingApiV2.new(Plek.new.find('publishing-api'))
 
-    data = GuidePresenter.new(@guide, @edition).exportable_attributes
+    latest_edition = @guide.latest_edition
+
+    data = GuidePresenter.new(@guide, latest_edition).exportable_attributes
     publishing_api.put_content(@guide.content_id, data)
 
-    if @edition.published?
-      publishing_api.publish(@guide.content_id, @edition.update_type)
+    if latest_edition.published?
+      publishing_api.publish(@guide.content_id, latest_edition.update_type)
     end
   end
 end

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -13,7 +13,7 @@
         <%= f.text_field :slug, class: 'input-md-12 form-control' %>
       </div>
 
-      <%= f.fields_for :edition, edition do |editions_form| %>
+      <%= f.fields_for :latest_edition do |editions_form| %>
 
         <div class='form-group'>
           <%= editions_form.label :related_discussion_title %>
@@ -49,7 +49,7 @@
 
     <fieldset class='inputs'>
       <legend>Content</legend>
-      <%= f.fields_for :edition, edition do |editions_form| %>
+      <%= f.fields_for :latest_edition do |editions_form| %>
         <div class="form-group">
           <%= editions_form.label :title %>
           <%= editions_form.error_list :title %>
@@ -66,7 +66,7 @@
 
     <fieldset class='update'>
       <div class='form-group'>
-        <%= f.fields_for :edition, edition do |editions_form| %>
+        <%= f.fields_for :latest_edition do |editions_form| %>
           <div class='form-group'>
             <%= editions_form.label :update_type %>
             <%= editions_form.error_list :update_type %>

--- a/app/views/guides/edit.html.erb
+++ b/app/views/guides/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render 'form', guide: @guide, edition: @edition%>
+<%= render 'form', guide: @guide%>
 
 <div class='well comments'>
   <fieldset class='meta'>

--- a/app/views/guides/index.html.erb
+++ b/app/views/guides/index.html.erb
@@ -23,7 +23,13 @@
           <%= state_label(guide) %>
         </td>
         <td class='content-controls'>
-          <%= link_to edit_action_label(guide), edit_guide_path(guide), class: 'btn btn-default btn-xs' %>
+          <% if guide.latest_edition.published? %>
+            <%= form_for :drafts, url: guide_drafts_path(guide_id: guide.id), html: {style: "display: inline;"} do |f| %>
+              <%= f.submit("Create new edition", class: 'btn btn-default btn-xs') %>
+            <% end %>
+          <% else %>
+            <%= link_to "Continue editing", edit_guide_path(guide), class: 'btn btn-default btn-xs' %>
+          <% end %>
           <%= link_to "View history", guide_editions_path(guide), class: 'btn btn-default btn-xs' %>
         </td>
       </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
 
   resources :guides do
     resources :editions, only: :index
+    resources :drafts
   end
 
   resources :editions, only: [] do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -49,7 +49,7 @@ if Rails.env.development?
         user:            author
       )
       guide = Guide.create!(slug: object[:url], content_id: nil, latest_edition: edition)
-      GuidePublisher.new(guide: guide, edition: edition).process
+      GuidePublisher.new(guide: guide).process
     end
   end
 end

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     allow_any_instance_of(GuidePublisher).to receive(:process)
   end
 
-  it "should create a new edition if there are no drafts" do
+  it "should create a new draft edition if the latest edition is published" do
     guide = given_a_published_guide_exists
     visit guides_path
     link = there_should_be_a_control_link "Create new edition", document: guide
@@ -22,7 +22,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     expect(guide.editions.map(&:title)).to match_array ["Sample Published Edition", "Sample Published Edition 2"]
   end
 
-  it "should create a new edition even when saving a draft" do
+  it "should not create a new edition if the latest edition isn't published" do
     guide = given_a_guide_exists state: 'draft'
     visit guides_path
     link = there_should_be_a_control_link "Continue editing", document: guide
@@ -31,35 +31,8 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     click_button "Save Draft"
     expect(current_path).to eq root_path
 
-    expect(guide.editions.draft.size).to eq 2
-    expect(guide.editions.map(&:title)).to match_array ["Sample Published Edition", "Sample Published Edition 2"]
-  end
-
-  it "should create a new edition when publishing a draft" do
-    guide = given_a_guide_exists state: 'draft'
-
-    visit edit_guide_path(guide)
-    fill_in "Title", with: "Sample Published Edition 2"
-    click_button "Save Draft"
-
-    visit edit_guide_path(guide)
-    click_button "Send for review"
-
-    visit edit_guide_path(guide)
-    click_button "Mark as Approved"
-
-    visit edit_guide_path(guide)
-    click_button "Publish"
-
-    expect(current_path).to eq root_path
-
-    expect(guide.editions.published.size).to eq 1
     expect(guide.editions.draft.size).to eq 1
-    expect(guide.editions.map(&:title)).to match_array [
-      "Sample Published Edition",
-      "Sample Published Edition 2",
-      "Sample Published Edition 2",
-    ]
+    expect(guide.editions.map(&:title)).to match_array ["Sample Published Edition 2"]
   end
 
   it "should record who's the last editor" do

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
   it "should create a new draft edition if the latest edition is published" do
     guide = given_a_published_guide_exists
     visit guides_path
-    link = there_should_be_a_control_link "Create new edition", document: guide
-    link.click
+    click_button "Create new edition"
     the_form_should_be_prepopulated
     fill_in "Title", with: "Sample Published Edition 2"
     click_button "Save Draft"
@@ -25,8 +24,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
   it "should not create a new edition if the latest edition isn't published" do
     guide = given_a_guide_exists state: 'draft'
     visit guides_path
-    link = there_should_be_a_control_link "Continue editing", document: guide
-    link.click
+    click_link "Continue editing"
     fill_in "Title", with: "Sample Published Edition 2"
     click_button "Save Draft"
     expect(current_path).to eq root_path
@@ -102,12 +100,6 @@ private
       title: 'Sample Published Edition',
     )
     Guide.create!(latest_edition: edition, slug: "/service-manual/test/slug_published")
-  end
-
-  def there_should_be_a_control_link(link_text, document:)
-    link = find_link link_text
-    expect(link[:href]).to eq edit_guide_path(document)
-    link
   end
 
   def the_form_should_be_prepopulated

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 require 'capybara/rails'
+require 'gds_api/publishing_api_v2'
 
 RSpec.describe "creating guides", type: :feature do
   let(:api_double) { double(:publishing_api) }

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe "creating guides", type: :feature do
         end
       end
 
-      it "does persist an extra edition" do
+      it "does not store a new extra edition" do
         edition = Generators.valid_edition(title: "Original Title")
         guide = Guide.create!(slug: "/service-manual/something", latest_edition: edition)
 

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -29,46 +29,4 @@ RSpec.describe Edition, type: :model do
       expect(edition.errors.full_messages_for(:state).size).to eq 1
     end
   end
-
-  describe "#copyable_attributes" do
-    it "returns a hash with attributes excluding fields that get populated on save" do
-      saved_edition = Generators.valid_edition
-      saved_edition.save!
-
-      attributes = saved_edition.copyable_attributes
-
-      expect(attributes['title']).to eq saved_edition.title
-      expect(attributes['body']).to eq saved_edition.body
-
-      expect(attributes['id']).to eq nil
-      expect(attributes['created_at']).to eq nil
-      expect(attributes['updated_at']).to eq nil
-    end
-
-    it "allows to add/override attributes" do
-      edition = Generators.valid_edition
-      edition.state = 'draft'
-      attributes = edition.copyable_attributes(state: 'published', title: 'Teams')
-
-      expect(attributes['title']).to eq 'Teams'
-      expect(attributes['state']).to eq 'published'
-    end
-  end
-
-  describe "#unsaved_copy" do
-    it "returns a copy without fields that get populated on save" do
-      saved_edition = Generators.valid_edition
-      saved_edition.save!
-
-      unsaved = saved_edition.unsaved_copy
-
-      expect(unsaved.title).to eq saved_edition.title
-      expect(unsaved.body).to eq saved_edition.body
-
-      expect(unsaved).to be_a_new_record
-      expect(unsaved.id).to eq nil
-      expect(unsaved.created_at).to eq nil
-      expect(unsaved.updated_at).to eq nil
-    end
-  end
 end

--- a/spec/models/guide_publisher_spec.rb
+++ b/spec/models/guide_publisher_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe GuidePublisher do
     end
 
     it "saves draft items" do
-      publisher = GuidePublisher.new(guide: guide, edition: guide.latest_edition)
+      publisher = GuidePublisher.new(guide: guide)
 
       double_api = double(:publishing_api)
       expected_plek = Plek.new.find('publishing-api')
@@ -34,7 +34,7 @@ RSpec.describe GuidePublisher do
     end
 
     it "saves draft then publishes it" do
-      publisher = GuidePublisher.new(guide: guide, edition: guide.latest_edition)
+      publisher = GuidePublisher.new(guide: guide)
 
       double_api = double(:publishing_api)
       expected_plek = Plek.new.find('publishing-api')


### PR DESCRIPTION
- Comments, and approvals, will stick around on the edition even when it is published.
- Only published versions of editions will stay around forever
- The code in GuidesController should be a lot easier to understand
- I have used inline styles for the "Create a new edition" form for now. Sorry.