### PR TITLE
Spike: Service Manual Section page hierarchy

### DIFF
--- a/lib/tasks/hierarchy_spike.rake
+++ b/lib/tasks/hierarchy_spike.rake
@@ -25,6 +25,7 @@ namespace :hierarchy_spike do
     with_payload(file_name) do |payload|
       validate_against_schema(payload)
       publishing_api.put_content(payload[:content_id], payload)
+      publishing_api.put_links(payload[:content_id], payload) if payload[:links].present?
       publishing_api.publish(payload[:content_id], 'minor')
     end
   end

--- a/lib/tasks/hierarchy_spike.rake
+++ b/lib/tasks/hierarchy_spike.rake
@@ -1,0 +1,34 @@
+require 'yaml'
+require "gds_api/publishing_api_v2"
+
+# The YAML data files are generated using a script
+# https://gist.github.com/tadast/defd1b6fc1e2eccd77f3
+
+namespace :hierarchy_spike do
+  desc "Store hard-coded Service Manual Section hierarchy to the publishing API as a draft"
+  task publish_guides: [:environment] do
+    publish_from_file("guides.yml")
+  end
+
+  desc "Publish hard-coded Service Manual Section hierarchy that was previously saved as a draft"
+  task publish_sections: [:environment] do
+    publish_from_file("section_hierarchy.yml")
+  end
+
+  def publish_from_file(file_name)
+    publishing_api = GdsApi::PublishingApiV2.new(Plek.new.find('publishing-api'))
+    with_payload(file_name) do |payload|
+      publishing_api.put_content(payload[:content_id], payload)
+      publishing_api.publish(payload[:content_id], 'minor')
+    end
+  end
+
+  def with_payload(file_name)
+    payloads = YAML.load_file(Rails.root.join('lib', 'tasks_data', file_name))
+    payloads.each do |payload|
+      print "Publishing #{payload[:title]} at #{payload[:base_path]}"
+      yield(payload)
+      puts " ✔️"
+    end
+  end
+end

--- a/lib/tasks/hierarchy_spike.rake
+++ b/lib/tasks/hierarchy_spike.rake
@@ -4,6 +4,11 @@ require "gds_api/publishing_api_v2"
 # The YAML data files are generated using a script
 # https://gist.github.com/tadast/defd1b6fc1e2eccd77f3
 
+GovukContentSchemaTestHelpers.configure do |config|
+  config.schema_type = 'publisher'
+  config.project_root = Rails.root
+end
+
 namespace :hierarchy_spike do
   desc "Store hard-coded Service Manual Section hierarchy to the publishing API as a draft"
   task publish_guides: [:environment] do
@@ -18,6 +23,7 @@ namespace :hierarchy_spike do
   def publish_from_file(file_name)
     publishing_api = GdsApi::PublishingApiV2.new(Plek.new.find('publishing-api'))
     with_payload(file_name) do |payload|
+      validate_against_schema(payload)
       publishing_api.put_content(payload[:content_id], payload)
       publishing_api.publish(payload[:content_id], 'minor')
     end
@@ -29,6 +35,13 @@ namespace :hierarchy_spike do
       print "Publishing #{payload[:title]} at #{payload[:base_path]}"
       yield(payload)
       puts " ✔️"
+    end
+  end
+
+  def validate_against_schema(payload)
+    validator = GovukContentSchemaTestHelpers::Validator.new(payload[:format], payload.to_json)
+    if !validator.valid?
+      raise "Payload #{payload[:content_id]} not valid against #{payload[:format]} schema: #{validator.errors}"
     end
   end
 end

--- a/lib/tasks_data/guides.yml
+++ b/lib/tasks_data/guides.yml
@@ -1,0 +1,5153 @@
+---
+- :content_id: c28c2fbf-86f6-4bfb-adaa-1dd20f0a0429
+  :title: 'Agile and government services: an introduction'
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:52+00:00'
+  :public_updated_at: '2015-11-04T12:08:52+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/agile-delivery/agile-and-government-services"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/agile-delivery/agile-and-government-services"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <p class="lede">
+      Agile project management will help you build world-class, user-centred services quickly and affordably.
+      </p> -->
+      <h2 id="the-origin-of-agile">The origin of agile</h2>
+      <p>Agile project management evolved in software development, but it’s focus on user needs and methods can be successfully applied to other projects. The Government Digital Service (GDS) manages its projects and workstreams using agile and has shown that it produces user-centred services quickly and affordably.</p>
+      <h2 id="digital-by-default-service-standard-and-assessment">Digital by default service standard and assessment</h2>
+      <p>All digital projects in government must use agile methods to comply with the service standard and pass service assessments. Agile methods can be tailored depending on the operational needs and constraints of different organisations.</p>
+      <h2 id="agile-principles">Agile principles</h2>
+      <p>An agile project is about creating fast iterations of products and services based on the feedback of real users.</p>
+      <p>It means:</p>
+      <ul>
+      <li>constant communication between team members</li>
+      <li>regularly releasing small pieces of functionality</li>
+      <li>displaying the progress being made by your team (eg with project management software, walls and whiteboards)</li>
+      </ul>
+      <h3 id="your-users">Your users</h3>
+      <p>User understanding is the most important factor when creating a service. You need a team that has the skills to understand what users need and can make sure those needs are met.</p>
+      <h3 id="your-team">Your team</h3>
+      <p>An agile team is multidisciplinary and will include the skills of a user researcher, developer, data analyst, content designer, designer and delivery manager. They must have the skills, organisational support and tools to do their jobs and be trusted to manage their own work.</p>
+      <h3 id="main-features-of-agile">Main features of agile</h3>
+      <p>Agile projects are broken down into phases:</p>
+      <ul>
+      <li>discovery</li>
+      <li>alpha</li>
+      <li>beta</li>
+      <li>live</li>
+      </ul>
+      <p>Product development during each phase is broken down into different stages, called sprints.</p>
+      <p>In a sprint, team members aim to achieve goals within set timeframes. A sprint at GDS generally lasts a week and runs from Wednesday to Tuesday, however other agile development teams may run longer or shorter sprints.</p>
+      <p>There are a range of tools and meetings to help the team achieve the goals set in a sprint, but the 2 essential meetings are:</p>
+      <ul>
+      <li>the stand up, a short daily team meeting</li>
+      <li>the retrospective, a meeting at the end of 1 or 2 sprints to reflect on what did and didn’t go well</li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 1a76a03c-4298-459c-827e-38497203e467
+  :title: Agile methodology explained
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:52+00:00'
+  :public_updated_at: '2015-11-04T12:08:52+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/agile-delivery/agile-methodology-explained"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/agile-delivery/agile-methodology-explained"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <p>Agile can be a liberating way of working. It won’t stop you from using existing skills and knowledge, but it will require your team, users and stakeholders to start working together in new ways.</p>
+      <h2 id="understand-your-users">Understand your users</h2>
+      <p>Real people will use your product</p>
+      <p>Prioritise features for users over everyone else – including your big, scary stakeholders – and ask for their feedback early and often. Really listen to your users. Even when they tell you things you don’t want to hear or disagree with.</p>
+      <p>If possible, use data from real people that are using your product and let it influence the direction of your project. Constantly put users first.</p>
+      <p>“What do you want next Friday? What have we learned last week?”</p>
+      <h2 id="iterate-often">Iterate often</h2>
+      <p>Build something that strives to achieve the most valuable user need and show it to the users, listen to their feedback and improve it. Keep doing this until you have something so useful that they wouldn’t be without it.</p>
+      <p>It might sound like over-simplifying the complexity of software development and project management, but agile development is all about “what do you want by next Friday?”</p>
+      <p>The process of producing incremental, production-ready software allows your team to:</p>
+      <ul>
+      <li>give value to their users and stakeholders regularly</li>
+      <li>shorten feedback loops that could be longer if using a waterfall methodology (where you only move on to the next phase when the phase you’re working on is complete)</li>
+      <li>think about what features are the next most important to produce</li>
+      <li>direct their efforts on creating usable software</li>
+      </ul>
+      <p>Run a retrospective at the end of each delivery cycle or sprint to review what worked or what could be improved.</p>
+      <p>Your team will continue to learn through delivery cycles and improve throughout the project.</p>
+      <h2 id="small-agile-teams">Small, agile teams</h2>
+      <p>The unit of delivery is the team</p>
+      <p>Small teams of between 5 to 10 people are often more productive and predictable than larger teams. Forget man-days (the amount of work produced by an average worker in a day) and think about your team as a unit.</p>
+      <p>A good team includes members with all of the skills necessary to successfully produce software. A fully functioning team has 3 main roles:</p>
+      <ul>
+      <li>product manager - responsible for delivering return on investment, usually by creating products that users love</li>
+      <li>delivery manager (aka Scrum master or project manager) – the agile expert responsible for removing blockers (things slowing a team down), they also act as a facilitator at team meetings</li>
+      <li>team members – self-organising and multi-disciplinary, they produce user stories, carry out the product manager’s vision and are responsible for estimating their output and speed</li>
+      </ul>
+      <p>Encourage your team members to pair up, as working together is beneficial. 2 people working on 1 thing will:</p>
+      <ul>
+      <li>produce better software solutions</li>
+      <li>encourage better quality controls</li>
+      <li>spread knowledge across the team</li>
+      </ul>
+      <p>A good team means you’re able to estimate your output, or speed, very effectively and consistently. You can then plan much more accurately.</p>
+      <ul>
+      <li>Fail fast</li>
+      </ul>
+      <p>Regularly releasing little pieces of code will:</p>
+      <ul>
+      <li>improve quality</li>
+      <li>improve visibility</li>
+      <li>reduce cost to market</li>
+      </ul>
+      <p>Agile techniques don’t guarantee success – you can still fail!</p>
+      <p>But these techniques do allow you to spot problems earlier on and resolve them. You can resolve issues, and stop issues from happening, by:</p>
+      <ul>
+      <li>releasing working software to your users regularly – it allows you to get feedback quickly and hear or see what they think; if the product is wrong you can easily change direction and iterate</li>
+      <li>demonstrating value to your sponsor with regular releases – if your software is rarely released you run the risk of creating a ‘too-big-to-fail’ service that shouldn’t be released, but must be released anyway</li>
+      <li>checking your teams’ progress – if your teams’ speed is still inconsistent after the initial 4 to 6 sprints, then something needs fixing (possibly unknown complications or poor estimation with timings)</li>
+      <li>using test-driven development (writing tests before you develop the features to be tested) to highlight issues with quality early on – establish the issues, baseline metrics, and monitor throughout the project</li>
+      </ul>
+      <p>Don’t be afraid to fail or experiment. Learn to fail, and create a culture that learns from failure.</p>
+      <h2 id="continuous-planning">Continuous planning</h2>
+      <p>It’s a myth that you don’t plan on agile projects. The freedom of agile projects does not come free: you have to plan. You just plan differently and continuously.</p>
+      <p>Base your agile planning on solid, historical data, not theories or opinions. Your plan must continuously demonstrate its accuracy: nobody on your agile project should take it for granted that the plan is workable.</p>
+      <p>Your teams should plan together, on at least 2 levels:</p>
+      <ul>
+      <li>release level – identify and prioritise the features you must have, and would like to have by the deadline</li>
+      <li>iteration level – plan for the next features to implement, in priority order (if features are too large to be estimated or delivered within a single iteration, break them down further)</li>
+      </ul>
+      <p>Review these plans after every sprint and adjust them based on:</p>
+      <ul>
+      <li>the progress of the previous sprint</li>
+      <li>any new facts and requirements</li>
+      </ul>
+      <h2 id="signs-you-aren-t-being-agile">Signs you aren't being agile</h2>
+      <p>If your team is new to agile, be wary of familiar situations and reactions from having to do things differently. These situations have a bad smell about them and will undermine your project and its chances of success:</p>
+      <ul>
+      <li>your core team isn’t full-time or is working on multiple projects – your team is the unit of delivery and you need 100%, so push back on managers and stakeholders if this is happening</li>
+      <li>you don’t have a dedicated team area – sit your team together, preferably in your own room, with space on the walls to draw ideas and stick up cards and post-its, rearrange your workspace or use tools in innovative ways to improve your teams’ working environment and increase productivity – you’ll challenge some longstanding working practices, but this is very important</li>
+      <li>there’s no continuous integration/development environment – if your teams aren’t insisting on this from the beginning you’ve probably got the wrong team:
+      iterative software development is, in many areas, dependent on the ability to continuously deploy and run automated tests</li>
+      <li>you have a separate quality assurance (QA) department – if your team pass software they’ve developed over to a QA department, they’ve got the wrong
+      attitude to delivering production-ready software; embed a quality culture into the team</li>
+      </ul>
+      <p>This is by no means a complete list, but these are most common things to watch out for.</p>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: ab7f03c6-ec30-4a14-84ed-cffabdd3e075
+  :title: Choose agile planning software
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:52+00:00'
+  :public_updated_at: '2015-11-04T12:08:52+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/agile-delivery/agile-planning-software"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/agile-delivery/agile-planning-software"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <p class="lede">
+        Agile planning boards are another way of managing a team’s work along with the wall. User stories are recorded as tickets on planning boards using software such as Pivotal Tracker, Trello, KanbanFlow.
+      </p> -->
+      <h2 id="why-use-planning-boards">Why use planning boards</h2>
+      <p>The best requirements and designs emerge from self-organising teams. Planning boards mean the team can create, update and pick up tickets to work on themselves.</p>
+      <p>They also allow team members to see what is being worked on and by who. A well written tickets allows work to be handed over during absence and leave.</p>
+      <h2 id="how-to-use-them">How to use them</h2>
+      <p>There are a number of software solutions available each with different features. Many are free and quick to set up which means you can try one and if it isn’t quite right move on and try another.</p>
+      <p>How you set up your boards is up to you, but it is usual to have workflow columns including:</p>
+      <ul>
+      <li>icebox (unpriortised tasks)</li>
+      <li>ready to do (the next most important things to do</li>
+      <li>doing right now</li>
+      <li>done</li>
+      </ul>
+      <p>Each ticket should be a user story, with a clear user need and acceptance criteria.</p>
+      <h3 id="examples">Examples</h3>
+      <p><img src="http://dummyimage.com/600x400/4d494d/686a82.gif&amp;text=placeholder+image" alt="placeholder+image"></p>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 45eb482c-5328-484b-93d8-684fd87e434e
+  :title: Create an agile working environment
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:52+00:00'
+  :public_updated_at: '2015-11-04T12:08:52+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/agile-delivery/create-agile-working-environment"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/agile-delivery/create-agile-working-environment"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <p>An agile working environment and culture can be different to a traditional working environment.</p>
+      <div class="exclamation-highlight">
+        <p>To pass <a href="/service-standard/point-4/">Use agile methods</a> in the <a href="/service-standard/">Digital Service Standard</a> you must be able to show evidence of the service team working in an agile environment.</p>
+      </div>
+
+      <p>You can expect to see lots of short meetings throughout a day, often around walls covered in notes or reference material. This can seem strange in office cultures that are much more used to formal meetings or conference calls.</p>
+      <p>Those working in creative and technical fields often need plenty of space for focused, detailed work. It’s not uncommon to see people spending a significant chunk of their day with headphones on to help them focus, or locked in conversation with just one person with whom they’re pairing.</p>
+      <iframe width="589px" height="411px" src="https://www.youtube.com/embed/2rAE6c6cSM4" frameborder="0" allowfullscreen></iframe>
+
+      <h2 id="meeting-the-service-standard">Meeting the service standard</h2>
+      <p>Working spaces for digital projects will vary so as a team you should dedicate time at the beginning of a project to deciding:</p>
+      <ul>
+      <li>how to structure your space</li>
+      <li>what tools you need</li>
+      </ul>
+      <p>You’ll need to explain in a service assessment how you’re working in an agile way, the tools, techniques and processes you’re using and how you’re communicating.</p>
+      <h2 id="your-physical-environment">Your physical environment</h2>
+      <p>The space a team works in is a tool. It is just as important as the choice of project management tools or choice of programming language.</p>
+      <h3 id="sitting-together">Sitting together</h3>
+      <p>Ideally your team will work from the same location, (referred to as co-location), and sit together.</p>
+      <p>Short, informal conversations are an important way to test assumptions, and this gets much harder when a team is distributed across an office or in different buildings.</p>
+      <h3 id="hacking-the-environment">Hacking the environment</h3>
+      <p>Removing dividers between desks makes a big difference and allows conversation between the team to flow more freely. If large monitors are getting in the way remove them.</p>
+      <p>You might also want to think about getting desk tidies. The difference a tidy environment makes to ability of a team to think and work is striking.</p>
+      <p>This process is known as ‘hacking the environment’.</p>
+      <h3 id="wall-space">Wall space</h3>
+      <p>Teams using agile approaches need wall space in their work area. If you can’t use a wall, whiteboards or even windows are an alternative.</p>
+      <p><img src="https://gds.blog.gov.uk/wp-content/uploads/sites/60/2014/09/IDA-user-research-wall-01.08.14-Pete-Gale-620x502.jpg" alt=""></p>
+      <p>You’ll need sticky notes or cards and blu-tack to stick your work to your walls.</p>
+      <p>The wall creates a physical focus for the team and for collaboration, they:</p>
+      <ul>
+      <li>will gather round it at their daily stand-up</li>
+      <li>refer to and update it during the day</li>
+      <li>can show the status of their work to anyone outside of the team</li>
+      </ul>
+      <p>This helps the team to:</p>
+      <ul>
+      <li>discuss what they’re working on</li>
+      <li>sort out problems</li>
+      <li>talk through ideas</li>
+      </ul>
+      <p>This is called ‘visual management’.</p>
+      <p><a href="https://gds.blog.gov.uk/2014/09/03/vertical-campfires-our-user-research-walls/">Read more about how government teams have created walls for their work</a></p>
+      <h2 id="the-right-technology">The right technology</h2>
+      <p>As a team you’ll also need online tools to help you communicate and manage your work.</p>
+      <p>Individual members of the team may also need access to tools to help them with their role, for example your user researcher may need access to video editing software.</p>
+      <h3 id="online-communication">Online communication</h3>
+      <p>It’s essential that your team can be in constant contact with one another to:</p>
+      <ul>
+      <li>make quick decisions</li>
+      <li>provide support and information</li>
+      <li>ensure everyone’s aware of the project as a whole</li>
+      </ul>
+      <p>You’ll achieve some of that through regular short meetings eg daily standup or weekly ‘show and tell’ session, but you’re also likely to need an online discussion channel. This is a channel that’s more immediate and conversational than email but that allows people to dip in and out. Because it is network based it works regardless of geography so distributed teams can continue to communicate as if they were in one room.</p>
+      <p>For example the Government Digital Service (GDS) uses Slack. Some departments like the Environment Agency use Yammer, the Ministry of Justice (MoJ) uses Hipchat.</p>
+      <h3 id="collaboration">Collaboration</h3>
+      <p>You must have a browser-based editing tool so your team can work on the same documents at the same time. This is a mandatory <a href="https://www.gov.uk/government/publications/open-standards-for-government/sharing-or-collaborating-with-government-documents">open standard</a> for government. It helps you to avoid problems of having multiple versions of the same document. GDS, MoJ and many other departments use Google drive for collaboration.</p>
+      <p>GDS and MoJ also use collaboration tools like Confluence for internal wikis. GDS uses  Basecamp for cross government communities like content and analytics.</p>
+      <h3 id="managing-your-backlog">Managing your backlog</h3>
+      <p>You might find it useful to use an electronic board as well as your physical wall to manage a large backlog.</p>
+      <p>An electric board is also helpful to record further detail behind backlog items for example, draft designs, or to link to discussions on collaboration tools for example, Confluence.</p>
+      <p>Teams at GDS use Trello, for example the <a href="https://trello.com/b/GyqsETvS/gov-uk-high-level-roadmap">GOV.UK roadmap</a> which is publically available. HMRC, Home Office and MoJ use JIRA.</p>
+      <p>For more information about finding the right technology for your needs, <a href="https://www.gov.uk/government/publications/digital-skills-in-the-civil-service/internet-tools-for-civil-servants-an-introduction">read the internet tools for civil servants guidance on GOV.UK</a>.</p>
+      <h2 id="visit-agile-working-environments">Visit agile working environments</h2>
+      <p>If you’re setting up an agile working environment for your team, you might find it useful to go and look at how other agile teams are working.</p>
+      <p>Get in touch with the agile delivery community to arrange a tour.</p>
+      <h2 id="further-reading">Further reading</h2>
+      <ul>
+      <li><a href="http://www.paulgraham.com/makersschedule.html">Paul Graham on Makers’ Schedules vs. Managers’ Schedules</a></li>
+      <li><a href="https://userresearch.blog.gov.uk/2015/07/15/how-to-make-a-research-wall-when-you-dont-have-a-wall/">How to make a research wall when you don't have a wall</a></li>
+      <li><a href="https://gds.blog.gov.uk/2012/12/19/the-agile-wall/">The role of the agile wall at GDS</a></li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: adcff8ab-c40d-4f23-b831-f03c35e7a8b0
+  :title: Agile wall
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:53+00:00'
+  :public_updated_at: '2015-11-04T12:08:53+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/agile-delivery/the-agile-wall"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/agile-delivery/the-agile-wall"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!--
+      <p class="lede">
+      Physical walls show what work is being planned and worked on, create a focus for the team and promote transparency.
+      </p> -->
+      <h2 id="why-have-a-wall">Why have a wall</h2>
+      <p>In agile working, visual management and face to face communication are fundamental to a project’s success. The wall promotes both of these; the team has their daily stand up around their wall and update it throughout the day.</p>
+      <p>Instead of keeping ideas, plans and work-in-progress buried in digital tools, charts and emails, teams can manage their workflow through their walls.</p>
+      <p>Anyone should be able to look at an agile wall and be able to understand a project. If a wall can’t be easily understood (eg it’s not immediately clear where the team is blocked), it’s up to the team’s delivery manager to make improvements.</p>
+      <h2 id="what-goes-on-a-wall">What goes on a wall</h2>
+      <p>Walls will differ from team to team, however most walls are used to manage what:</p>
+      <ul>
+      <li>the team have yet to start work on</li>
+      <li>they’re currently doing</li>
+      <li>they’ve already done</li>
+      </ul>
+      <p>Work to do is represented as cards that are moved along the wall. Sometimes cards are annotated, eg to show who’s working on them or that the work is blocked.</p>
+      <p>Team walls capture the flow of work through different stages.</p>
+      <p>The team should also track:</p>
+      <ul>
+      <li>progress against their goals and key performance indicators (KPIs) – for live data this could be shown on an electronic dashboard like the <a href="https://gov.uk/performance">GDS performance platform</a>
+      </li>
+      <li>risks and issues</li>
+      <li>major obstacles to delivery (‘blockers’)</li>
+      <li>important deadlines and dependencies</li>
+      </ul>
+      <p>Information about the service and team is also commonly shown, like:</p>
+      <ul>
+      <li>the service vision and roadmap (goals)</li>
+      <li>who is in the team</li>
+      <li>what their working arrangements are, eg when their show and tells are held</li>
+      </ul>
+      <h2 id="examples">Examples</h2>
+      <p>How GDS uses the agile wall is discussed in the blog post <a href="https://gds.blog.gov.uk/2012/12/19/the-agile-wall">The role of the agile wa)l</a>.</p>
+      <p>This wall is used to manage a software team’s work. It shows their goals, successes and a simple flow of tasks: to do - in progress - in review - to deploy - done.</p>
+      <p>This is a section of the wall used to manage the transfer of departments and agency websites to GOV.UK. It uses a similar flow of tasks but on a much larger scale.</p>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 8adca8f7-203d-4147-97cd-c1361c8988bf
+  :title: Retrospective
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:53+00:00'
+  :public_updated_at: '2015-11-04T12:08:53+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/agile-delivery/retrospective"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/agile-delivery/retrospective"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <p class="lede">
+        A meeting to find out what’s working and what isn’t, so your team can continuously improve.
+      </p> -->
+      <h2 id="what-a-retrospective-is">What a retrospective is</h2>
+      <p>A retrospective is a meeting where your team get a chance to talk about what went well and badly. You also take some actions to improve things.</p>
+      <p>It is generally held at the end of a sprint, but can also cover a longer period or specific task eg a full project retrospective. If it would be useful to review something so you can make improvements then a retrospective is a good way to do it.</p>
+      <h2 id="why-do-retrospectives-">Why do retrospectives?</h2>
+      <p>A central principle of agile working is quick feedback loops. You demonstrate something to the user as soon as possible so you can see how well it suits their needs. Retrospectives are the way we apply this to our own teams to find out what’s working and what isn’t, so a team can continuously improve.</p>
+      <p>Having a regular retrospective means you can fine-tune your working processes and your environment to your needs by:</p>
+      <ul>
+      <li>making regular small improvements, ideally before problems start to fester</li>
+      <li>identifying working practices that make you more efficient, productive or at least happier</li>
+      </ul>
+      <p>This is a chance for everyone in your team to contribute to improving process and productivity.</p>
+      <h2 id="how-a-retrospective-works">How a retrospective works</h2>
+      <p>There’s no one right way to run a retrospective, but it will take this general form:</p>
+      <ol>
+      <li>gather data</li>
+      <li>generate insights</li>
+      <li>decide what to do</li>
+      </ol>
+      <p>There are different ways you can do this. The agile retrospective wiki includes plans for <a href="http://www.google.com/url?q=http%3A%2F%2Fretrospectivewiki.org%2Findex.php%3Ftitle%3DRetrospective_Plans&amp;sa=D&amp;sntz=1&amp;usg=AFQjCNGZicjBIt-CG_MKtxK9eaYbOPg25Q">different types of retrospectives</a>.</p>
+      <h3 id="have-a-facilitator">Have a facilitator</h3>
+      <p>All retrospectives must be facilitated. The facilitator’s role is to give everyone a chance to talk about their concerns and give positive feedback.</p>
+      <p>At the same time, they make sure the meeting remains a structured, productive meeting and doesn’t become overly negative. Ideally, your facilitator will be someone outside of your team so your whole team can contribute, but it’s not essential.</p>
+      <p>The facilitator needs to:</p>
+      <ul>
+      <li>plan the retrospective</li>
+      <li>make sure that everyone gets a chance to contribute</li>
+      <li>keep the retrospective on track</li>
+      <li>make sure actions are created and assigned</li>
+      <li>manage time so that it does not run over</li>
+      </ul>
+      <h3 id="set-out-working-agreements">Set out working agreements</h3>
+      <p>You’ll find it helpful to have some working agreements for a retrospective. These can be stated if necessary, eg in the first retrospective your team has.</p>
+      <p>Working agreements could be that:</p>
+      <ul>
+      <li>everyone contributes</li>
+      <li>no one speaks over the other (except for the facilitator)</li>
+      <li>no phones or laptops are allowed – everyone should be concentrating on the discussion</li>
+      </ul>
+      <h3 id="set-a-time-limit">Set a time limit</h3>
+      <p>Each of the activities should be timeboxed (has a set time it will run for), and it’s your facilitator’s job to make sure that your team stick to this.</p>
+      <p>Build in about 10% ‘shuffle time’ to move between activities to make sure it doesn’t overrun.</p>
+      <p>It’s OK to finish early if people have said what they need to. It’s not OK to overrun – if there is too much to say, have the team prioritise the top areas for discussion and/or book more time for the next retrospective.</p>
+      <h3 id="example-timeline">Example timeline</h3>
+      <p>This timeline is based on a team of 8 to 10 and covers a 2-week sprint. 90 minutes is a reasonable amount of time to use for this scope and amount of people.</p>
+      <ol>
+      <li>Explain the scope and purpose of the session: (5 minutes)</li>
+      <li>Update on actions from last retrospective: (5 minutes)</li>
+      <li>Write down all the things that went well: (10 minutes)</li>
+      <li>Discuss all the good things: (10 minutes)</li>
+      <li>Write down all the things that went badly (15 minutes)</li>
+      <li>Discuss all the bad things (20 minutes)</li>
+      <li>Agree actions, assign them to someone with a deadline (15 minutes)</li>
+      </ol>
+      <h2 id="what-you-should-get-from-a-retrospective">What you should get from a retrospective</h2>
+      <p>During the discussion you will uncover some successes you can celebrate, as well as some problems that you can fix or things you can improve.</p>
+      <p>Make a list of actions that will address these. Aim to have done them within the next sprint or iteration.</p>
+      <p>Some problems may take longer to fix, in which case you should try to make an action that will start the process of improving it by your next retrospective.</p>
+      <p>Actions should:</p>
+      <ul>
+      <li>be concrete and measurable (eg ‘write 10 more unit tests for the redirector’, or ‘speak to Jamie about arranging a project retrospective’; not ‘write more tests’, or ‘we should understand the lessons learned from this project’)</li>
+      <li>have a date by which they should be completed</li>
+      <li>be assigned to a specific person</li>
+      <li>not be assigned to someone who isn’t present</li>
+      </ul>
+      <p>Retrospectives should follow up on the actions of previous retrospectives to make sure they’ve been completed. If they’re consistently not getting done, you may have too many.</p>
+      <h2 id="examples-from-around-government">Examples from around government</h2>
+      <p>Piers Dunstall from the Skills Funding Agency writes about <a href="https://sfadigital.blog.gov.uk/2015/03/04/a-retrospective-retrospective-what-should-be-covered/">facilitating his first retrospective</a>.</p>
+      <p>Natalie Taylor from the Home Office’s Registered Traveller service talks about <a href="https://digitaltransformation.blog.gov.uk/2014/09/08/agile-working-the-appreciative-retrospective/">running an appreciative retro</a>.</p>
+      <p>Richard Mayou from the Skills Funding Agency shares the <a href="https://sfadigital.blog.gov.uk/2014/12/23/reviewing-2014-our-first-giant-retrospective-and-cdo-show-and-tell/">outcomes from a giant retrospective</a>.</p>
+      <h2 id="join-the-discussion">Join the discussion</h2>
+      <p>There are <a href="#">communities of practice</a> across all areas of government service design, including one for service managers and delivery managers. You can also read and contribute to <a href="https://www.blog.gov.uk/">government blogs</a>.</p>
+      <h2 id="further-reading">Further reading</h2>
+      <p>You may find these resources useful when running retrospectives:</p>
+      <ul>
+      <li>
+      <p><a href="http://retrospectivewiki.org/index.php?title=Agile_Retrospective_Resource_Wiki">The Agile Retrospective Wiki</a></p>
+      </li>
+      <li>
+      <p><a href="https://leanpub.com/gettingvalueoutofagileretrospectives">Getting Value out of Agile Retrospectives</a> – free eBook, includes the business value and benefits of retrospectives with exercises and advice for introducing, improving and facilitating them</p>
+      </li>
+      <li>
+      <p><a href="https://pragprog.com/book/dlret/agile-retrospectives">Agile Retrospectives: Making Good Teams Great</a> by Esther Derby and Diana Larsen</p>
+      </li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 9351e0c3-d921-42f6-bb6c-8c8972eec845
+  :title: Roadmap
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:53+00:00'
+  :public_updated_at: '2015-11-04T12:08:53+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/agile-delivery/the-roadmap"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/agile-delivery/the-roadmap"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <p class="lede">The roadmap is visual overview of a project’s goals and shows the direction a service will take. It is produced during the discovery phase.</p> -->
+      <h2 id="why-you-need-a-roadmap">Why you need a roadmap</h2>
+      <p>The roadmap will be used to inform the business case you’ll need to write to move your project into the alpha phase. You’ll measure project progress against the goals in the roadmap and modify them as you learn more about user needs.</p>
+      <h2 id="how-to-make-a-roadmap">How to make a roadmap</h2>
+      <p>You need to start with the project’s vision and goals that were created in the discovery phase. Along with your team, plot these goals against your project’s phases to create a roadmap.</p>
+      <p>You can use your wall to show your road map and record it in a spreadsheet.</p>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: b202dea8-bdf0-4f1a-a0c0-4b993dbeef9d
+  :title: Show and tell
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:53+00:00'
+  :public_updated_at: '2015-11-04T12:08:53+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/agile-delivery/show-and-tell"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/agile-delivery/show-and-tell"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <h2 id="what-a-show-and-tell-is">What a show and tell is</h2>
+      <p>Also known as a sprint review, this meeting happens every few weeks to give the rest of the organisation a chance to:</p>
+      <ul>
+      <li>see the most important work the team has done during that period</li>
+      <li>hear their plans for the next few weeks</li>
+      <li>listen to them and ask questions</li>
+      </ul>
+      <h2 id="why-show-and-tell-">Why show and tell?</h2>
+      <p>People outside the team get to look at or use what’s being developed and form their view of how they’re meeting user needs. They’ll also leave the show and tell with information to share with the wider organisation.</p>
+      <p>They are useful even early in the development of a service (in the discovery and alpha phases). This is a chance for your team to get feedback and so help shape what the team does next.</p>
+      <p>It is also an important opportunity to invite your project sponsors and stakeholders along.</p>
+      <h2 id="how-show-and-tells-work">How show and tells work</h2>
+      <p>The delivery team runs the show and tell, but you can ask for specific things to be shown. It’s the team’s responsibility to make sure the meeting is useful to the people there. You should check with them beforehand.</p>
+      <p>The team will highlight issues, dependencies, assumptions and risks that are affecting them but the meeting isn’t a forum for detailed review or discussion of these.</p>
+      <p>The show and tell is an opportunity for you to ask questions about the work done and provide feedback. It’s not an opportunity to argue for changes in the team’s plans or challenge their user research - if you have concerns around these, take them up with the service manager before or after the meeting.</p>
+      <p>##Example: Ministry of Justice's creative show and tell</p>
+      <p>The digital team at the Ministry of Justice were struggling to get their stakeholders to listen at their show and tell review meetings. They decided to turn the concept on its head and get their audience to demonstrate their product.</p>
+      <p>Abisola Fatokun explains <a href="https://mojdigital.blog.gov.uk/2014/07/28/getting-stakeholders-more-involved-in-sprint-reviews/">how they did it</a>.</p>
+      <p>##Further reading</p>
+      <p><a href="https://userresearch.blog.gov.uk/2015/06/03/tips-for-presenting-user-research-at-show-and-tell/">Tips for presenting user research at show and tell</a></p>
+      <p>###Elsewhere on the manual</p>
+      <ul>
+      <li><a href="/agile-delivery/the-agile-wall/">Set up an agile wall</a></li>
+      <li><a href="/agile-delivery/the-roadmap/">Make a roadmap</a></li>
+      <li><a href="/agile-delivery/agile-governance/">Governing an agile service</a></li>
+      </ul>
+      <!-- ##Join the discussion
+      To give feedback, make a suggestion or share your experience, use the agile hackpad.
+
+
+      ##Be part of the community
+
+      There’s an active community of delivery and service managers in the UK government, email [Nick Smith](mailto:nick.smith@digital.cabinet-office.gov.uk) to join. -->
+      <!-- ## Tags
+      <ol class="tags">
+        <li><a href="/tag/agile-ceremonies/">agile ceremonies</a></li>
+        <li><a href="/tag/show-and-tell/">show and tell</a></li>
+      </ol> -->
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 514a2199-8f93-448b-a21f-0866590ccac1
+  :title: Sprint planning
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:53+00:00'
+  :public_updated_at: '2015-11-04T12:08:53+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/agile-delivery/sprint-planning"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/agile-delivery/sprint-planning"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <p class="lede">
+        A meeting where you’ll agree what work you need to do in your next sprint.
+      </p> -->
+      <h2 id="what-sprint-planning-is">What sprint planning is</h2>
+      <p>You do sprint planning at the start of each sprint. There are 2 parts to it:</p>
+      <ul>
+      <li>what we’ll do</li>
+      <li><a href="http://agilemanifesto.org/principles.html">Twelve Principles of the Agile Manifesto</a></li>
+      <li>how we’ll do it</li>
+      </ul>
+      <h2 id="how-sprint-planning-works">How sprint planning works</h2>
+      <h3 id="before-sprint-planning">Before sprint planning</h3>
+      <p>You need to write user stories with acceptance criteria before the meeting.</p>
+      <p>Discuss the stories ahead of sprint planning with:</p>
+      <ul>
+      <li>relevant team members</li>
+      <li>subject matter experts</li>
+      <li>stakeholders</li>
+      </ul>
+      <h3 id="at-sprint-planning">At sprint planning</h3>
+      <p>The product owner should read out the stories and explain the acceptance criteria in order of priority. It’s the job of the team to:</p>
+      <ul>
+      <li>understand the story and acceptance criteria</li>
+      <li>agree on the number of user stories they’ll aim to achieve within each sprint</li>
+      <li>agree on the tasks needed to complete it</li>
+      </ul>
+      <p>A <a href="http://www.agilelearninglabs.com/resources/scrum-introduction/">good description of sprint planning</a> is on the Agile Learning Labs website.</p>
+      <p>This meeting can be hard to get right with large teams. Some people want to dig deep and question every story; others want to keep moving and don’t want to go into detail. Persevere!</p>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 9ce4c8aa-742a-4852-a523-7134fedcc65b
+  :title: Stand up
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:53+00:00'
+  :public_updated_at: '2015-11-04T12:08:53+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/agile-delivery/stand-up"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/agile-delivery/stand-up"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <p class="lede">
+        Daily meetings with your team so you know what they’re doing and if they have any problems.
+      </p> -->
+      <h2 id="what-a-stand-up-is">What a stand-up is</h2>
+      <p>The stand-up is a regular meeting you should have with your team.</p>
+      <h2 id="how-a-stand-up-works">How a stand-up works</h2>
+      <p>It’s a daily meeting that should last no more than 15 minutes. It’s best if you do it standing up, in a semicircle, in front of your project wall. This will help you to keep it short and allows your team members to point at user story cards on the wall to keep things on topic.</p>
+      <p>Each member of your team should say:</p>
+      <ul>
+      <li>what I worked on or produced yesterday</li>
+      <li>what I’m working on today (and help I might need)</li>
+      <li>what’s blocking me (ie stopping me from finishing a user story card)</li>
+      </ul>
+      <p>Ask people to keep it brief and don’t be afraid to remind them of this. If people try to solve issues during the stand-up, stop the conversation and arrange a huddle after the stand-up to discuss in a smaller group.</p>
+      <h2 id="further-reading">Further reading</h2>
+      <ul>
+      <li><a href="https://gds.blog.gov.uk/2012/10/26/what-weve-learnt-about-scaling-agile/">What we've learnt about scaling agile</a></li>
+      <li><a href="https://gds.blog.gov.uk/2012/12/12/a-day-in-the-life-of-a-delivery-manager/">A day in the life of a delivery manager</a></li>
+      <li><a href="http://guide.agilealliance.org/guide/daily.html">Daily meeting from the Agile Alliance</a></li>
+      <li><a href="http://martinfowler.com/articles/itsNotJustStandingUp.html">It's Not Just Standing Up: Patterns for Daily Standup Meetings</a></li>
+      <li><a href="https://en.wikipedia.org/wiki/Stand-up_meeting">Wikipedia: Stand-up meeting</a></li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 6adf9af0-7897-466b-a1ba-589488ecc1fe
+  :title: User stories
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:53+00:00'
+  :public_updated_at: '2015-11-04T12:08:53+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/agile-delivery/user-stories"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/agile-delivery/user-stories"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <p class="lede">
+        The agile way to plan, organise and prioritise your work, and be clear about what your goals are.
+      </p> -->
+      <h2 id="what-user-stories-are">What user stories are</h2>
+      <p>User stories are a way of organising your work into manageable chunks that create tangible value, and can be discussed and prioritised independently.</p>
+      <p>A user story briefly explains:</p>
+      <ul>
+      <li>the person using the service (actor)</li>
+      <li>what the user needs the service for (narrative)</li>
+      <li>why the user needs it (goal)</li>
+      </ul>
+      <h2 id="why-write-user-stories-">Why write user stories?</h2>
+      <p>User stories are an essential part of the agile toolkit. The story card is a placeholder, a promise to have a conversation when the time is right. You use the story card and some brief initial conversations to estimate the amount of time a story needs to be completed and then put it into an agile backlog.</p>
+      <p>When work actually starts, you consult the users or user representative to fill out the story details. A user story is the sum of all of these conversations, sketches and whiteboard diagrams – not just the card. You don’t need to write down or archive your conversations.</p>
+      <p>Using user stories in this way allows you to avoid ‘analysis paralysis’, the painful condition of trying to guess the details of some far-future goal.</p>
+      <h2 id="who-should-write-user-stories">Who should write user stories</h2>
+      <p>User stories can be added to a product backlog at any point in the sprint cycle by any person in the team. It’s up to the product owner to coordinate and prioritise them, and to select stories for each sprint at the start of each sprint cycle.</p>
+      <h2 id="how-to-write-user-stories">How to write user stories</h2>
+      <p>When writing a user story, make sure the story is well-formed. Don’t skip the part explaining why there’s a need for a service just because it can be difficult.</p>
+      <p>If stories are too big then split them into smaller stories.</p>
+      <h3 id="structure">Structure</h3>
+      <p>Story cards follow a standard structure:</p>
+      <ul>
+      <li>title</li>
+      <li>actor</li>
+      <li>narrative</li>
+      <li>goal</li>
+      </ul>
+      <p>They don’t capture every detail, but you should have a more in-depth discussion about a user story at the appropriate time.</p>
+      <p>Actor:    As a    journalist<br>
+      Narrative:  I want to see contact information for the news article I’m reading<br>
+      Goal:   So that   I can get directly in touch with the press office about it</p>
+      <p>You might want to include a list of acceptance criteria. These should be a reminder for things to test or check which may have come up during conversation, but they should not be used as a way of defining the scope of a story.</p>
+      <h3 id="actor">Actor</h3>
+      <p>Being specific about the actor will help you to break down interactions into logical chunks.</p>
+      <p>Sometimes the actor will be a user of your service, or the actor will be an administrator, technician or manager in your organisation.</p>
+      <p>Make sure you already have a good understanding of your users from your initial project work or existing research. If not, take the time to develop that understanding.</p>
+      <h3 id="narrative">Narrative</h3>
+      <p>Use this as a reminder of the main interaction that needs to be addressed as part of the user experience. Remember that the story card does not need to spell out every detail.</p>
+      <h3 id="goal">Goal</h3>
+      <p>Use this to help you decide whether the story is “done” or delivered, ie does the work meet the goal of the user?</p>
+      <p>When writing stories with your development team, always start by thinking about and discussing your users’ goals:</p>
+      <ol class="list-bullet">
+        <li>why do they want to use your service?</li>
+        <li>what are they trying to achieve?</li>
+        <li>what need has motivated them to seek out your service?</li>
+        <li>in what context do they use it – at home/work/on a mobile phone/whilst caring for a child?</li>
+        <li>how often do they use it?</li>
+      </ol>
+
+      <p>Suzanne and James Robertson have excellent advice on this in the book Mastering the Requirements Process (3rd edition).</p>
+      <h3 id="acceptance-criteria">Acceptance criteria</h3>
+      <p>Acceptance criteria can be used to determine when a story is done.</p>
+      <p>Only include these on the back of the story card if the team finds them useful for recording user assumptions they might later forget. Sometimes writing acceptance criteria on the story card is useful where the user or user representative is not immediately available but is no substitute at all for face-to-face conversation.</p>
+      <h3 id="user-story-cards">User story cards</h3>
+      <p>A user story is represented through a story card that has a title and a few lines of text.</p>
+      <p>Your story cards can be virtual, as well as actual cards. On a large product or service keep your stories in a digital format, and then turn them into physical cards as part of sprint planning.</p>
+      <h2 id="how-to-get-user-stories">How to get user stories</h2>
+      <p>Stories can come from many places, but the most common sources include:</p>
+      <ul>
+      <li>Story writing workshops – more commonly at the start of a project, the development team and stakeholders will get together to write stories</li>
+      <li>user interviews with real users – ideally, you will set up a user panel which the development team have ongoing access to</li>
+      <li>user representatives embedded within your team – this may include the service manager or product owner</li>
+      <li>observation – watch real users using your service</li>
+      </ul>
+      <h2 id="further-reading">Further reading</h2>
+      <ul>
+      <li>Mastering the Requirements Process, 3rd Ed, Suzanne Robertson &amp; James Robertson, 2012</li>
+      <li><a href="http://agilemanifesto.org/principles.html">Twelve Principles of the Agile Manifesto</a></li>
+      <li>User Stories Applied, Mike Cohn, 2004. <a href="http://www.mountaingoatsoftware.com/books/user-stories-applied">Free chapter on Writing User Stories</a>
+      </li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 899cae02-1648-4e1b-b5cb-61da8263130a
+  :title: Assurance for services
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:54+00:00'
+  :public_updated_at: '2015-11-04T12:08:54+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/agile-delivery/assurance-services"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/agile-delivery/assurance-services"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <h2 id="what-assurance-is">What assurance is</h2>
+      <p>Assurance is a range of activities and processes put in place to make sure services meet user needs and organisational goals. It’s important because it helps successful delivery of services by improving people’s understanding of progress, helping them make informed decisions about the work being done.</p>
+      <p>Assurance is an ongoing process that helps maintain quality through the life of a service.</p>
+      <h2 id="who-s-involved-in-assurance">Who’s involved in assurance</h2>
+      <p>Everyone working on a service has responsibility for assurance. It’s built in to agile ways of working with regular checkpoints and opportunities for feedback that help keep governance and delivery work on track. This self assurance gives teams the opportunity to:</p>
+      <ul>
+      <li>review each others’ work</li>
+      <li>challenge and refine ways of working through transparent communications</li>
+      <li>reflect on how the service could be improved in the light of feedback</li>
+      </ul>
+      <p>This way of working helps assure the quality of the services being delivered and provides reassurance to those responsible for governance, helping to build trust.</p>
+      <h3 id="external-assurance">External assurance</h3>
+      <p>Sometimes, services benefit from an independent view provided by someone not directly involved in day-to-day delivery. This provides extra confidence that everyone is seeing a clear picture of progress. It can also be useful where there are multiple teams with interdependencies or higher levels of investment, complexity and risk associated with the service.</p>
+      <p>External assurance could be done by:</p>
+      <ul>
+      <li>departmental assurance teams</li>
+      <li>specialist reviewers, eg technical, legal, content, design</li>
+      <li>the Major Projects Authority — mandatory for certain projects</li>
+      <li>the Government Digital Service (GDS) — via Digital by Default Service Standard * assessments (mandatory for services with more than 100,000 transactions per year)</li>
+      </ul>
+      <h2 id="how-assurance-is-done">How assurance is done</h2>
+      <p>Assurance should be done in line with the governance principles for digital services:</p>
+      <ul>
+      <li>don’t slow down delivery — assurers need to work at the same pace as delivery teams, using the data teams are already producing to manage delivery</li>
+      <li>decisions when they’re needed, at the right level — assurers should have the authority to make decisions and provide recommendations to solve problems before they affect delivery</li>
+      <li>do it with the right people — assurers need recognised skills and experience in what they’re assuring so they can be effective and credible</li>
+      <li>go see for yourself — face-to-face communication with delivery teams and people who govern is the most effective way of assuring</li>
+      <li>only do it if it adds value — assurance should be focused where it can add the most value and this will be different for each service</li>
+      <li>trust and verify — mutual trust between assurers and those they assure is vital</li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: e14067c4-088b-4cf8-9530-ff6d78e6998e
+  :title: Funding a service
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:54+00:00'
+  :public_updated_at: '2015-11-04T12:08:54+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/agile-delivery/funding-a-service"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/agile-delivery/funding-a-service"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <p>There are 5 phases of service delivery — discovery, alpha, beta, live and retirement. You’ll need to get approval at different phases when you build your service.</p>
+      <h2 id="discovery-and-alpha">Discovery and alpha</h2>
+      <p>Discovery is right at the start of your project — where you research user needs, find out about any policy or technological constraints and get a picture of what your first prototypes will explore.</p>
+      <p>During the alpha phase, you start building and testing those prototypes.</p>
+      <p>To start discovery, you need approval for discovery and alpha. This means:</p>
+      <ul>
+      <li>investment approval from your department</li>
+      <li>Cabinet Office spend control approval to spend on external resources, eg on suppliers</li>
+      </ul>
+      <p>You don’t normally need a detailed business case for discovery and alpha because they inform the development of the bigger investment case for beta and live.</p>
+      <p>As a guide, discovery and alpha together shouldn’t cost over £750,000. If you plan to go above this, you should question whether you’ve sized the discovery and alpha correctly — if you do exceed this figure you’ll need a detailed business case.</p>
+      <h2 id="beta-and-live">Beta and live</h2>
+      <p>The beta phase is where you build a fully working prototype that you’ll test in public. The live phase is when your public beta has been tested and is ready to release.</p>
+      <p>To go to beta you’ll need approval for beta and live. This means:</p>
+      <ul>
+      <li>investment approval from your department</li>
+      <li>Cabinet Office spend control approval to spend on external resources, eg on suppliers</li>
+      <li>any other approvals specific to your service eg headcount or salary/grade changes</li>
+      </ul>
+      <p>You need to submit a business case to HM Treasury (HM Treasury published guidance) if any of following apply:</p>
+      <ul>
+      <li>your anticipated total spend on the entire programme (including non-digital aspects) is higher than your organisation’s delegated authority as set by HM Treasury</li>
+      <li>your digital spend is above £10 million</li>
+      </ul>
+      <p>If you need to approach HM Treasury and your digital spend is below £10 million, just include it concisely within your programme business case rather than writing a separate business case for it.</p>
+      <h2 id="managing-business-cases-for-digital-services">Managing business cases for digital services</h2>
+      <p>HM Treasury has introduced the ‘programme business case’, where detail can be added by phase. This is because agile delivery:</p>
+      <ul>
+      <li>typically enables smaller, more frequent funding approvals</li>
+      <li>may form part of a larger programme of transformational change</li>
+      </ul>
+      <p>The programme business case can be used for projects or programmes that have agile delivery elements. It replaces the traditional approval process (strategic outline case followed by outline business case and full business case).</p>
+      <p>However, these still apply for large investment decisions involving lengthy public sector OJEU (Official Journal of the European Union) procurement processes.</p>
+      <p>There’s more information about this in the <a href="https://www.gov.uk/government/publications/the-green-book-appraisal-and-evaluation-in-central-governent/agile-systems-projects-a-clarification-of-business-case-guidance">HM Treasury clarification on business cases for agile</a>.</p>
+      <h2 id="get-involved">Get involved</h2>
+      <p>To give feedback, make a suggestion or share your experience, use the <a href="https://gds-governance-guidance.hackpad.com/Funding-your-digital-service-zuSsD3LefFv">governance guidance hackpad</a>.</p>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 66e30ed2-f1a4-4cdc-b8ae-8add35e245aa
+  :title: Reporting on a service
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:54+00:00'
+  :public_updated_at: '2015-11-04T12:08:54+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/agile-delivery/reporting-on-a-service"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/agile-delivery/reporting-on-a-service"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <h2 id="when-to-set-up-reporting">When to set up reporting</h2>
+      <p>Set up reporting in the early phases of service delivery. Work with your service team to experiment and learn to see what works and what doesn’t just as you’d experiment and learn about the service during these early phases.</p>
+      <h2 id="how-much-reporting-to-do">How much reporting to do</h2>
+      <p>It’s best to start by erring on the side of too little reporting rather than too much – you’ll quickly find out what you’re missing.</p>
+      <p>Service teams should work with you to understand what reporting you need. Make sure any reporting is really necessary and don’t impose too many requirements. If you do, it will be counter-productive because it means less time spent on delivery work. This is especially important as you transition between one phase and another – you don’t want the team to lose momentum.</p>
+      <h2 id="reporting-methods">Reporting methods</h2>
+      <p>Teams should set up reporting in a way that won’t cause any extra work.  This includes:</p>
+      <ul>
+      <li>visual management – teams should use their walls to capture everything they need for delivery</li>
+      <li>face to face meetings, like the stand-up and show and tell</li>
+      </ul>
+      <p>This reporting should provide all the information that’s needed for good governance.</p>
+      <h3 id="example-gov-uk">Example: GOV.UK</h3>
+      <p>The GOV.UK team uses the data on its team wall to create a report for people who cannot visit the wall</p>
+      <p>Everyone should feel comfortable and welcome to view a team wall at any point. This will support a culture of transparency in your organisation and make sure any problems can be discussed and solved openly.</p>
+      <h2 id="consistency-in-reporting">Consistency in reporting</h2>
+      <p>Delivery teams need flexibility in how they work in order to be effective, but you might be working with a number of services, and some consistency in how delivery teams provide information can help you govern well.</p>
+      <p>Teams should:</p>
+      <ul>
+      <li>use their walls to manage their day-to-day work</li>
+      <li>maintain a backlog and use a wall to track how it’s changing over time</li>
+      <li>track progress against goals and key performance indicators (KPIs)</li>
+      <li>hold regular show and tell meetings</li>
+      </ul>
+      <p>Some consistency in reporting means you can more effectively:</p>
+      <ul>
+      <li>see progress</li>
+      <li>support delivery teams</li>
+      <li>make informed decisions</li>
+      <li>communicate with the rest of your organisation (and the public) about the service</li>
+      </ul>
+      <p>Don’t try and force more consistency than this because the circumstances of each team will be so different.</p>
+      <h2 id="giving-feedback">Giving feedback</h2>
+      <p>You should provide timely, constructive feedback to delivery teams on what they need – this helps them to improve their reporting. Good reporting from teams will help you make decisions and give feedback when it’s needed.</p>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 0f9899fb-1802-4073-a830-43eaf8e44f9f
+  :title: Find training on agile
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:54+00:00'
+  :public_updated_at: '2015-11-04T12:08:54+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/agile-delivery/agile-training-and-support"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/agile-delivery/agile-training-and-support"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <h2 id="agile-training">Agile training</h2>
+      <p>When taking part in any training course, it’s important to remember that there are many different approaches to applying agile delivery management.</p>
+      <p>It’s worthwhile to learn a number of tools and techniques and strengthen your understanding with self-initiated learning and doing.</p>
+      <h2 id="book-an-agile-training-course">Book an agile training course</h2>
+      <p>If you are a civil servant find and book your course through Civil Service Learning.</p>
+      <h2 id="delivery-managers-and-scrum-master-training">Delivery managers and scrum master training</h2>
+      <p>Some options to think about when training are:</p>
+      <ul>
+      <li>specific frameworks and methodologies: Start with lightweight frameworks and methodologies such as Scrum, Kanban and Extreme Programming (others are available)</li>
+      <li>more specific practices such as: agile user stories, agile estimating, agile planning, managing teams (more are available)</li>
+      <li>softer skills such as workshop facilitation, coaching, motivating teams</li>
+      </ul>
+      <h2 id="training-for-other-team-roles-and-stakeholders">Training for other team roles and stakeholders</h2>
+      <p>If you need to find out more about agile and how it relates to your role, book a course that gives you an introduction and covers its benefits. Make sure that it’s a broad course that covers more than one methodology or framework.</p>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 5a8a1f7f-ad9e-4e6a-aa67-7614eebafd4a
+  :title: Book onto the service manager induction programme
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:54+00:00'
+  :public_updated_at: '2015-11-04T12:08:54+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/agile-delivery/service-manager-induction"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/agile-delivery/service-manager-induction"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <p>##Aim of the course</p>
+      <p>The 4-day induction programme aims to equip service managers with the basic knowledge, network and confidence to take the lead in transforming digital services.</p>
+      <p>##Who should take part</p>
+      <p>This programme is designed specifically for newly appointed service managers.</p>
+      <p>The will complete the programme in cohorts drawn from across government departments and agencies. </p>
+      <p>After completing the induction programme, participants are also expected to join all 3 open programme days.</p>
+      <p>##Location</p>
+      <p>All sessions will run at a central London location.</p>
+      <p>##Costs</p>
+      <p>The programme is funded centrally, but you or your department will need to pay for any accommodation, meals and subsistence expenses, in line with your departmental policies.</p>
+      <p>##What’s covered</p>
+      <p>The induction programme includes the following modules:</p>
+      <p>###Why are we here?</p>
+      <p>Together we’re leading the digital transformation of government, by making services so good people prefer to use them. This introductory session explores:</p>
+      <ul>
+      <li>why we need to change the way government does digital</li>
+      <li>what has happened so far, including the launch of GOV.UK and adoption of the 25 exemplar transformations</li>
+      <li>what this means for agencies and departments in general and for the role of service manager in particular</li>
+      </ul>
+      <p>###Putting users first</p>
+      <p>User-centred processes start with user needs, and so does this induction programme. In this session the group will:</p>
+      <ul>
+      <li>meet some users of government digital services</li>
+      <li>explore different techniques for finding out what users need</li>
+      <li>write some user stories</li>
+      <li>decide what requirements count as user needs</li>
+      </ul>
+      <p>###Digital leadership</p>
+      <p>Which principles of leadership can be brought to bear in the new era of agile digital services? Your group will:</p>
+      <ul>
+      <li>find out how high achieving digital leaders get things done so you can model and demonstrate that behaviour in your department</li>
+      <li>hear war stories from someone who is a leader in the digital field</li>
+      <li>take away tips and practical advice on digital leadership</li>
+      </ul>
+      <p>###Thinking agile</p>
+      <p>Agile marks a fundamental shift from traditional methods of delivery in government. This session will introduce agile thinking and show how it leads to better outcomes. You’ll cover:</p>
+      <ul>
+      <li>agile as a mindset, much wider than a set of tools and techniques</li>
+      <li>the principles in the Agile Manifesto and how they apply to software projects and beyond</li>
+      <li>the agile disciplines that keep teams focused on outcomes and maximise the chances of success</li>
+      </ul>
+      <p>###Meeting the service standard</p>
+      <p>The Digital Service Standard is the benchmark your services must reach in order to be taken live on GOV.UK. You will:</p>
+      <ul>
+      <li>learn about the standard, how it was created and what tools are available to help departments meet it</li>
+      <li>consider how services will be assessed against the standard</li>
+      <li>assess which parts of the standard are most challenging for your own services and department</li>
+      <li>identify development needs to help you and your department to meet the standard</li>
+      </ul>
+      <p>###Building the team</p>
+      <p>As a service manager you need the support of a multidisciplinary team working intensively together through rapid iterations. Your group will:</p>
+      <ul>
+      <li>understand the roles needed in an agile, user-centred service re-design team</li>
+      <li>get to the heart of what job titles and descriptions really mean, so that your department can appoint the right people, and at the right levels
+      consider the team’s tools and working environments</li>
+      <li>identify specific development needs for yourself and your team members</li>
+      </ul>
+      <p>###Technology for digital services</p>
+      <p>You may not be the most technical person on your team, but as service manager you cannot leave all the technology decisions to others. This session will cover:</p>
+      <ul>
+      <li>choosing technology, making it possible to change your mind and avoiding lock-in</li>
+      <li>risk and risk management, and getting the whole team thinking about security</li>
+      <li>questions to ask your development team to help them make the best technology decisions possible</li>
+      </ul>
+      <p>###Make, test and learn</p>
+      <p>It’s time to try out the methods and tools picked up on the programme so far. In this practical exercise your group will:</p>
+      <ul>
+      <li>self-organise to respond to a real-life brief</li>
+      <li>discover user needs, write user stories and prototype solutions to meet them</li>
+      <li>test your solutions with target users and iterate based on what you learn</li>
+      </ul>
+      <p>##Request a place</p>
+      <p>Please email digital.academy@DWP.GSI.GOV.UK to register your interest in future programmes. </p>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 261807d1-29bb-4e51-9c3e-a69baccb4525
+  :title: Book onto the specialist digital foundation day
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:55+00:00'
+  :public_updated_at: '2015-11-04T12:08:55+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/agile-delivery/specialist-digital-foundation-day"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/agile-delivery/specialist-digital-foundation-day"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <p>##Who should take part</p>
+      <p>This one day workshop is a foundation for people who will work on digital services in accordance with the Digital Service Standard. </p>
+      <p>The day is suitable for people who are working on digital services. It is not recommended for newly appointed service managers, who should book to attend the service manager induction programme instead.</p>
+      <p>##What’s covered</p>
+      <p>It covers:</p>
+      <ul>
+      <li>the changing way government does digital</li>
+      <li>how we put users first in everything we do</li>
+      <li>the principles behind agile methodologies</li>
+      <li>how services are assessed before they can go live on GOV.UK</li>
+      </ul>
+      <p>The foundation day is highly participative with group exercises and the chance to discuss good practice from a range of departments and agencies. </p>
+      <p>By the end of the day participants will understand:</p>
+      <ul>
+      <li>why government needs to change</li>
+      <li>what has happened so far including the launch of GOV.UK and adoption of the 25 exemplar transformations</li>
+      <li>what this means for your organisation and your role</li>
+      <li>user needs – what they are, how to identify them, and how to use them to drive service delivery</li>
+      <li>agile as a mindset, its principles and disciplines and how that keeps teams focussed on outcomes</li>
+      <li>the Digital Service Standard – how it was created, what are your department’s gaps, and how can you meet them</li>
+      </ul>
+      <h2 id="the-modules">The modules</h2>
+      <p>The day includes these modules:</p>
+      <p>###Why are we here?</p>
+      <p>Together we’re leading the digital transformation of government, by making services so good people prefer to use them. This introductory session explores:</p>
+      <ul>
+      <li>why we need to change the way government does digital</li>
+      <li>what has happened so far, including the launch of GOV.UK and adoption of the 25 exemplar transformations</li>
+      <li>what this means for agencies and departments in general and for your role in particular</li>
+      </ul>
+      <p>###Putting users first</p>
+      <p>User-centred processes start with user needs. In this session the group will:</p>
+      <ul>
+      <li>meet some users of government digital services</li>
+      <li>explore different techniques for finding out what users need</li>
+      <li>write some user stories</li>
+      <li>decide what requirements count as user needs</li>
+      </ul>
+      <p>###Thinking agile</p>
+      <p>Agile marks a fundamental shift from traditional methods of delivery in government. This session will introduce agile thinking and show how it leads to better outcomes. You’ll cover:</p>
+      <ul>
+      <li>agile as a mindset, much wider than a set of tools and techniques</li>
+      <li>the principles to be found in the Agile Manifesto and how they apply to software projects and beyond</li>
+      <li>the agile disciplines that keep teams focused on outcomes and maximise the chances of success</li>
+      </ul>
+      <p>###Meeting the service standard</p>
+      <p>The Digital Service Standard is the benchmark your services must reach in order to be taken live on GOV.UK. You will:</p>
+      <ul>
+      <li>learn about the standard, how it was created and what tools are available to help departments meet it</li>
+      <li>consider how services will be assessed against the standard</li>
+      <li>assess which parts of the standard are most challenging for your own services and department</li>
+      <li>identify development needs to help you and your department to meet the standard</li>
+      </ul>
+      <p>##Pre-learning requirements</p>
+      <p>As preparation before the day, we ask that participants:</p>
+      <ul>
+      <li>complete a pre-course questionnaire to tell us why you’re coming on the Digital Foundation Day, and how much you already know about digital in government</li>
+      <li>spend 45 minutes to 1 hour looking over the Government Service Design Manual on GOV.UK - important pages to read include user needs, agile and the Digital Service Standard.</li>
+      </ul>
+      <p>##Request a place</p>
+      <p>To request a place on the foundation day, please fill in this <a href="https://civilservicelearning.civilservice.gov.uk/learning-opportunities/digital-foundation-day">Civil Service Learning request form</a>.</p>
+      <p>##Any questions?</p>
+      <p>Contact the GDS Skills team: service-manager-programme@digital.cabinet-office.gov.uk</p>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 0a37bae2-e1e9-4c9a-ba2a-0c01e44fabc4
+  :title: Book onto the open programme
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:55+00:00'
+  :public_updated_at: '2015-11-04T12:08:55+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/agile-delivery/open-programme"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/agile-delivery/open-programme"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <h2 id="aim-of-the-course">Aim of the course</h2>
+      <p>These 3 days contain specialist modules to help you succeed and improve in particular areas of the Digital by Default Service Standard.</p>
+      <h2 id="who-should-take-part">Who should take part</h2>
+      <p>Unless already very familiar with digital in government, participants should complete either the specialist digital foundation day or the service manager induction before taking part in the open programme.</p>
+      <h2 id="location">Location</h2>
+      <p>All sessions will run at a central London location.</p>
+      <h2 id="costs">Costs</h2>
+      <p>The programme is funded centrally, but you or your department will need to pay for any accommodation, meals and subsistence expenses, in line with your departmental policies.</p>
+      <h2 id="module-supporting-people-to-use-your-digital-service">Module: Supporting people to use your digital service</h2>
+      <p>This one day module covers:</p>
+      <ul>
+      <li>digital take-up</li>
+      <li>digital inclusion</li>
+      <li>assisted digital</li>
+      </ul>
+      <p>It focuses on supporting your users to use your digital service. These are all areas required by the Digital  Service Standard.</p>
+      <p>You will:</p>
+      <ul>
+      <li>learn about why it’s important to support people to use your service</li>
+      <li>develop your understanding of why people might not use your digital service and how to overcome barriers</li>
+      <li>walk personas through a user journey, to see where they might need support and what that could look like</li>
+      <li>discuss the requirements of the Digital Service Standard for these areas, covering expectations at each development phase</li>
+      <li>share your experience with other service managers and work together to improve your understanding of effective support for digital services</li>
+      </ul>
+      <h3 id="background">Background</h3>
+      <p>It’s essential to ‘shift’ people away from non-digital channels and increase the take-up of government digital services so more users can benefit from improved government services. Departments and agencies will also come under increasing pressure to deliver the return on the investment in digital services – estimated at between £1.7 and £1.8 billion per year.</p>
+      <p>Digital inclusion helps people become capable of using and benefiting from the internet. This means that most users will be able to use new and redesigned government digital services unaided, but there are some who will need help through assisted digital support.</p>
+      <h2 id="module-design-and-improve-your-digital-service">Module: Design and improve your digital service</h2>
+      <p>This one day module covers:</p>
+      <ul>
+      <li>the GOV.UK Design Principles</li>
+      <li>user research</li>
+      <li>data-driven services</li>
+      </ul>
+      <p>These are all areas required by the Digital Service Standard.</p>
+      <h3 id="design-principles-in-action">Design principles in action</h3>
+      <p>A set of simple but powerful design principles underpin all the work done by GDS to develop the award-winning GOV.UK website. In this session your group will:</p>
+      <ul>
+      <li>discover the 10 design principles and how they were created</li>
+      <li>hear from a product manager who has used them on a project</li>
+      <li>consider how they will be applied to your own services</li>
+      </ul>
+      <h3 id="always-be-testing">Always be testing</h3>
+      <p>Carry out user research in every stage of your project. Do it continuously through each stage – don’t leave it as something that happens at the beginning and end of phases. You will find out how doing user research continuously will:</p>
+      <ul>
+      <li>keep your team concentrating on real user needs</li>
+      <li>help teams design products which are prioritised by user needs</li>
+      <li>help teams iterate products in response to user feedback</li>
+      </ul>
+      <h3 id="data-driven-services">Data-driven services</h3>
+      <p>Using data to inform decision-making is vital to the development of your services. Your group will:</p>
+      <ul>
+      <li>discuss your service’s performance indicators as they currently stand</li>
+      <li>consider what data you currently use to inform your decision-making, and what data you would like to use</li>
+      <li>design your own performance data dashboard to understand your services in a simple, visual way</li>
+      <li>find out about the Performance Platform and how you can use it</li>
+      </ul>
+      <h2 id="module-practice-procurement-and-platforms-for-your-digital-service">Module: Practice, procurement and platforms for your digital service</h2>
+      <p>This one day module will cover:</p>
+      <ul>
+      <li>governance</li>
+      <li>procurement</li>
+      <li>spend control</li>
+      <li>the agile context</li>
+      <li>an overview of the GOV.UK Verify platform.</li>
+      </ul>
+      <p>These are all areas required by the Digital Service Standard.</p>
+      <h3 id="procurement-spend-control-and-governance">Procurement, spend control and governance</h3>
+      <p>Delivering high quality digital services that improve continuously often depends on effective procurement. As a group you will:</p>
+      <ul>
+      <li>consider how to procure tools and systems fit for the purpose of agile, user-centred development</li>
+      <li>discuss the range of options available, and how to determine make or buy decisions</li>
+      <li>hear the latest on the government procurement processes and frameworks available on digital transformations</li>
+      </ul>
+      <h3 id="being-agile">Being agile</h3>
+      <p>GDS delivery managers will lead discussions and exercises around key features of agile, such as:</p>
+      <ul>
+      <li>agile artefacts, themes, epics and user stories</li>
+      <li>sprint planning and the use of walls to make shared priorities visible</li>
+      <li>retrospectives to continually inspect and improve the work teams do together</li>
+      </ul>
+      <h3 id="identity-assured">Identity assured</h3>
+      <p>We need to know that users of digital services are who they say they are. In this session, you will learn how the GOV.UK Verify Programme is:</p>
+      <ul>
+      <li>creating a market so that users can choose from a number of identity providers</li>
+      <li>setting standards for consistently meeting the needs of users, services and departments</li>
+      <li>building and running the hub that connects services to identity providers</li>
+      <li>working with departments and agencies to identify their services’ GOV.UK Verify requirements and plan their transition to using the GOV.UK Verify service</li>
+      </ul>
+      <h2 id="request-a-place">Request a place</h2>
+      <p>The GDS Skills Team will invite all service manager induction and foundation day participants to book their places on the open programme.</p>
+      <p>If you have not completed either of these, but are very familiar with digital in government and wish to book straight onto the open programme, contact the Skills Team for an invitation: service-manager-programme@digital.cabinet-office.gov.uk</p>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 2c3dd929-e410-480f-a14a-e172c187ab4c
+  :title: 'Digital Service Standard and assessments: an introduction'
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:56+00:00'
+  :public_updated_at: '2015-11-04T12:08:56+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/service-phases-and-assessments/an-introduction"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/service-phases-and-assessments/an-introduction"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <h2 id="what-the-digital-service-standard-is">What the Digital Service Standard is</h2>
+      <p>The Digital Service Standard is a set of 18 criteria to help government create and run digital services. All public facing transactional services must meet the standard and it’s used by departments and GDS to check whether a service is good enough for public use.</p>
+      <h2 id="why-government-has-a-service-standard">Why government has a service standard</h2>
+      <p>The standard helps people understand how to build a good service. It’s also used to measure the quality of government services at each stage of development (alpha, beta, live) as part of service assessments.</p>
+      <p>Progress against the standard is also monitored for a service to access funding in the Cabinet Office’s spend control process. Well-designed services have a better chance of accessing funding, which helps ensure cost-effective use of public money.</p>
+      <h2 id="benefits-of-having-service-assessments">Benefits of having service assessments</h2>
+      <p>An assessment is an opportunity to get feedback from a panel of experts. Having feedback throughout a service’s development unblocks problems and reduces the risk of projects going off track. Assessments also:</p>
+      <ul>
+      <li>ensure all services meet the same high standard</li>
+      <li>provide a regular checkpoint for meeting the standard</li>
+      <li>protect the quality of GOV.UK</li>
+      <li>allow teams to share knowledge</li>
+      <li>give services a chance to promote the work they’ve done</li>
+      </ul>
+      <p>All the assessment reports are published on the <a href="https://gdsdata.blog.gov.uk/all-service-assessments-and-self-certification">GDS data blog</a>. Not only does this make the process open and transparent, it also helps other services better understand the assessment process and its requirements.</p>
+      <p>We’ve also published a dashboard on the <a href="https://www.gov.uk/performance/digital-by-default-service-assessments">Performance Platform</a> to show trends in assessments.</p>
+      <h2 id="related-guidance">Related guidance</h2>
+      <ul>
+      <li><a href="/service-phases-and-assessments/check-if-you-need-a-service-assessment/">Check if you need a service assessment</a></li>
+      <li><a href="/service-phases-and-assessments/arrange-a-service-assessment/">Arrange a service assessment</a></li>
+      <li>
+      <a href="/service-phases-and-assessments/how-services-are-assessed/">How services are assessed</a> against the Digital Service Standard</li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 1c3f9fa3-3a19-4cc7-b9e6-648cf4fb9adb
+  :title: Check if you need a service assessment
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:56+00:00'
+  :public_updated_at: '2015-11-04T12:08:56+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/service-phases-and-assessments/check-if-you-need-a-service-assessment"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/service-phases-and-assessments/check-if-you-need-a-service-assessment"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <p>To find out if your service needs an assessment you need to check:</p>
+      <p>Does it need to be assessed against the digital service standard?
+      If yes, what type of assessment?</p>
+      <h2 id="find-out-if-you-need-an-assessment">Find out if you need an assessment</h2>
+      <p>Your service will need to meet the service standard and have assessments if it meets the following criteria:</p>
+      <ol>
+      <li>It’s a transactional service that’s completely new or being redesigned</li>
+      <li>It’s the responsibility of a central government department, agency or non-departmental public body</li>
+      </ol>
+      <p>If you service meets these criteria the service must achieve the standard. It will need to be assessed at 3 stages of development (alpha, beta, live) before it can go live on GOV.UK without the beta banner.</p>
+      <p>If your service doesn’t meet these criteria it doesn’t have to meet the standard and be assessed. But where possible you should still follow the standard as best practice.</p>
+      <h3 id="definition-of-a-transactional-service">Definition of a transactional service</h3>
+      <p>A transactional service involves an exchange of money, information, permission, goods or services. It will usually be one of the following:</p>
+      <ul>
+      <li>request - for example the service <a href="https://www.gov.uk/prison-visits">Visit someone in prison</a>
+      </li>
+      <li>claim - <a href="https://www.gov.uk/carers-allowance/how-to-claim">Carer’s Allowance</a>
+      </li>
+      <li>appeal -</li>
+      <li>change of circumstances - <a href="https://www.gov.uk/sold-bought-vehicle">Tell DVLA you’ve sold or bought a vehicle</a>
+      </li>
+      <li>application - <a href="https://www.gov.uk/apply-online-for-student-finance">Apply online for student finance</a>
+      </li>
+      <li>order -</li>
+      <li>registration - <a href="https://www.gov.uk/register-to-vote">Register to vote</a>
+      </li>
+      <li>payment - <a href="https://www.gov.uk/renew-patent">Renew a patent</a>
+      </li>
+      </ul>
+      <p>The outcome of these transactions is recorded and changes the information government holds.</p>
+      <p>Transactional services may also give users access to private data (using identity checks), even where records are not changed. For example to check account details like <a href="https://www.gov.uk/view-driving-licence">View or share your driving licence information</a> or the progress of an application.</p>
+      <h2 id="find-out-what-type-of-assessment-you-need">Find out what type of assessment you need</h2>
+      <p>The type of assessment your service will have depends on:</p>
+      <ul>
+      <li>how many transactions it has (or will have)</li>
+      <li>whether it’s external (public facing) or internal (for civil  and crown servants)</li>
+      </ul>
+      <p>Depending on the amount of transactions and who your users are you will either be assessed by a panel at:</p>
+      <ul>
+      <li>the Government Digital Service (GDS)</li>
+      <li>your own department</li>
+      </ul>
+      <h2 id="external-services">External services</h2>
+      <p>The service standard applies to all public facing transactional services.</p>
+      <p>Use this table to work out which type of assessment your service should have:</p>
+      <table>
+      <thead>
+      <tr>
+      <th>Type of service</th>
+      <th>Type of assessment</th>
+      <th></th>
+      <th></th>
+      <th></th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+      <td>External services with over 100,000 transactions a year</td>
+      <td>GDS runs assessments</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      </tr>
+      <tr>
+      <td>External services with under 100,000 transactions a year</td>
+      <td>Department runs assessments</td>
+      <td></td>
+      <td></td>
+      </tr>
+      </tbody>
+      </table>
+      <h2 id="internal-services">Internal services</h2>
+      <p>We’re currently testing assessments for internal digital services used by civil servants.</p>
+      <p>During this time you should assess services against the standard and aim to meet it. However, services will be allowed to carry on provided they:</p>
+      <ul>
+      <li>are safe and secure</li>
+      <li>meet a user need</li>
+      <li>can be easily iterated</li>
+      </ul>
+      <p>Use this table to work out which type of assessment your service should have:</p>
+      <table>
+      <thead>
+      <tr>
+      <th>Type of service</th>
+      <th>Type of assessment</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+      <td>Internal departmental services for one department</td>
+      <td>Departments run assessments and their digital leader signs it off</td>
+      </tr>
+      <tr>
+      <td>Cross-government websites for all civil servants (eg Civil Service Learning)</td>
+      <td>GDS runs assessments</td>
+      </tr>
+      <tr>
+      <td>Internal services for more than one department and with over 100,000 transactions a year</td>
+      <td>GDS runs assessments</td>
+      </tr>
+      <tr>
+      <td>Internal services for more than one department and with under 100,000 transactions a year</td>
+      <td>Department leading on development runs assessment and their digital leader signs it off</td>
+      </tr>
+      </tbody>
+      </table>
+      <h2 id="when-you-need-an-assessment">When you need an assessment</h2>
+      <p>Your service should be assessed at 3 stages:</p>
+      <ul>
+      <li>alpha</li>
+      <li>beta</li>
+      <li>live</li>
+      </ul>
+      <h3 id="alpha-assessment">Alpha assessment</h3>
+      <p>You should be ready for your alpha assessment when you have:</p>
+      <ul>
+      <li>built a working prototype that gives you a clear idea what you will need to build in beta</li>
+      <li>achieved all of the outcomes (and can provide evidence) for the alpha phase</li>
+      </ul>
+      <h3 id="beta-assessment">Beta assessment</h3>
+      <p>You should be ready for your beta assessment when you have:</p>
+      <ul>
+      <li>an end-to-end prototype of your service that is ready to go on GOV.UK (privately or publically) to test with real users</li>
+      <li>all the evidence you’ll be asked to show in your beta assessment</li>
+      </ul>
+      <h3 id="live-assessment">Live assessment</h3>
+      <p>You should be ready for your live assessment when you have:</p>
+      <ul>
+      <li>a working service that can be used for real by the public and replace or integrate with any existing services</li>
+      <li>achieved all of the outcomes (and can provide evidence) for the beta phase</li>
+      </ul>
+      <p>Read more about [why assessments are important] and [how services are assessed against the service standard].</p>
+      <p>Find out <a href="/service-phases-and-assessments/arrange-a-service-assessment/">how to arrange an assessment</a>.</p>
+      <h2 id="voluntary-assessments">Voluntary assessments</h2>
+      <p>If your service is not obliged to meet the standard but you still want to have an assessment, contact:</p>
+      <ul>
+      <li>GDS, by emailing gdsapprovals@digital.cabinet-office.gov.uk, if it will have over 100,000 transactions</li>
+      <li>your digital leader if it will have under 100,000 transactions</li>
+      </ul>
+      <h2 id="related-guidance">Related guidance</h2>
+      <ul>
+      <li><a href="/service-phases-and-assessments/an-introduction/">Digital service standard and assessments: an introduction</a></li>
+      <li><a href="/service-phases-and-assessments/arrange-a-service-assessment/">Arrange a service assessment</a></li>
+      <li>
+      <a href="/service-phases-and-assessments/how-services-are-assessed/">How services are assessed</a> against the Digital Service Standard</li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 89838854-ee86-4018-9802-f59dd2166d23
+  :title: Arrange a service assessment
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:57+00:00'
+  :public_updated_at: '2015-11-04T12:08:57+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/service-phases-and-assessments/arrange-a-service-assessment"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/service-phases-and-assessments/arrange-a-service-assessment"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <p>Depending on the size and type of your service you’ll have your assessment either with the Government Digital Service (GDS) or within your department.</p>
+      <p>If you’re not sure which applies to you, <a href="/service-phases-and-assessments/check-if-you-need-a-service-assessment">check if you need an assessment</a>.</p>
+      <h2 id="arrange-an-assessment-with-gds">Arrange an assessment with GDS</h2>
+      <p>To arrange an assessment with GDS email <a href="mailto:gdsapprovals@digital.cabinet-office.gov.uk">gdsapprovals@digital.cabinet-office.gov.uk</a> 4 weeks before you want one.</p>
+      <p>GDS will agree a date and time for the assessment with you. The assessment will take place at <a href="">Aviation House, London</a>.</p>
+      <h2 id="arrange-an-assessment-within-your-department">Arrange an assessment within your department</h2>
+      <p>You should contact your department’s digital leader and assessments lead. They will agree an assessment date and location with you.</p>
+      <p>Assessments within departments are known as self certification assessments.</p>
+      <h2 id="information-you-need-to-provide">Information you need to provide</h2>
+      <p>The assessment team will contact you to ask for some information about your service before your assessment. This will include:</p>
+      <ul>
+      <li>a brief description of the service and its intended users</li>
+      <li>a link to the most recent prototype or development environment for the service</li>
+      <li>a high level technical architecture diagram</li>
+      </ul>
+      <h2 id="who-should-attend-an-assessment">Who should attend an assessment</h2>
+      <p>The service manager must attend, and bring other team members along to represent different aspects of the service and help answer questions.</p>
+      <p>Often they will be a technical architect, a designer, a user researcher or a delivery manager, but that’s up to you.</p>
+      <h2 id="preparing-for-an-assessment">Preparing for an assessment</h2>
+      <p>You will be assessed against the <a href="/service-standard/">digital service standard</a>.</p>
+      <p>You can read the prompts and evidence the panel uses to assess each point of the standard to check you are ready for the assessment.</p>
+      <p><a href="/service-phases-and-assessments/how-services-are-assessed/">Read more about how services are assessed against the service standard</a>.</p>
+      <h2 id="related-guidance">Related guidance</h2>
+      <ul>
+      <li><a href="/service-phases-and-assessments/check-if-you-need-a-service-assessment/">Check if you need a service assessment</a></li>
+      <li>
+      <a href="/service-phases-and-assessments/how-services-are-assessed/">How services are assessed</a> against the Digital Service Standard</li>
+      <li><a href="/service-phases-and-assessments/an-introduction/">Digital service standard and assessments: an introduction</a></li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 60d2f9d5-b25c-4f71-9624-4ec13c3ddf98
+  :title: How services are assessed against the Service Standard
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:57+00:00'
+  :public_updated_at: '2015-11-04T12:08:57+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/service-phases-and-assessments/how-services-are-assessed"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/service-phases-and-assessments/how-services-are-assessed"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <h2 id="what-happens-at-a-government-digital-service-gds-assessment">What happens at a Government Digital Service (GDS) assessment</h2>
+      <p>Services that process (or are likely to process) over 100,000 transactions a year need to be assessed throughout their development by a panel from GDS. There are assessments at the alpha, beta and live stages of development.</p>
+      <p>At an assessment you need to give a brief overview of the service, including a live demonstration. GDS will provide video screens and cables. Your service team must then answer questions from the panel, demonstrating how the service meets the service standard.</p>
+      <p>The questions are based on the service standard prompts and evidence that the panel uses to assess each point of the standard.</p>
+      <h2 id="gds-assessment-results">GDS assessment results</h2>
+      <p>You should get your assessment result within 3 working days. This will be sent in an email to you and the responsible department’s digital leader.</p>
+      <p>There are 2 possible outcomes: pass and not passed.</p>
+      <p>You’ll have an opportunity to fact check the report before it’s published on the <a href="https://gdsdata.blog.gov.uk/all-service-assessments-and-self-certification/">GDS Data blog</a>.</p>
+      <h3 id="your-service-has-passed-what-next">Your service has passed: what next</h3>
+      <p>When a service passes a beta assessment, you’ll be able to launch it publicly with beta branding on GOV.UK.</p>
+      <p>When it passes a live assessment, you can remove this beta branding, along with any warnings on the GOV.UK start page.</p>
+      <h3 id="your-service-hasn-t-passed-what-next">Your service hasn’t passed: what next</h3>
+      <p>After an assessment the panel will give feedback and recommendations on how to meet the standard. The service will need to be reassessed against the points it hasn't passed.</p>
+      <p>If a GDS assessment panel doesn’t pass a beta service, it won’t appear on or be linked from GOV.UK.</p>
+      <h3 id="spend-controls-and-funding">Spend controls and funding</h3>
+      <p>The Cabinet Office assesses how a service is meeting the standard as part of its spend control process. It won’t approve further spending if there isn’t enough evidence that work is in line with the standard. If the Cabinet Office does reject your business case, GDS will explain what evidence your service team must give to get further funding.</p>
+      <h3 id="reassessment-after-not-passing">Reassessment after not passing</h3>
+      <p>Depending on the circumstances, GDS may invite your team back to either a full assessment or one just covering the failed criteria. If a service needs only minor changes or a small amount of additional evidence, this can be done through email and video conference.</p>
+      <h2 id="ongoing-performance-assessments-for-live-services">Ongoing performance assessments for live services</h2>
+      <p>Live services must continue to maintain the standard, their performance will be tracked and publicly displayed on the Performance Platform. GDS may use assessments to review services that have drops in performance or user satisfaction.</p>
+      <h2 id="what-happens-at-a-self-certification">What happens at a self certification</h2>
+      <p>Public facing services with fewer than 100,000 transactions must also meet the standard and need to arrange assessments within their department. These should follow the GDS assessment format.</p>
+      <p>Most assessments are run by the department developing the service and their digital leader will certify the standard has been met. A GDS-trained assessor will lead the assessment.</p>
+      <h2 id="self-assessment-results">Self assessment results</h2>
+      <p>The responsible digital leader will consider the recommendations from the lead assessor to certify the service with GDS. The assessment will be filed with GDS and a report will be created.</p>
+      <p>After the beta assessment, a certified service may launch publicly with beta branding on GOV.UK. When the service passes a live assessment, you can remove this beta branding, along with any warnings on the GOV.UK start page.</p>
+      <h2 id="assessments-for-internal-services">Assessments for internal services</h2>
+      <p>We’re currently testing the assessment process for internal digital services used by civil servants. Services should aim to meet the standard, but can still carry on if they:</p>
+      <ul>
+      <li>are safe and secure</li>
+      <li>meet a user need</li>
+      <li>can be easily iterated</li>
+      </ul>
+      <h2 id="training-for-departmental-self-certification-assessors">Training for departmental self-certification assessors</h2>
+      <p>Training is available for people in departments who will be running assessments. Contact the GDS Service Standard Assessment team <a href="mailto:dbd-assessments@digital.cabinet-office.gov.uk">dbd-assessments@digital.cabinet-office.gov.uk</a> if you’d like to take part in one of these sessions.</p>
+      <h2 id="assessment-reports">Assessment reports</h2>
+      <p>Assessment reports are published on the <a href="https://gdsdata.blog.gov.uk/all-service-assessments-and-self-certification/">GDS data blog</a>.</p>
+      <h2 id="related-guidance">Related guidance</h2>
+      <ul>
+      <li><a href="/service-phases-and-assessments/an-introduction/">Digital service standard and assessments: an introduction</a></li>
+      <li><a href="/service-phases-and-assessments/check-if-you-need-a-service-assessment/">Check if you need a service assessment</a></li>
+      <li><a href="/service-phases-and-assessments/arrange-a-service-assessment/">Arrange a service assessment</a></li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 86fd6b62-5d50-433c-a656-cb5f14688926
+  :title: Set up a service team
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:57+00:00'
+  :public_updated_at: '2015-11-04T12:08:57+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/the-team/set-up-a-service-team"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/the-team/set-up-a-service-team"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <h2 id="meeting-the-service-standard">Meeting the service standard</h2>
+      <p>To pass <a href="/service-standard/point-3/">point 3 of the Digital Service Standard</a> you’ll need to talk in your assessment about how your service delivery team is multidisciplinary. Your team must also be led by a suitably skilled and senior service manager with decision-making responsibility.</p>
+      <p>The team must be multidisciplinary because you need a range of skills to successfully build and run a digital service. The governance of your team must free up your service manager to make decisions and not block or slow down service delivery.</p>
+      <h2 id="service-phases">Service phases</h2>
+      <h3 id="discovery-and-alpha">Discovery and alpha</h3>
+      <p>During discovery and alpha you’ll need a small team to carry out user research, try things out and solve the harder potential problems on the project.</p>
+      <h3 id="beta">Beta</h3>
+      <p>You often need to <a href="">increase the size of the team</a> during beta when the team will be making frequent iterations based on regular user testing. Only increase its size (also known as ‘scaling up’) when the team and your backlog say it’s the right thing to do.</p>
+      <h3 id="live">Live</h3>
+      <p>Typically in live you’ll have less work and will look to reduce the size of the team. If you need to make a big change in live you may need more people temporarily.</p>
+      <h2 id="delivery-and-operational-roles">Delivery and operational roles</h2>
+      <p>Most programmes of work are not just about digital. They could include a change to an organisation’s operating model, training, buildings or telephony. It’s sensible then to differentiate between:</p>
+      <ul>
+      <li>the digital delivery team</li>
+      <li>collaborative work with operational areas of the organisation</li>
+      </ul>
+      <h2 id="the-skills-a-delivery-team-needs">The skills a delivery team needs</h2>
+      <p>A digital delivery team must have the skills to:</p>
+      <ul>
+      <li>analyse user needs (including accessibility and assisted digital needs) and turn these into user stories</li>
+      <li>manage the scope and prioritisation of user stories</li>
+      <li>manage and report to stakeholders and manage dependencies on other teams</li>
+      <li>where needed, procure services or solutions from 3rd parties</li>
+      <li>design, build, test and iterate software solutions and deploy and host the software
+      test solutions on real users</li>
+      <li>find solutions for accrediting and handling of data</li>
+      <li>support the live running of the service (monitoring, fixing things when they break, responding to users)</li>
+      </ul>
+      <h2 id="roles-in-a-delivery-team">Roles in a delivery team</h2>
+      <p>All public facing <a href="">transactional services</a> must have a <a href="">service manager</a>. The following should also be in the delivery team or the skills available depending on the size of the service:</p>
+      <ul>
+      <li>a product manager</li>
+      <li>a delivery manager and/or scrum master</li>
+      <li>one or more user researchers</li>
+      <li>one or more content designers</li>
+      <li>one or more designers</li>
+      <li>developer and technical lead</li>
+      </ul>
+      <p>The delivery team will also need an assisted digital lead and an accessibility lead and the support of:</p>
+      <ul>
+      <li>a digital performance analyst</li>
+      <li>technical architect</li>
+      <li>web operations</li>
+      <li>quality assurance and testing</li>
+      </ul>
+      <p>Your team may also need <a href="">agile coaching</a> and <a href="">business analysis</a> skills.</p>
+      <p>Read more about what each role does and how they work together in <a href="">Roles in a service team</a>.</p>
+      <h2 id="operational-support-and-collaboration">Operational support and collaboration</h2>
+      <p>Outside of the delivery team you’ll need the skills of a wide range of people working on the operational side of your department.</p>
+      <p>Your delivery team will be using agile methods, but your organisation may be managing other aspects of its service delivery with a mix of agile and <a href="">waterfall</a> methodologies. You may need to adapt some of your processes and approaches when working with subject experts in:</p>
+      <ul>
+      <li>policy and legal</li>
+      <li>security</li>
+      <li>call centre operations</li>
+      <li>communications</li>
+      <li>procurement</li>
+      <li>recruitment and training</li>
+      </ul>
+      <h2 id="working-with-and-recruiting-third-parties">Working with and recruiting third parties</h2>
+      <p>If you need contractors or other third parties, it’s important to understand <a href="">the procurement process</a> to make sure they join at the right time.</p>
+      <p>You’ll also need to understand <a href="">how to best work with third parties</a>.</p>
+      <h2 id="examples-from-around-government">Examples from around government</h2>
+      <p>Steve Woods talks about getting the right people together for project inception at DWP’s Personal Independence Payments service.</p>
+      <h2 id="related-guidance">Related guidance</h2>
+      <p><a href="">Roles in a service team</a>
+      <a href="">Recruit a service team</a>
+      <a href="">Governing a service team</a>
+      <a href="">Changing the size of a team</a>
+      <a href="">Running more than one team</a>
+      <a href="">Working with external suppliers</a></p>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 62b23226-7ed9-41df-8be3-9420c2c57d22
+  :title: Recruit a service team
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:57+00:00'
+  :public_updated_at: '2015-11-04T12:08:57+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/the-team/recruiting-people-and-skills"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/the-team/recruiting-people-and-skills"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <p class="lede">
+        Plan for having more people and teams, and how they'll work together.
+      </p> -->
+      <p>Building great digital services and supporting technology requires strong leadership and a wide array of technical skills. These are often not yet common across government. It also means rebalancing the skills and priorities of existing senior technology roles.</p>
+      <h2 id="recruitment-hub">Recruitment Hub</h2>
+      <p>GDS is supporting departments on digital and technology recruitment through a Recruitment Hub. This service is designed to help ensure the best possible candidates are in post to deliver excellent digital public services supported by the right technology. The hub will provide recruitment guidance, support and advice to departments for senior and specialist roles.</p>
+      <p>The Recruitment Hub is not intended to replace existing HR and recruitment processes, and exists purely to help organisations acquire these new and hard-to-reach skills.</p>
+      <h3 id="senior-civil-servant-scs-recruitment">Senior Civil Servant (SCS) recruitment</h3>
+      <p>GDS must approve the job descriptions and appointments for all SCS-level technology positions. All senior grades (Deputy Director / Grade 5 level and above) are part of the Senior Civil Service, which is overseen by the Cabinet Office on behalf of the civil service as a whole. Senior civil servants may be called to account by Parliament, and are barred from holding any political office.</p>
+      <p>The template job descriptions, and organisation design advice should be a useful starting point for departments and agencies to tailor to their specific roles.</p>
+      <p>For SCS level hires, the Recruitment Hub could also provide:</p>
+      <ul>
+      <li>feedback, advice and approval on tailored organisational design and SCS job descriptions as needed, to ensure that the lines of reporting and share of responsibilities between other digital and technology (IT) leaders within organisations are clearly set out</li>
+      <li>guidance in coordinating headhunting support for departments looking to identify suitable candidates for senior appointments</li>
+      <li>GDS expertise to work with departments in sifting, shortlisting and interviewing of applicants</li>
+      <li>campaigns need to be planned effectively with sift and interview dates agreed before advertising so that GDS can provide appropriate resources with enough notice.</li>
+      </ul>
+      <p>Departments should continue to liaise with advertisers and Civil Service Commissioners directly.</p>
+      <h3 id="non-scs-specialist-recruitment">Non-SCS specialist recruitment</h3>
+      <p>GDS does not need to approve the appointment of non-SCS specialist posts, but will again provide guidance, support and advice for departments seeking to bring in specialist digital skills. The template job descriptions and organisation design advice should again be a useful starting point for departments and agencies, and is likely to require less tailoring than SCS roles.</p>
+      <p>In addition, the Recruitment Hub could also provide:</p>
+      <ul>
+      <li>feedback and advice on the design and organisation of digital delivery teams within departments</li>
+      <li>guidance on routes to market (frameworks etc)</li>
+      <li>guidance and advice on attraction and recruitment campaign strategies</li>
+      <li>GDS expertise to work with departments in sifting, shortlisting and interviewing of some key Band A / Grade 6 / Grade 7 specialist posts</li>
+      </ul>
+      <p>In specific cases where a position requires a particular specialist set of technical skills (eg technical architects, designers), departments should request sifting or shortlisting support from GDS via the Recruitment Hub. This service should be requested before the post is advertised.</p>
+      <p>We cannot promise to provide this in all cases, but will try to make expert advice available from the shortlisting stage for crucial posts.</p>
+      <p>All queries for the hub should be made to digitaltalent@digital.cabinet-office.gov.uk.</p>
+      <h2 id="job-descriptions">Job descriptions</h2>
+      <p>To get the right skills into government, we need make sure we’re asking the right people to apply.</p>
+      <p>Choose from a set of template job descriptions for senior technology leaders and digital specialists.</p>
+      <p>The templates have left gaps for departments to complete. Recruiters will need to add:</p>
+      <ul>
+      <li>information about the department and its objectives</li>
+      <li>information about the role and current priorities and activities in digital and technology</li>
+      <li>location</li>
+      <li>recruitment process details and contacts</li>
+      <li>information on reporting lines</li>
+      <li>GIS declaration and Immigration Status Forms</li>
+      </ul>
+      <p>Before advertising any SCS technology position, the Recruitment Hub must have reviewed and agreed the job description after it has been tailored to a specific organisation and post. GDS does not need to approve non-SCS job descriptions prior to advertisement, though will provide advice if asked to by departments.</p>
+      <h2 id="templates">Templates</h2>
+      <ul>
+      <li>
+      <a href="https://www.gov.uk/service-manual/the-team/recruitment/Agile-coach.odt">Agile Coach</a> (this is not a permanent role)</li>
+      <li><a href="https://www.gov.uk/service-manual/the-team/recruitment/Businessanalyst-generic.odt">Business analyst</a></li>
+      <li><a href="https://www.gov.uk/service-manual/the-team/recruitment/Contentdesigners-generic.odt">Content designer</a></li>
+      <li><a href="https://www.gov.uk/service-manual/the-team/recruitment/DeliveryManager-generic.odt">Delivery manager</a></li>
+      <li><a href="https://www.gov.uk/service-manual/the-team/recruitment/DesignerJobDescription-generic.odt">Designer</a></li>
+      <li><a href="https://www.gov.uk/service-manual/the-team/recruitment/Developer-generic.odt">Developer</a></li>
+      <li><a href="https://www.gov.uk/service-manual/the-team/recruitment/Digitalperformanceanalyst-generic.odt">Performance analyst</a></li>
+      <li><a href="https://www.gov.uk/service-manual/the-team/recruitment/ProductManager-generic.odt">Product manager</a></li>
+      <li><a href="#">Service manager</a></li>
+      <li><a href="https://www.gov.uk/service-manual/the-team/recruitment/Technicalarchitect-generic.odt">Technical architect</a></li>
+      <li><a href="https://www.gov.uk/service-manual/the-team/recruitment/Userresearcher-generic.odt">User researcher</a></li>
+      <li><a href="https://www.gov.uk/service-manual/the-team/recruitment/WebOps-generic.odt">Web ops</a></li>
+      </ul>
+      <!-- ## Related topics
+      <ol class="tags">
+        <li><a href="/tag/team-recruitment/">team recruitment</a></li>
+        <li><a href="/tag/government-recruitment-rules/">government recruitment rules</a></li>
+        <li><a href="/tag/agile-procurement/">agile procurement</a></li>
+        <li><a href="/tag/job-roles/">job roles</a></li>
+      </ol> -->
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: bde2ed45-898d-4a55-9b26-a38d61be97cf
+  :title: Change the size of a service team
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:57+00:00'
+  :public_updated_at: '2015-11-04T12:08:57+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/the-team/changing-the-size-of-a-service-team"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/the-team/changing-the-size-of-a-service-team"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <p class="lede">
+        You may need to change the size of team during the life of a service as the amount and type of work changes. The process of increasing or decreasing team size is known as ‘scaling’.
+      </p> -->
+      <h3 id="discovery-and-alpha">Discovery and alpha</h3>
+      <p>During discovery and alpha you’ll need a small team to experiment, try stuff out and solve the harder potential problems on the project.</p>
+      <h3 id="beta">Beta</h3>
+      <p>You often need to scale up during beta when the team will be delivering and iterating frequently based on regular user testing.</p>
+      <h3 id="live">Live</h3>
+      <p>Typically in live you’ll have less work and will look to reduce the size of the team. If you need to make a big change in live you may need more people temporarily.</p>
+      <h2 id="when-to-increase-the-size-of-the-team">When to increase the size of the team</h2>
+      <p>You should only recruit more people when you already have a team that’s working well together and delivering consistently. Adding more people, particularly when done quickly, is likely to magnify any problems if the team isn’t working well.</p>
+      <p>Make changes according to service needs. This will mean you increase the team only when you absolutely need to. You may need to scale up if:</p>
+      <ul>
+      <li>there’s too much work for the team</li>
+      <li>your current pace means you won’t meet delivery commitments</li>
+      <li>the team is too big or too far apart to work together effectively</li>
+      </ul>
+      <h3 id="there-s-too-much-work-for-the-team">There’s too much work for the team</h3>
+      <p>This might be the case if:</p>
+      <ul>
+      <li>the backlog isn’t reducing in size despite steady progress</li>
+      <li>you’re finding it difficult to prioritise, plan and manage dependencies between things</li>
+      <li>the team’s delivery manager has too much work</li>
+      </ul>
+      <p>Before scaling up, check that the backlog is as big as you think. For example does everything in it need to be finished by a fixed date?</p>
+      <h3 id="the-current-pace-means-you-won-t-meet-a-delivery-date">The current pace means you won’t meet a delivery date</h3>
+      <p>Delivery teams should track their progress to forecast when they will complete work. If forecasts show that delivery will happen after a deadline, you may be able to scale up to meet your delivery date.</p>
+      <h3 id="the-team-is-too-big-or-too-far-apart-to-work-together-effectively">The team is too big or too far apart to work together effectively</h3>
+      <p>As a team grows, it may become too big to work as effectively as 2 smaller teams would. Teams that are too big  can have a negative impact on the culture and behaviours of people working in the team, so it could be better to split into smaller teams.</p>
+      <p>Your team might be too big if:</p>
+      <ul>
+      <li>the daily stand-up is lasting more than 15 minutes</li>
+      <li>team members’ updates are not relevant to everyone</li>
+      <li>you start to see smaller stand-ups happening organically after the main stand-up so people who are working together can plan better</li>
+      </ul>
+      <p>It might also make sense to split a big team when different features of your service need different balances of skills to develop. Teams working on particular features should remain multidisciplinary. Having smaller teams in this situation simplifies communication.</p>
+      <h2 id="how-to-increase-the-size-of-the-team">How to increase the size of the team</h2>
+      <p><a href="#">You can find out how to recruit a team member in the recruitment section of the service manual</a>.</p>
+      <p>You can scale up by adding people to existing teams or by creating new ones. It’s better to increase the size of existing teams until it becomes impractical. If this happens, consider adding more teams.</p>
+      <p>Add more people to the team gradually when you need them, don’t recruit a full team for beta during discovery. You can build your team as and when the work needs to use new business case arrangements and procurement frameworks.</p>
+      <p>Only add people when you are confident that they are a good cultural fit and have the right skills and experience. Don’t attempt to make do, if you can’t get the right people available to work on the service, adjust your scope or delivery deadlines instead.</p>
+      <p>Adding more people will slow delivery initially. Be prepared for a drop in productivity while new people are brought up to speed and integrated into the team. If you add too many people, it could eventually lead to a permanent slowing down of the team due to communication and coordination overheads.</p>
+      <h3 id="plan-for-increasing-the-team">Plan for increasing the team</h3>
+      <p>It’s important to plan for changes in the team. Planning activities include:</p>
+      <ul>
+      <li>consulting with the delivery team on who should be added when</li>
+      <li>making sure the team can devote time to integrating new people</li>
+      <li>making sure new people will have the tools they need to be productive on the day they arrive</li>
+      </ul>
+      <h3 id="adding-new-teams">Adding new teams</h3>
+      <p>New teams should consist of experienced and new team members to provide continuity in culture, knowledge and expertise.</p>
+      <h2 id="when-to-reduce-the-size-of-the-team">When to reduce the size of the team</h2>
+      <p>When a service moves from beta to live, you’ll have met your user needs and there’s typically less remaining work. You won’t always need the same size of team as you did during peak development. You’ll still need to continuously iterate your service so you’ll need to plan to scale down carefully. You’ll need to:</p>
+      <ul>
+      <li>review the service roadmap, release plans and product backlog with your team</li>
+      <li>consider whether it’s sensible to merge teams</li>
+      <li>give remaining team members time to reorganise their work</li>
+      </ul>
+      <h2 id="examples-from-around-government">Examples from around government</h2>
+      <p>Jack Collier from Ministry of Justice talks about <a href="https://mojdigital.blog.gov.uk/2014/05/28/creating-a-winning-team-at-ds/">splitting the team for the court finder and tribunals decisions services</a>.</p>
+      <p>Read about the Government Digital Service’s experience in <a href="https://gds.blog.gov.uk/2012/10/26/what-weve-learnt-about-scaling-agile/">scaling from a single team of 12 people to 14 teams in 18 months</a>.</p>
+      <h2 id="join-the-discussion">Join the discussion</h2>
+      <p>There are communities of practice across all areas of government service design, including one for service managers and delivery managers. You can also read and contribute to <a href="https://www.blog.gov.uk/">government blogs</a>.
+      &lt;!--</p>
+      <h2 id="what-to-read-next">What to read next</h2>
+      <ul>
+      <li><a href="/the-team/recruiting-people-and-skills/">Recruit a service team</a></li>
+      <li><a href="/the-team/setting-up-a-service-team/">Setting up a service team</a></li>
+      <li>
+      <a href="">Governing more than one team</a> --&gt;</li>
+      </ul>
+      <h2 id="related-topics">Related topics</h2>
+      <ol class="tags">
+        <li><a href="/tag/team-structure/">team structure</a></li>
+        <li><a href="/tag/changing-team-size/">changing team size</a></li>
+        <li><a href="/tag/team-recruitment/">team recruitment</a></li>
+      </ol>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: cd98eebb-98ed-4119-a931-3abd56e2577d
+  :title: Agile coach
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:57+00:00'
+  :public_updated_at: '2015-11-04T12:08:57+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/the-team/agile-coach"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/the-team/agile-coach"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <div class="lede">
+        Agile coaches work at all levels in the organisation and encourage effective working by embedding an agile culture.
+      </div> -->
+      <h2 id="why-you-might-need-an-agile-coach">Why you might need an agile coach</h2>
+      <p>The UK government is transforming the way we deliver digital services which require the need for an agile coach to embed and build capability in agile and lean practices in teams and the foundations to support them across the organisation.</p>
+      <p>Since 2012, departments have moved to a more agile way of working to deliver digital service transformation. Agile coaches will be working directly with government departments and agencies, to help organisations, portfolios, programmes and teams to be as effective as possible by embedding an agile culture.</p>
+      <p>The focus is increasingly on building and maintaining the internal capabilities of departments to effectively govern, deliver and run digital services being built and provide an environment that enables continuous delivery in perpetuity. The input of an agile coach is integral to ensure departments’ agile practices and team capabilities are set up to support this. This extends to providing advice to organisations on to govern delivery in line with the GDS governance for service delivery principles and ongoing improvement of digital services.</p>
+      <p>Agile coaches work in several capacities across transformation programmes to deliver lasting change within departments that focuses on delivering value for citizens.</p>
+      <h2 id="different-areas-an-agile-coach-might-work-in">Different areas an agile coach might work in</h2>
+      <p>Coaches may be required to work :</p>
+      <ul>
+      <li>at the team level, working with teams to ensure that delivery teams within departments are adopting agile and performing effectively</li>
+      <li>at the portfolio or programme level, to help departments to establish the right processes for managing a portfolio of work in an agile way</li>
+      <li>at the organisation level, to drive strategic change across the organisation and ensure that adoption of agile techniques is embedded from the most senior levels of the organisation</li>
+      <li>across all levels to ensure that organisations adopt a pragmatic approach to the way in which they govern delivery and continuous improvement of digital services</li>
+      </ul>
+      <h2 id="what-an-agile-coach-should-do">What an agile coach should do</h2>
+      <p>The main responsibilities of the post are:</p>
+      <ul>
+      <li>embed an agile culture using techniques from a wide range or agile and lean methodologies and frameworks, but be methodology agnostic</li>
+      <li>help to create an open and trust based environment, which enables a focus on delivery and facilitates continuous improvement</li>
+      <li>assess the culture of a team or organisation and delivery processes in place to identify improvements and facilitate these improvements with the right type of support</li>
+      <li>showcase relevant tools and techniques, such as coaching, advising, workshops and mentoring</li>
+      <li>engage with stakeholders at all levels of the organisation</li>
+      <li>develop clear lines of escalation, in agreement with senior managers</li>
+      <li>ensure any stakeholder can easily find out an accurate and current project or programme status, without disruption to delivery</li>
+      <li>work effectively with other suppliers, departments and agencies</li>
+      <li>apply best tools and techniques to: team roles, behaviours, structure and culture, agile ceremonies and practices, knowledge transfer and sharing, programme management, cross team coordination, and overall governance of digital service delivery</li>
+      <li>ensure key metrics and requirements that support the team and delivery are well defined and maintained</li>
+      <li>equip staff with the ability to coach others</li>
+      <li>if organisation level, executive coaching on the fundamental considerations of digital service delivery design</li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: ee461709-05c4-4f61-b4e7-a54c9db028ff
+  :title: Content designer
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:58+00:00'
+  :public_updated_at: '2015-11-04T12:08:58+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/the-team/content-designer"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/the-team/content-designer"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <div class="lede">
+        Content designers make sure that the writing on a website or service meets the needs of the user as clearly, simply and quickly as possible.
+      </div> -->
+      <iframe id="yt0" frameborder="0" allowfullscreen="1" title="YouTube video player" width="100%" height="350px" src="https://www.youtube.com/embed/kUlL1AU_CO0?controls=0&amp;showinfo=0&amp;origin=https%3A%2F%2Fwww.gov.uk&amp;rel=0&amp;enablejsapi=1" role="presentation"></iframe>
+
+      <h2 id="the-importance-of-content-designers">The importance of content designers</h2>
+      <p>You can add up, but it doesn’t mean you’re an accountant. You can write, but it doesn’t mean you’re a content designer.</p>
+
+      <p>For many reasons, in the past the government has often published content that’s difficult to understand and difficult to act on.</p>
+
+      <p>What gets published can be more about what the government wants to say than what the user needs to know.</p>
+
+      <p>At best this results in a frustrated user. At worst, citizens and businesses get into trouble because they can’t understand (or can’t face wading through) difficult content.</p>
+
+      <p>The content designer’s job is to make sure that doesn’t happen.</p>
+
+      <h2 id="skills-and-attributes">Skills and attributes</h2>
+      <p>Content designers must be able to:</p>
+
+      <ul>
+        <li>
+      <a href="/service-manual/user-centred-design">identify user needs</a> – based on:
+          <ul>
+            <li>legacy content</li>
+            <li>source material provided by policy colleagues</li>
+            <li>feedback from users and stakeholders</li>
+            <li>analytics data both from the site and from search engines</li>
+          </ul>
+        </li>
+        <li>gain an in-depth knowledge of a wide range of subjects – so they can make informed decisions about the best way to present information to users</li>
+        <li>develop content plans and strategies – high-level plans showing how the identified user needs will be met</li>
+        <li>
+      <a href="/guidance/content-design/writing-for-gov-uk">write great content</a> – in <a href="/guidance/content-design/writing-for-gov-uk#plain-english">plain English</a>, optimised for the web and according to <a href="/guidance/style-guide/a-to-z-of-gov-uk-style">house style</a>
+      </li>
+        <li>edit content – making sure the site remains accurate, relevant, current and optimised both for users and search engines</li>
+        <li>make tough decisions and work hard for the user – grappling with complicated legislation and turning it into clear, clean, crisp web content (that still has enough depth to be useful)</li>
+        <li>work with developers and designers to <a href="https://gds.blog.gov.uk/2012/11/05/tools-over-content/">create better solutions</a> – for example, writing logic and content for <a href="https://gds.blog.gov.uk/2012/02/16/smart-answers-are-smart/">smart answers</a>
+      </li>
+        <li>understand and incorporate the results of <a href="/service-manual/user-centred-design/user-research">user testing</a>
+      </li>
+        <li>review the work of other editors – to make sure consistency and excellence is maintained across the site</li>
+        <li>publish content – using various systems</li>
+        <li>communicate the <a href="/guidance/content-design/what-is-content-design">principles of good content design</a> to others in the organisation</li>
+        <li>advocate for the user and act as a guardian for the site – pushing back on change requests that don’t contribute to meeting user needs and incorporating change requests that do</li>
+        <li>build positive relationships with others inside the team and in the wider organisation</li>
+        <li>innovate and anticipate – excellent content designers are excited about the possibilities of web content and contributing to the digital sector’s future</li>
+      </ul>
+
+      <h2 id="guidance">Guidance</h2>
+
+      <p>Read <a href="/service-manual/content-designers">guidance in the manual of particular interest to content designers</a>.</p>
+
+      <h2 id="job-description">Job description</h2>
+
+      <p>Click either of the options below to download a template Content designer job description.</p>
+
+      <p><a href="/service-manual/the-team/recruitment/Contentdesigners-generic.odt">Download as OpenDocument Format</a> / <a href="/service-manual/the-team/recruitment/Contentdesigners-generic.docx">Download as MS Word doc</a></p>
+
+      <p>Cabinet Office will help departments to recruit suitably skilled individuals through the <a href="/service-manual/the-team/recruitment/hub">Recruitment Hub</a>.</p>
+
+      <h2 id="related-topics">Related topics</h2>
+      <ol class="tags">
+        <li><a href="/tag/team-structure/">team structure</a></li>
+        <li><a href="/tag/job-roles/">job roles</a></li>
+        <li><a href="/tag/content-designer/">content designer</a></li>
+        <li><a href="/tag/team-recruitment/">team recruitment</a></li>
+      </ol>
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 415ffa6c-734e-4c15-8425-49e1a8b6c63e
+  :title: Delivery manager
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:58+00:00'
+  :public_updated_at: '2015-11-04T12:08:58+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/the-team/delivery-manager"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/the-team/delivery-manager"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <div class="lede">
+        Delivery managers remove obstacles, or blockers to progress, constantly helping the team become more self organising.
+      </div> -->
+      <p></p>
+      <div class="inner">
+            <span><span class="player-container player-wide" style="height: 100%; width: 100%;"><span class="video"><iframe id="yt0" frameborder="0" allowfullscreen="1" title="YouTube video player" width="100%" height="350px" src="https://www.youtube.com/embed/ipHEn97mws4?controls=0&amp;showinfo=0&amp;origin=https%3A%2F%2Fwww.gov.uk&amp;rel=0&amp;enablejsapi=1" role="presentation"></iframe></span><span class="ui-corner-bottom control-bar"></span></span></span>
+      </div>
+      <h2 id="the-importance-of-delivery-managers">The importance of delivery managers</h2>
+
+      <p>Skilled delivery managers remove obstacles, or blockers to progress, constantly helping the team become more self organising. They enable the work a team does rather than impose how it’s done. It’s not about micro managing!</p>
+
+      <p>Equally important in an agile team – and particularly important to the delivery manager – is ongoing effort to improve products, services or processes. Their role in this is to facilitate project meetings- including daily <a href="/service-manual/agile-delivery/features-of-agile.html">stand-ups</a>, <a href="/service-manual/agile-delivery/features-of-agile.html">sprint planning meetings</a>, and <a href="/service-manual/agile-delivery/running-retrospectives.html">retrospectives</a>. They also track progress and produce artefacts for showing this, like burn down/up charts. They must be able to enable the team to produce estimates of how much effort is required to produce features that the <a href="/service-manual/the-team/service-manager.html">Product Manager</a> wants.</p>
+
+      <p><img src="https://www.gov.uk/service-manual/the-team/burn-up.png"></p>
+
+      <p>Equally important in an agile team – and particularly important to the delivery manager – is ongoing effort to improve products, services or processes. Their role in this is to facilitate project meetings- including daily <a href="/agile-delivery/tools-and-methods/stand-up/">stand-ups</a>, <a href="/agile-delivery/tools-and-methods/sprint-planning/">sprint planning meetings</a>, and <a href="/agile-delivery/tools-and-methods/retrospectives/">retrospectives</a>. They also track progress and produce artefacts for showing this, like burn down/up charts. They must be able to enable the team to produce estimates of how much effort is required to produce features that the Product Manager wants.</p>
+
+      <h2 id="skills">Skills</h2>
+
+      <p>Delivery managers need to have:</p>
+
+      <ul>
+        <li>strong estimation and budget scoping skills</li>
+        <li>experience in Agile Project Management methodologies</li>
+        <li>familiarity with structured programme and project management environments</li>
+        <li>experience delivering digital services</li>
+        <li>experience in open source and cloud technologies and their sourcing</li>
+        <li>good communication skills</li>
+      </ul>
+
+      <p>A delivery manager will also need the following skills:</p>
+
+      <ul>
+        <li>strong organisational and communication skills</li>
+        <li>collaborative approach to working</li>
+        <li>good at prioritising time-critical work</li>
+        <li>an understanding of the wider digital landscape</li>
+      </ul>
+
+      <h2 id="related-topics">Related topics</h2>
+      <ol class="tags">
+        <li><a href="/tag/team-structure/">team structure</a></li>
+        <li><a href="/tag/job-roles/">job roles</a></li>
+        <li><a href="/tag/delivery-manager/">delivery manager</a></li>
+        <li><a href="/tag/team-recruitment/">team recruitment</a></li>
+      </ol>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 88bf8754-b3b8-4ed2-b87c-7d922cbaa1db
+  :title: Designer
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:58+00:00'
+  :public_updated_at: '2015-11-04T12:08:58+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/the-team/designer"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/the-team/designer"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <div class="lede">
+        Designers focus on the user interactions, user experience and visual designs of the website or service.
+      </div> -->
+      <p></p>
+      <div class="inner">
+            <span><span class="player-container player-wide" style="height: 100%; width: 100%;"><span class="video"><iframe id="yt0" frameborder="0" allowfullscreen="1" title="YouTube video player" width="100%" height="350px" src="https://www.youtube.com/embed/d_Om02sbn_c?controls=0&amp;showinfo=0&amp;origin=https%3A%2F%2Fwww.gov.uk&amp;rel=0&amp;enablejsapi=1" role="presentation"></iframe></span><span class="ui-corner-bottom control-bar"></span></span></span>
+      </div>
+      <p>Those with the title of designer may have a particular focus on one or more specific design disciplines – interaction, graphic, UX – but a good digital service needs talented, flexible designers to help build user-centred products.</p>
+
+
+      <p>Those with the title of designer may have a particular focus on one or more specific design disciplines – interaction, graphic, UX – but a good digital service needs talented, flexible designers to help build user-centred products.</p>
+
+      <h2 id="how-designers-work">How designers work</h2>
+      <p>Designers, user researchers and front-end developers should work together in one team, designing in-browser. This is a better way of working, avoiding silos and ensuring that decisions are made with complete awareness of the implications.</p>
+
+      <p>As a result, the people you hire should already have worked like this, or at least understand it.</p>
+
+      <p>Depending on the types of project you are tackling you may require a team of designers with a range of different skills. A good first hire for a team tends to be a strong interaction designer, however adding designers with graphic design skills and designers who also have a background in undertaking user research can also give your team additional flexibility and capabilities.</p>
+
+      <p>We strongly believe that design and user experience is the responsibility of the entire team and must be considered from the outset of the project through to and beyond going live. UX includes how fast the servers are, to how the copy is written, to how the layout is implemented in code, and what the structure of the URLs is. It’s worth looking at Frances Berriman’s <a href="http://fberriman.com/2012/06/14/designing-better-user-experiences-txjs-2012/">talk on this</a>.</p>
+
+      <h2 id="how-to-hire-designers">How to hire designers</h2>
+
+      <p>When building a team ask to see examples of work and ask the designers to explain their practical contribution. You should look for the designer to share stories and documentation that demonstrates how they have worked closely with other members of the team including developers, content designers, user researchers and stakeholders in an agile and iterative way.</p>
+
+      <p>When evaluating their design work, it is important that the designer can explain a strong rationale for their design decision making that is based in supporting user needs. This ability to explain their rationale convincingly is more important than their ability to show polished wireframes or designs in their portfolio. Often a lack of polished designs in a portfolio can indicate that a designer is highly collaborative or has strong development skills, so take care not to focus only on polished comps or layouts.</p>
+
+      <p>You should also ask the designer to talk about any significant differences between the design they present in their portfolio and the actual live design. It is important that designers create appropriate work and are able to persuade stakeholders and their team to make good design decisions.</p>
+
+      <p>You should also ask the designer to talk about any significant differences between the design they present in their portfolio and the actual live design. It is important that designers create appropriate work and are able to persuade stakeholders and their team to make good design decisions.</p>
+
+
+      <h2 id="related-topics">Related topics</h2>
+      <ol class="tags">
+        <li><a href="/tag/team-structure/">team structure</a></li>
+        <li><a href="/tag/job-roles/">job roles</a></li>
+        <li><a href="/tag/designer/">designer</a></li>
+        <li><a href="/tag/team-recruitment/">team recruitment</a></li>
+      </ol>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 12b40ea4-4a45-4058-8ddd-8125c23b3059
+  :title: Developer
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:58+00:00'
+  :public_updated_at: '2015-11-04T12:08:58+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/the-team/developer"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/the-team/developer"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <div class="lede">
+        Developers build, deliver and constantly improve the software that underpins every service.
+      </div> -->
+      <p></p>
+      <div class="inner">
+            <span><span class="player-container player-wide" style="height: 100%; width: 100%;"><span class="video"><iframe id="yt0" frameborder="0" allowfullscreen="1" title="YouTube video player" width="100%" height="350px" src="https://www.youtube.com/embed/xEcsGlZn__w?controls=0&amp;showinfo=0&amp;origin=https%3A%2F%2Fwww.gov.uk&amp;rel=0&amp;enablejsapi=1" role="presentation"></iframe></span><span class="ui-corner-bottom control-bar"></span></span></span>
+      </div>
+      <p>Developers build software with a relentless focus on how it will be used. They continually improve the service by identifying new tools and techniques and removing technical bottlenecks</p>
+
+      <p>Good digital services will require code to be written, adapted, maintained and supported. A team of skilled developers will be able to make sure that happens in an efficient and transparent way, and to help continually improve the service by identifying new tools and techniques and removing technical bottlenecks.</p>
+
+      <h2 id="the-importance-of-developers">The importance of developers</h2>
+
+      <p>No digital service can be effectively built, delivered, owned and operated without the technical skills to understand and improve the software enabling it. In order to provide the best service to your users it is vital that you are in a position to rapidly tailor that software to their needs and to the efficient running of the underlying systems.</p>
+
+      <p>Developers will be able to work directly on those services, but are also an important part of service innovation as they bring ideas, generate prototypes and contribute to a rounded team. </p>
+
+      <p>Once a service is live the need for developers continues. There will always be technical optimisations that can be made – faster and more responsive systems, acting to mitigate the risks of a constantly changing security environment – but as you respond to new or more clearly understood user needs the software will need to adapt. As the policy and other context around a service changes the software may need to integrate with new systems or provide new features and a development team can help ensure that work is pro-active.</p>
+
+      <h2 id="skills-and-attributes">Skills and attributes</h2>
+
+      <p>A great developer:</p>
+
+      <ul>
+        <li>builds software with a relentless focus on how it will be used</li>
+        <li>seeks collaboration and early feedback</li>
+        <li>designs software they expect to operate and maintain</li>
+        <li>leaves code simpler and better tested than when they started</li>
+        <li>looks for opportunities to share progress and knowledge</li>
+        <li>is always hoping to learn from colleagues and the wider community</li>
+        <li>distinguishes the important from the urgent</li>
+        <li>uses data to make decisions, building tools to gather that data</li>
+      </ul>
+
+      <p>You would expect any developer to:</p>
+
+      <ul>
+        <li>have deep skills in at least one programming language</li>
+        <li>be aware of the differences between a few languages and frameworks, and be pragmatic at picking the right one</li>
+        <li>understand the core concepts of the internet and web – they should be able to give a good answer to the question ‘what happens when I click a link in a web browser?’</li>
+        <li>be deeply committed to testing their work with automated tests and exploratory testing</li>
+        <li>be able to explain their work to people without particular technical skills</li>
+      </ul>
+
+      <h2 id="developers-in-the-team">Developers in the team</h2>
+
+      <p>It’s really important that your team is clear as to who makes technical decisions. Everyone on the team will have useful knowledge, skills and experience to bring to bear and you will need an agreed way to understand that input and make a call. Some teams accomplish that by appointing a Tech Lead or delegating certain decisions to a Technical Architect, others will put that responsibility in other roles. The important thing is that clear technical decisions be made by people equipped to understand the trade-offs involved.</p>
+
+      <p>As your team grows it is likely that you will find a range of skills and experience. You should be ensuring a balance within the team, making sure that more junior team members are well supported and coached by more experienced team members, but that everyone’s ideas are considered and engaged with by the team and its decision maker.</p>
+
+      <h2 id="related-topics">Related topics</h2>
+      <ol class="tags">
+        <li><a href="/tag/team-structure/">team structure</a></li>
+        <li><a href="/tag/job-roles/">job roles</a></li>
+        <li><a href="/tag/developer/">developer</a></li>
+        <li><a href="/tag/team-recruitment/">team recruitment</a></li>
+      </ol>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 7a2bd696-fccc-45b2-8212-df31669ff051
+  :title: Performance analyst
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:58+00:00'
+  :public_updated_at: '2015-11-04T12:08:58+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/the-team/performance-analyst"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/the-team/performance-analyst"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <div class="lede">
+        Performance analysts identify, collect and present key performance data and analysis to influence the development of a service.
+      </div> -->
+      <h2 id="job-description">Job description</h2>
+
+      <p>Performance Analysts sit at the heart of <a href="/service-manual/the-team">a team</a>, working to specify, collect and present the key performance data and analysis for their service.  The post holder will be part of a revolution in the way in which government continuously measures, assesses, and improves performance in transacting with the public. </p>
+
+      <p>They support service managers by generating new and useful information and translating it into actions that will allow them to iteratively improve their service for users.</p>
+
+      <p>You will have excellent analytical and problem solving skills will enable you to quickly develop recommendations based on the quantitative and qualitative evidence gathered via <a href="/service-manual/making-software/analytics-tools.html">web analytics</a>, <a href="/service-manual/measuring-success/cost-per-transaction.html">financial data</a> and <a href="/service-manual/operations/helpdesk.html">user feedback</a>. </p>
+
+      <p>You will need to be confident in explaining technical concepts to senior civil servants with limited technological background. You will be comfortable working with data, from gathering and analysis through to design and presentation. Commercial experience of performance management is an advantage. </p>
+
+      <p>The main responsibilities of the post are to:</p>
+
+      <ul>
+        <li>support the <a href="/service-manual/the-team/service-manager.html">service manager</a> to make sure their service meets the performance requirements set out in the <a href="/service-manual/digital-by-default">Digital by Default Service Standard</a>
+      </li>
+        <li>communicate service performance against key indicators to internal and external stakeholders</li>
+        <li>ensure high-quality analysis of departmental transaction data</li>
+        <li>support the procurement of the necessary digital platforms to support automated and real-time collection and presentation of data</li>
+        <li>share examples of best practice in digital performance management across government</li>
+        <li>identify delivery obstacles to improving transactional performance in     departments and working with teams to overcome those obstacles</li>
+      </ul>
+
+      <h2 id="personal-specification----competencies-and-skills-required">Personal specification – competencies and skills required</h2>
+
+      <p>You need to be able to see the big picture. You must have these skills:</p>
+
+      <p><strong>Essential</strong>                   </p>
+
+      <ul>
+        <li>be alert to emerging issues and trends which might impact or benefit own and team’s work</li>
+        <li>understand how the services, activities and strategies in the area work together to create value for the user</li>
+        <li>make sure own area/team activities are aligned to departmental priorities</li>
+      </ul>
+
+      <p>You must be able to make effective decisions by: </p>
+
+      <p><strong>Essential</strong>                       </p>
+
+      <ul>
+        <li>identifing a range of relevant and credible information sources and recognise the need to collect new data when necessary from internal and external sources</li>
+        <li>recognising patterns and trends in a wide range of evidence and draw important conclusions</li>
+        <li>exploring different options outlining costs, benefits, risks and potential responses to each</li>
+        <li>inviting challenge and where appropriate involve others in decision making to help build engagement and present robust recommendations</li>
+      </ul>
+
+      <p>You need to be a good leader with strong communication skills. You will be able to:</p>
+
+      <p><strong>Essential</strong></p>
+
+      <ul>
+        <li>communicate using appropriate styles, methods and timing, including digital channels, to maximise understanding and impact</li>
+        <li>communicate in a succinct, engaging manner and stand ground when needed</li>
+        <li>convey enthusiasm and energy about their work and encourage others to do the same</li>
+        <li>promote the work of the department and play an active part in supporting the civil service values and culture</li>
+      </ul>
+
+      <p>You must be able to build capability for all:</p>
+
+      <p><strong>Essential</strong></p>
+
+      <ul>
+        <li>proactively manage own career and identify own learning needs with line manager, plan and carry out workplace learning opportunities</li>
+        <li>continually seek and act on feedback to evaluate and improve their own and team’s performance</li>
+      </ul>
+
+      <p>You must be able to manage a quality service:</p>
+
+      <p><strong>Essential</strong></p>
+
+      <ul>
+        <li>make effective use of project management skills and techniques to deliver outcomes, including identifying risks and mitigating actions</li>
+        <li>develop, implement, maintain and review systems and service standards to provide quality, efficiency and value for money</li>
+        <li>establish mechanisms to seek out and respond to feedback from customers about service provided</li>
+      </ul>
+
+      <p>You will be able to deliver at pace: </p>
+
+      <p><strong>Essential</strong></p>
+
+      <ul>
+        <li>make sure there is efficient and effective use of resources to deliver programmes and projects on time, within budgets and to agreed quality standards</li>
+        <li>regularly monitor own and team’s work against targets</li>
+        <li>act promptly to keep work on track and maintain performance</li>
+        <li>plan ahead but reassess workloads and priorities if situations change or people are facing conflicting demands</li>
+      </ul>
+
+      <p>Some specialist skills you will have:</p>
+
+      <p><strong>Essential</strong></p>
+
+      <ul>
+        <li>familiarity with data analysis, web analytics and visualisation tools essential eg Google Analytics, Google Refine, Tableau etc</li>
+        <li>experience of providing performance analysis and recommendations on digital public services</li>
+      </ul>
+
+      <h2 id="related-topics">Related topics</h2>
+      <ol class="tags">
+        <li><a href="/tag/team-structure/">team structure</a></li>
+        <li><a href="/tag/job-roles/">job roles</a></li>
+        <li><a href="/tag/performance-analyst/">performance analyst</a></li>
+        <li><a href="/tag/team-recruitment/">team recruitment</a></li>
+      </ol>
+
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: acc4eec2-8a8d-4f62-9082-10bd07dc524d
+  :title: Product manager
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:59+00:00'
+  :public_updated_at: '2015-11-04T12:08:59+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/the-team/product-manager"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/the-team/product-manager"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <h2 id="what-a-product-manager-does">What a product manager does</h2>
+      <p>A product manager (or product owner) is responsible for the delivery, on-going success and continuous improvement of one or more digital products and/or platforms.</p>
+      <h2 id="when-they-should-join-the-team">When they should join the team</h2>
+      <p>The product manager should be involved from the start. They should be involved at all phases of the project and work closely and collaboratively with the rest of the team.</p>
+      <h2 id="skills-they-need">Skills they need</h2>
+      <p>A product manager will need skills to:</p>
+      <ul>
+      <li>lead one or more multi disciplinary agile delivery teams to deliver excellent new products and/or iterations to existing products to meet user needs</li>
+      <li>gather user requirements based on a communicable understanding of diverse audience groups</li>
+      <li>define and get user buy-in for product definition and delivery approach</li>
+      <li>create effective, prioritised product descriptions and delivery plans to meet user needs in a cost effective way</li>
+      <li>interpret user research in order to make the correct product decisions, noting that users do not always know what they want</li>
+      <li>keep continually abreast of changes to user habits, preferences and behaviours across various digital platforms and their implications for successful delivery of government digital services</li>
+      <li>underpin the delivery and iteration of digital services through effective analysis of qualitative and quantitative user data</li>
+      <li>disseminate an understanding of the digital marketplace, including best practice, costs, suppliers, methodologies and skills to both internal and external stakeholders</li>
+      <li>communicate credibly with a wide range of digital delivery disciplines and talent both internally and externally</li>
+      <li>be actively involved across partner and user communities to promote the department’s principles and foster a collaborative approach to solution delivery and engagement</li>
+      </ul>
+      <h2 id="how-to-hire-a-product-manager">How to hire a product manager</h2>
+      <p>You can use the digital services store to <a href="https://digitalservicesstore.service.gov.uk/">find a product manager</a> for your service.</p>
+      <p>The <a href="https://www.gov.uk/government/publications/digital-services-store-buyers-guide">Digital Services Store buyers' guide</a> provides guidance on using the store.</p>
+      <h3 id="job-description-template">Job description template</h3>
+      <p>You can use this example <a href="https://www.gov.uk/service-manual/the-team/recruitment/ProductManager-generic.odt">product manager job description</a> to help you recruit someone with the skills you need.</p>
+      <h2 id="further-reading">Further reading</h2>
+      <ul>
+      <li>
+      <a href="https://digitaltransformation.blog.gov.uk/2015/03/19/lessons-from-the-sharp-end-a-year-in-the-life-of-a-reluctant-product-owner/">A year in the life of a reluctant product owner</a> (Digital transformation blog)</li>
+      <li>
+      <a href="https://gds.blog.gov.uk/2012/07/27/what-ive-learned-so-far-doing-product-management-in-government/">What I've learned (so far) doing product management in government</a> (Government Digital Service blog)</li>
+      </ul>
+      <h3 id="elsewhere-on-the-manual">Elsewhere on the manual</h3>
+      <ul>
+      <li><a href="/user-research/user-needs-an-introduction/">User needs: an introduction</a></li>
+      <li><a href="/agile-delivery/agile-and-government-services/">Agile and government services: an introduction</a></li>
+      <li><a href="/the-team/set-up-a-service-team/">Set up a service team</a></li>
+      </ul>
+      <!-- ## Tags
+      <ol class="tags">
+        <li><a href="/tag/team-structure/">team structure</a></li>
+        <li><a href="/tag/job-roles/">job roles</a></li>
+        <li><a href="/tag/product-manager/">product manager</a></li>
+        <li><a href="/tag/team-recruitment/">team recruitment</a></li>
+      </ol> -->
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 898bacec-43a9-413b-9d2e-6b7a36c7b36c
+  :title: Service manager
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:59+00:00'
+  :public_updated_at: '2015-11-04T12:08:59+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/the-team/service-manager"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/the-team/service-manager"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <div class="lede">
+        Service managers develop and deliver all the changes necessary to provide effective digital services.
+      </div> -->
+      <p>Service managers are business people who work full time to develop and deliver an effective user focused digital service, including all related processes, for which they are responsible and accountable.</p>
+
+      <p>Outside government, organisations in the public and private sector are learning that experienced and highly skilled managers (often called product managers in the commercial world) are necessary to deliver high-quality digital services.</p>
+
+      <p>We are adopting that model, requiring each transactional digital service handling over 100,000 transactions each year to be developed, operated and continually improved by a service manager. These are not technical IT posts, nor are they confined to running a website. Instead, they are individuals who work full-time to develop and deliver all the changes necessary to provide effective digital services. With a handful of exceptions, this is a new role within government.</p>
+
+      <h2 id="responsibilities">Responsibilities</h2>
+
+      <p>These service managers will:</p>
+
+      <ul>
+        <li>be experienced leaders, with an in-depth understanding of their service (built on continuity of involvement over a period of years) and equipped to represent their service and its users’ needs at all levels within the organisation. For high-profile services these will be at Senior Civil Service level</li>
+        <li>be accountable for the quality and usage of their service, and able to iterate the service based on user feedback at least every month</li>
+        <li>be able to lead effectively on the change management and process re-engineering required to implement successful services</li>
+        <li>have the digital literacy to engage with technical staff and suppliers to define the best system and platform configurations to achieve business/user objectives</li>
+        <li>encourage the maximum possible take-up of their digital service by effective marketing, and specify/manage the requirements for assisted digital activity to supplement this</li>
+        <li>oversee service redesign and subsequent operational delivery; supporting and ensuring the necessary project and approval processes are followed, monitoring and reporting on progress in line with the Digital by Default Service Standard, identifying and mitigating risks, and be authorised to deliver on all aspects</li>
+        <li>actively participate in networking with other service managers inside and outside government, and share good practice and learning</li>
+      </ul>
+
+      <h3 id="whats-the-difference-between-a-service-manager-and-a-product-manager">What’s the difference between a service manager and a product manager?</h3>
+
+      <p>This will depend on the scale of the service you are working on.  In some cases the service manager will also be able to fulfil the role of product manager – working closely with the delivery team (the ‘makers’), prioritising stories for each sprint, attending daily stand ups, being on hand to comment on solutions as they emerge, and accepting stories once they are delivered. However, in many cases it is likely that the service manager won’t have the capacity to be this hands-on, so they are likely to need a dedicated product manager.</p>
+
+      <h2 id="related-topics">Related topics</h2>
+      <ol class="tags">
+        <li><a href="/tag/team-structure/">team structure</a></li>
+        <li><a href="/tag/job-roles/">job roles</a></li>
+        <li><a href="/tag/service-manager/">service manager</a></li>
+        <li><a href="/tag/team-recruitment/">team recruitment</a></li>
+      </ol>
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 3a7bc265-f524-4f4f-a741-012607ac3a66
+  :title: Technical architect
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:59+00:00'
+  :public_updated_at: '2015-11-04T12:08:59+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/the-team/technical-architect"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/the-team/technical-architect"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <div class="lede">
+        Technical architects are senior members of the development team and help breaking down complex software problems, and identify solutions.
+      </div> -->
+      <p>We want to expand our team of outstanding Technical Architects to help the UK government build and run great digital services for the people of the UK.  Candidates must have a strong track record of building and running high volume, reliable and flexible services that are relentlessly user-focused and continually improved through iterative development.</p>
+      <p>The role requires an equal balance of technical expertise, gained through current, hands-on involvement in developing real-world systems, and excellent interpersonal skills allied with the ability to quickly develop strong working relationships in high pressure environments. Candidates should ideally have experience in development of transformational digital services on “brownfield estates” and/or rapid development and scaling of very high-volume “greenfield” services.</p>
+      <p>Technical Architects carry out a wide range of activities, from actively writing code as a senior member of the development team and breaking down complex problems and identifying steps towards solutions, through to coaching individuals and engaging with non-technical people at all levels of seniority.</p>
+      <h3 id="the-main-responsibilities-of-the-post-are-">The main responsibilities of the post are:</h3>
+      <ul>
+      <li>Provide hands-on technical leadership, in the development, operation and ongoing improvement of complex, transformational digital services serving millions of users.</li>
+      <li>Work with product managers to understand user needs for new and existing services.</li>
+      <li>Act as the technical authority in prospective, information gathering and scene setting meetings with other government departments, evaluate technical proposals from external suppliers, and make implementation recommendations to senior stakeholders.</li>
+      <li>Work with delivery teams and partners to break technical requirements down into appropriate pieces, and to identify key API requirements for integration with internal and external systems.</li>
+      <li>Lead the rapid development of user-driven prototypes to identify technical options and inform architectural approaches, working with colleagues and supplier team members to write tests, code and documentation for new and existing systems.</li>
+      <li>Ensure that new and updated platforms, products and transactions are thoroughly tested for performance, are able to handle specified load, and can be maintained over the long-term.</li>
+      <li>Work with external suppliers to ensure that their system architectures are robust, scalable, open and secure, with appropriate overall system design and integration points/APIs, to deliver a high quality user experience.</li>
+      <li>Advise on, manage and implement agile delivery projects within government departments, providing guidance, mentoring and training in agile technical delivery and evolutionary software architecture to government departments and agencies.</li>
+      <li>Provide mentorship and/or line management for software developers and junior software developers</li>
+      <li>Assist with building a culture of continuous delivery and improvement, ensuring that key systems are regularly analysed, maintained and improved.</li>
+      </ul>
+      <h2 id="related-topics">Related topics</h2>
+      <ol class="tags">
+        <li><a href="/tag/team-structure/">team structure</a></li>
+        <li><a href="/tag/job-roles/">job roles</a></li>
+        <li><a href="/tag/technical-architect/">technical architect</a></li>
+        <li><a href="/tag/team-recruitment/">team recruitment</a></li>
+      </ol>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 7f5d3479-2c0b-43f3-bf75-d6c319f4680d
+  :title: User researcher
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:59+00:00'
+  :public_updated_at: '2015-11-04T12:08:59+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/the-team/user-researcher"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/the-team/user-researcher"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <h2 id="the-role-of-user-researchers">The role of user researchers</h2>
+      <p>User researchers are there to:</p>
+      <ul>
+      <li>really understand who your users are and what are their needs</li>
+      <li>keep a close focus on designing digital services that best meet your users' needs</li>
+      </ul>
+      <h2 id="when-they-should-join-the-team">When they should join the team</h2>
+      <p>User researchers should be involved from the start. They should be involved at all phases of the project and work closely and collaboratively with the rest of the team.</p>
+      <h3 id="discovery">Discovery</h3>
+      <p>In the early stages of discovery they:</p>
+      <ul>
+      <li>assist in developing a clear understanding and empathy for end users</li>
+      <li>make sense of existing research</li>
+      </ul>
+      <h3 id="alpha-and-beta">Alpha and beta</h3>
+      <p>Through the alpha and beta phases they work closely with the design team to:</p>
+      <ul>
+      <li>provide guidance based on their understanding of end user needs and behaviour,</li>
+      <li>design methods to answer outstanding questions about the users and the design of the service</li>
+      </ul>
+      <h2 id="skills-they-need">Skills they need</h2>
+      <p>When hiring a user researcher there are 2 main things to consider.</p>
+      <ol>
+      <li>Do they have enough experience in designing, facilitating and analysing user research?</li>
+      <li>Their ability to work well in an agile team.</li>
+      </ol>
+      <h3 id="experience">Experience</h3>
+      <p>You need researchers with enough experience in designing, facilitating and analysing research, particularly one-on-one interviews and usability testing.</p>
+      <p>You are looking for a researcher who has over 100 hours of facilitation experience and who demonstrates an empathetic yet methodical approach to facilitation.</p>
+      <p>A researcher with hours of experience observing end users interacting with digital products can bring value to the design team immediately.</p>
+      <p>Most experienced researchers should be able to provide you with an estimate of their total hours of experience observing users and, on request, provide video clips showing examples of their facilitation techniques for you to review.</p>
+      <p>In product development a mixture of experience in both qualitative and quantitative research is useful, although the most essential will be the ability to design and conduct qualitative research.</p>
+      <h3 id="agile">Agile</h3>
+      <p>An ability to work well in an agile team means they need to be able to:</p>
+      <ul>
+      <li>work collaboratively with designers and product owners</li>
+      <li>be flexible and responsive in designing research</li>
+      <li>be comfortable with a fast moving work environment where change is constant</li>
+      <li>show experience and ability in quickly and effectively communicating research insights in an actionable way so they actively shape the design and development of the product</li>
+      </ul>
+      <p>This will usually mean that the researcher has exercised some creativity and experimentation in their method of communicating findings and they should be able to share examples that were more and less successful.</p>
+      <p>In particular you should look for a researcher who has experience contributing to other disciplines in the team. Capabilities in design or content are particularly helpful.</p>
+      <h2 id="how-to-hire-researchers">How to hire researchers</h2>
+      <p>You'll get better results by bringing a researcher into your team rather than outsourcing research to third party.</p>
+      <p>You can use the digital services store to <a href="https://digitalservicesstore.service.gov.uk/">find user researchers</a> to work on your service.</p>
+      <p>The <a href="https://www.gov.uk/government/publications/digital-services-store-buyers-guide">Digital Services Store buyers' guide</a> provides guidance on using the store.</p>
+      <p>###Job description template</p>
+      <p>You can use this example <a href="https://www.gov.uk/service-manual/the-team/recruitment/Userresearcher-generic.odt">user researcher job description</a> to help you recruit someone with the skills you need.</p>
+      <h2 id="further-reading">Further reading</h2>
+      <ul>
+      <li>
+      <a href="https://userresearch.blog.gov.uk/2015/03/18/so-youre-going-to-be-a-user-researcher-top-tips-to-get-you-going/">So, you’re going to be a user researcher: top tips to get you going</a> (Government Digital Service (GDS) user reseach blog)</li>
+      <li>
+      <a href="https://userresearch.blog.gov.uk/2014/09/10/what-user-researchers-do-when-theyre-not-researching/">What user researchers do when they're not researching</a> (GDS user research blog)</li>
+      <li>
+      <a href="https://userresearch.blog.gov.uk/2014/06/05/how-we-do-research-analysis-in-agile/">How we do research analysis in agile</a> (GDS user research blog)</li>
+      <li>
+      <a href="https://userresearch.blog.gov.uk/2014/05/29/5-ways-to-help-user-research-work-better-in-agile/">5 ways to help user research work better in agile</a> (GDS user research blog)</li>
+      </ul>
+      <h3 id="elsewhere-on-the-manual">Elsewhere on the manual</h3>
+      <ul>
+      <li><a href="/user-research/user-needs-an-introduction/">User needs: an introduction</a></li>
+      <li><a href="/user-research/research-in-discovery/">Research in discovery</a></li>
+      <li><a href="/user-research/research-programmes/">Plan a research program for a project</a></li>
+      </ul>
+      <!-- ## Tags
+      <ol class="tags">
+        <li><a href="/tag/team-structure/">team structure</a></li>
+        <li><a href="/tag/job-roles/">job roles</a></li>
+        <li><a href="/tag/user-researcher/">user researcher</a></li>
+        <li><a href="/tag/team-recruitment/">team recruitment</a></li>
+      </ol> -->
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 67b66612-5d06-4b92-8003-25c718cb6ebc
+  :title: Web operations engineer
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:59+00:00'
+  :public_updated_at: '2015-11-04T12:08:59+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/the-team/web-operations-engineer"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/the-team/web-operations-engineer"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <div class="lede">
+        Web operations engineers run the production systems and help build software that is easy to operate, scale and secure.
+      </div> -->
+      <p>Web operations engineers (sometimes called systems administrators, operations
+      engineers or site reliability engineers) run the production systems and help the development team build software that is easy to operate, scale and secure. This involves expertise in areas such as infrastructure, configuration management, monitoring, deployment and operating systems.</p>
+
+      <h2 id="the-importance-of-web-operations">The importance of web operations</h2>
+
+      <p>Web operations people help run the eventual production systems, but also to help the development team build software that is easy to operate. Thinking about how the eventual system will be run at the very start of the project is important if you want to smoothly move from prototypes to production systems.</p>
+
+      <p>At a high level they will:</p>
+
+      <ul>
+        <li>work with developers to optimise existing applications and to design new ones</li>
+        <li>participate in stand-ups, planning sessions and retrospectives</li>
+        <li>design, build and run systems for application deployment, systems orchestration and configuration management</li>
+        <li>encourage everyone (developers, delivery managers, product owners) to think about how new applications will be run and maintained</li>
+        <li>contribute to designing internal processes needed in the running of a high performance development and operations organisation</li>
+        <li>help everyone understand constraints around security, performance, cost and resulting tradeoffs</li>
+      </ul>
+
+      <h2 id="skills">Skills</h2>
+
+      <p>Web operations engineers will have specific skills, such as:</p>
+
+      <ul>
+        <li>a deep understanding of the target operating system</li>
+        <li>experience of multiple programming languages</li>
+        <li>common deployment patterns</li>
+        <li>continuous integration</li>
+        <li>capacity planning</li>
+        <li>load and performance testing techniques</li>
+        <li>highly-available systems design</li>
+        <li>administration and tuning of production database systems</li>
+        <li>installation and usage of monitoring tools; for instance Nagios, Ganglia, Riemann, Graphite etc</li>
+        <li>knowledge of configuration, deployment and management of web application stacks</li>
+        <li>configuration management tools like Puppet, Chef, CFEngine</li>
+      </ul>
+
+      <p>And ideally have an interest in or some experience with:</p>
+
+      <ul>
+        <li>EC2 or similar dynamic provisioning</li>
+        <li>compliance, auditing and security</li>
+        <li>open source development</li>
+        <li>experience in a product centric environment</li>
+      </ul>
+
+      <h2 id="related-topics">Related topics</h2>
+      <ol class="tags">
+        <li><a href="/tag/team-structure/">team structure</a></li>
+        <li><a href="/tag/job-roles/">job roles</a></li>
+        <li><a href="/tag/web-operations-engineer/">web operations engineer</a></li>
+        <li><a href="/tag/team-recruitment/">team recruitment</a></li>
+      </ol>
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: d49769c9-4713-47eb-a7cf-f675d5521b21
+  :title: Managing more than one team
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:59+00:00'
+  :public_updated_at: '2015-11-04T12:08:59+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/the-team/governing-more-than-one-team"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/the-team/governing-more-than-one-team"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <p class="lede">
+        As soon as you have more than one team you’ll need shared planning, coordination and management of dependencies. This can mean a small increase in the amount of work, but don’t lose sight of the aim to have self organising, self managed teams.
+      </p> -->
+      <h2 id="plan-for-scaling">Plan for scaling</h2>
+      <p>It’s important to plan for changes in team composition. Planning activities include:</p>
+      <ul>
+      <li>consulting with the delivery team on who should be added when</li>
+      <li>making sure the team can devote time to integrating new people</li>
+      <li>making sure new people will have the tools they need to be productive on the day they arrive</li>
+      </ul>
+      <p>When you have more teams, don’t force them to work in exactly the same way as each other. Delivery teams work best when they can control how they work.</p>
+      <p>Scaling up doesn’t mean you need to add more people who govern; don’t complicate governance processes as you scale. You need to:</p>
+      <ul>
+      <li>make sure everyone understands the service vision and goals — especially new starters</li>
+      <li>have teams plan together and think about what they’ll individually be responsible for</li>
+      <li>where possible look at splitting work by theme, product or feature sets to minimise dependencies between teams</li>
+      <li>think about whether it makes sense to share specialist people across teams, eg software architects and people working in security, policy or finance</li>
+      </ul>
+      <h2 id="get-your-teams-working-together">Get your teams working together</h2>
+      <p>It’s better for multiple teams to be sitting in the same location — just as a single team benefits from this. When your teams don’t sit together:</p>
+      <ul>
+      <li>there are communication overheads</li>
+      <li>there’s less informal communication and learning</li>
+      <li>it’s harder to establish a shared culture</li>
+      </ul>
+      <p>This is particularly problematic when business and delivery team members don’t sit together. If you can’t find a suitable shared space or team members live and work in different parts of the country, split the team. There are ways to minimise the problems separation causes, for example:</p>
+      <ul>
+      <li>video communication</li>
+      <li>social media</li>
+      <li>regular face-to-face meetings</li>
+      </ul>
+      <p>You can also get team representatives together in a cross team stand up (sometimes called a ‘stand up of stand ups’), where the following questions are explored:</p>
+      <ul>
+      <li>what has your team done since we last met?</li>
+      <li>what will your team do before we meet again?</li>
+      <li>is anything slowing your team down or getting in their way?</li>
+      <li>are you about to do something that will affect another team’s plans?</li>
+      </ul>
+      <p>The last question helps teams to gain early sight of any dependencies or cross team issues that will need joint remedy. The frequency of these meetings is best determined by the teams and the pace of delivery.</p>
+      <!-- ## What to read next
+
+      * [Recruit a service team](/the-team/recruiting-people-and-skills/)
+      * [Roles in a service team](/the-team/setting-up-a-service-team/)
+      * [Create an agile working environment](#) -->
+      <!-- ## Related topics
+      <ol class="tags">
+        <li><a href="/tag/agile-governance/">agile governance</a></li>
+        <li><a href="/tag/portfolio-and-programme-management/">portfolio and programme management</a></li>
+        <li><a href="/tag/service-manager/">service manager</a></li>
+      </ol> -->
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 6f61860e-6ca3-465f-a605-8c0684c3f41c
+  :title: Working with external suppliers
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:00+00:00'
+  :public_updated_at: '2015-11-04T12:09:00+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/the-team/working-with-third-parties"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/the-team/working-with-third-parties"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <p class="lede">
+        You may need specialist help to design, develop, build or improve your service. When buying in these services, there’s support GDS may be able to provide.
+      </p> -->
+      <h2 id="identifying-the-skills-you-need">Identifying the skills you need</h2>
+      <p>When you have an idea of the service you are going to create, talk to your team about the skills that are lacking. This is your chance to develop skills in-house, so before you go outside the civil service, first see if you have team members who can be developed into roles.</p>
+
+      <p>If not, you can hire individuals or companies to fill in the gaps of specialist skills.</p>
+
+      <h2 id="individuals">Individuals</h2>
+
+      <p>GDS can help you hire some roles. We have job descriptions for:</p>
+
+      <ul>
+        <li><a href="/the-team/setting-up-a-service-team/delivery-manager/">delivery managers</a></li>
+        <li><a href="/the-team/setting-up-a-service-team/designer/">designers</a></li>
+        <li><a href="/the-team/setting-up-a-service-team/developer/">developers</a></li>
+        <li><a href="/the-team/setting-up-a-service-team/web-operations-engineer/">web ops</a></li>
+        <li><a href="/the-team/setting-up-a-service-team/content-designer/">content designer</a></li>
+      </ul>
+
+      <p>GDS can give you some advice on certain candidates or interviews and setting contracts.</p>
+
+      <h2 id="companies">Companies</h2>
+      <p>If you need part of a team or a complete team, remember: you are buying skills to help your team or to build your team around. You are not locking yourselves into a long contract, with minimum spend criteria etc.</p>
+
+      <h2 id="choosing-your-supplier">Choosing your supplier</h2>
+      <p>When you are considering an individual or company to work with, they should give you evidence of:</p>
+
+      <ul>
+        <li>a proven track record of Agile delivery</li>
+        <li>how they will use continuous delivery methods</li>
+        <li>how they will share knowledge and provide coaching and mentoring to civil servants who are developing and/or will be responsible for the service</li>
+        <li>how they will deliver in an Agile way; possibly while working with departments who work in waterfall or PRINCE delivery method</li>
+        <li>their commitment to work on-site with civil servants to share knowledge</li>
+        <li>how they will ‘bake in’ quality to the process</li>
+      </ul>
+
+      <p>They should also be aware of the departmental digital strategies and how they will need to work with them.</p>
+
+      <p>GDS can give you advice on buying this sort of capability through existing processes like G-Cloud, Spot-buy etc. You can now use the <a href="https://www.gov.uk/digital-marketplace">Digital Marketplace</a>.</p>
+
+      <h2 id="people-not-process">People, not process</h2>
+      <p>An underlying principle behind Agile development is that people are more important than process. It has been proven that great teams make great products whether they’re in government or business.</p>
+
+      <p>At GDS, we don’t call people ‘resources’, whether permanent or contract. You look after people, resources are things you use (and discard).</p>
+
+      <h2 id="guidance-for-a-smooth-induction">Guidance for a smooth induction</h2>
+
+      <p>Some guiding principles for service managers or delivery managers:</p>
+
+      <ul>
+        <li>make sure you have enough budget</li>
+        <li>speak to your HR team and confirm you can negotiate salary etc, particularly for technical roles</li>
+        <li>shield your people from the form-filling culture that HR sometimes brings</li>
+        <li>contractors shouldn’t work from home all the time (be sensible here, the odd day won’t hurt)</li>
+        <li>monitoring the work through project tracking tools, but most importantly talk to your people and understand the work they’re doing</li>
+      </ul>
+
+      <p>And don’t forget, contractors can’t sign things.</p>
+
+      <p></p>
+      <h2 id="working-together">Working together</h2>
+      <p>Suppliers and permanent staff should sit together, work together and work through problems together. The team should create an environment where difficult questions can be asked and all ideas are listened to. All team members should work to do the right thing for the user, not just what they have been asked to do.</p>
+
+      <p>Both suppliers and permanent staff should suggest ideas and work together to identify further skills gaps and solutions to create a better product.</p>
+
+      <p>The individual’s or company’s intention should always be to disengage from the department, leaving the team to function on its own.</p>
+
+      <p></p>
+      <h2 id="knowledge-transfer">Knowledge transfer</h2>
+      Your team structure and processes should centre around transferring knowledge to permanent staff, wherever possible.
+      <p>Don’t let a contractor become a single point of failure and treat all team members (permanent and contractors) the same.</p>
+      <p></p>
+      <h2 id="further-reading">Further reading</h2>
+      <ul>
+      <li>A blog post by Meri Williams of GDS on <a href="https://gds.blog.gov.uk/2012/11/27/people-management-in-an-agile-setting/">people management in an agile setting</a>
+      </li>
+      </ul>
+      <h2 id="related-topics">Related topics</h2>
+      <ol class="tags">
+        <!-- <li><a href="/tag/skills-transfer-from-third-parties/">skills transfer from third parties</a></li>
+        <li><a href="/tag/hiring-contractors/">hiring contractors</a></li> -->
+        <li><a href="/tag/agile-procurement/">agile procurement</a></li>
+      </ol>
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 97044d4d-8617-459f-baa7-a037e2d3b7ea
+  :title: 'User needs: an  introduction'
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:00+00:00'
+  :public_updated_at: '2015-11-04T12:09:00+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/user-needs-an-introduction"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/user-needs-an-introduction"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <p class="lede">
+        Develop a deep understanding of your users’ needs to design services that work well for them.
+      </p> -->
+      <div class="panel-mandatory">
+      <h2 class="heading-medium">You must understand user needs</h2>
+      To design government services that work well for people you need a deep understanding of your users’ needs.
+      </div>
+
+
+      <p>You must demonstrate your understanding of user needs to meet the <a href="/service-standard/">digital service standard</a>. You will need to show understanding of user needs from both:</p>
+      <ul>
+          <li>the context of your users' lives</li>
+          <li>the context of your service</li>
+      </ul>
+
+      <div class="panel-indent">You will be assessed on this at each phase of building your service.</div>
+
+      <h2 id="start-by-understanding-why-people-will-use-your-service">Start by understanding why people will use your service</h2>
+      <p>People will use your service to meet a need in their life. These needs can be things like:</p>
+      <ul>
+      <li>going back to work after having a child</li>
+      <li>getting ready to travel abroad</li>
+      <li>caring for a family member who is sick</li>
+      <li>trying to get a job</li>
+      </ul>
+      <p>So when you research user needs you'll find them from the context of your users' lives. You can see them in the ways they use existing government and non-government services to get things done.</p>
+      <p>Most of these needs will already exist and be quite stable over time.</p>
+      <h2 id="continue-to-research-needs-during-the-life-of-your-service">Continue to research needs during the life of your service</h2>
+      <p>But social trends, new technologies and significant changes in your service (and other government services) can change users' needs. So you must continue to researching these needs throughout the life of a service.</p>
+      <h2 id="go-from-user-needs-to-planning-what-your-team-will-do">Go from user needs to planning what your team will do</h2>
+      <p>Once you have researched and <a href="/user-research/user-needs-an-introduction/">recorded your users' needs</a> you can start <a href="/agile-delivery/user-stories/">writing user stories</a> for your team. Your user stories will say what your team needs to do to build a service that meets user needs.</p>
+      <p>This diagram demonstrates how to go from knowing there are people who will be using your service to writing user stories that your team will deliver.</p>
+      <p>To use this diagram, start at the bottom (the lived experience) and work your way up (to service delivery).</p>
+      <p><img src="/public/images/user-needs-pyramid.png" alt="User Needs diagram"></p>
+      <h2 id="measure-how-effectively-your-service-is-meeting-your-user-needs">Measure how effectively your service is meeting your user needs</h2>
+      <p>As your team starts to work on the stories, make a hypothesis about the impact that each story will have on specific user needs, then you can measure if they have been effective.</p>
+      <p>You need to understand what user need each story is supporting (it can be more than one), and you’ll need to think about metrics that can show whether the user need is being better supported as a result of this feature or change.</p>
+      <h2 id="examples-from-around-government-">Examples from around government:</h2>
+      <p>Here are some examples of how other services around government found out about the user needs on their services.</p>
+      <div class="js-collapsible-collection subsection-collection" data-collapse-depth="1">
+          <div class="collapsible-subsections">
+              <div class="govspeak">
+
+               <h2 class="heading-medium">Child care research on GOV.UK</h2>
+                  <p>Through contextual user research in discovery we understood that when people are looking for information about shared parental leave or child tax credits, they need to work out whether going back to work in some way or staying at home is the best choice for their family. This decision has many facets, not just financial.</p>
+
+                  <p>We learned this from people who had recently made decisions about childcare, and also from employers who provide information to employees who are going on maternity leave and returning to work.</p>
+
+                  <p>We used journey maps to show the relationships and touch points for each of these types of users.</p>
+
+                <h2 class="heading-medium">Personal Independence Payment (PIP)</h2>
+                  <p>For the Personal Independence Payment (PIP) project, the Department for Work and Pensions team understood the need people for people with long term ill health or a disability to live an independent life.</p>
+
+                  <p>As someone with long term ill health or a disability. I need financial support so I can live independently.</p>
+              </div>
+           </div>
+      </div>
+
+
+
+      <h2 id="further-reading">Further reading</h2>
+      <ul>
+      <li>
+      <a href="https://userresearch.blog.gov.uk/2015/05/28/we-need-to-talk-about-user-needs/">We need to talk about user needs</a> from the government user research blog</li>
+      <li>
+      <a href="https://designnotes.blog.gov.uk/2014/12/12/epic-win-identifying-high-level-user-needs-2/">Epic win: identifying high-level user needs</a> from the GDS design notes blog</li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 8c691bd4-1e88-47f4-9cc6-ee7880eacf2d
+  :title: How to write a user need
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:00+00:00'
+  :public_updated_at: '2015-11-04T12:09:00+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/how-to-write-a-user-need"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/how-to-write-a-user-need"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <h2 id="record-and-share-your-user-needs">Record and share your user needs</h2>
+      <p>When you understand the needs of your users, you can write them down and share them with your team and wider stakeholders.  Do this in a format that's easy to update as you learn more.</p>
+      <p>It's a good idea to display your user needs on posters so they are always visible to your team.</p>
+      <h2 id="user-needs-must-be-precise">User needs must be precise</h2>
+      <p>A precisely worded user need helps you when designing a service. Writing a user need based on how users actually speak helps make the user need more precise.</p>
+      <p>Don’t just say ‘users need to know about tax codes’. Instead, make sure you know if they want to know how a tax code is calculated, or if they just want to know that they’re paying the right amount of tax.</p>
+      <h2 id="write-user-needs-in-a-standard-structure">Write user needs in a standard structure</h2>
+      <p>When you write user needs use this standard structure:</p>
+      <p>As a...      (type of user or persona)<br>
+      I need...  (narrative about the need)<br>
+      So that... (desirable outcome)</p>
+      <h3 id="example">Example</h3>
+      <p>As a carer<br>
+      I need to know if I can get financial support<br>
+      So that I can apply for the benefits I'm entitled to</p>
+      <p>As someone with long term ill health or a disability<br>
+      I need financial support<br>
+      So that I can live independently</p>
+      <h2 id="add-more-context">Add more context</h2>
+      <p>You can provide more context with constraints and triggers:</p>
+      <p>Because &lt; constraint &gt;
+      When &lt; trigger or situation &gt;</p>
+      <h3 id="example">Example</h3>
+      <p>As a vulnerable young adult, <br>
+      because I live in shared accommodation where post often goes missing, <br>
+      I need important documents delivered somewhere safe</p>
+      <p>As a frequent business traveller,<br>
+      when my new passport's printed, I want to know exactly when I'll get it, <br>
+      so I don't waste time waiting for it</p>
+      <h2 id="put-your-user-needs-in-the-context-of-the-whole-service">Put your user needs in the context of the whole service</h2>
+      <p>Once you've written and shared individual user needs, it's useful to put them in the user's broader experience of your service. You can do this using:</p>
+      <ul>
+      <li><a href="">user journey mapping</a></li>
+      <li><a href="">personas</a></li>
+      </ul>
+      <p>This will help you to think about, and explain:</p>
+      <ul>
+      <li>how people come into your service</li>
+      <li>what happens after they finish using your service</li>
+      <li>how separate transactions fit together to provide a complete service</li>
+      <li>how the digital parts of your service interact with non-digital parts</li>
+      </ul>
+      <!-- ##Join the discussion
+
+      [Discuss user needs on Hackpad](https://userresearchmethods.hackpad.com/Understanding-user-needs-scAlOU1I8ds).
+
+      ##Be part of the community
+
+      There’s an active community of user researchers in the UK government.  If you’re doing user research within government [email Leisa Reichalt](mailto:leisa.reichelt@digital.cabinet-office.gov.uk) to join the community. -->
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 68f516ff-ccf1-492e-b7a1-560ce661ffe4
+  :title: How to work with user needs
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:00+00:00'
+  :public_updated_at: '2015-11-04T12:09:00+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/how-to-work-with-user-needs"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/how-to-work-with-user-needs"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <p>User needs play two important roles for our teams.</p>
+      <p>Firstly, they help to build and maintain empathy and understanding for our users. Everyone in the team should be able to identify the most important user needs for their service.</p>
+      <p>Secondly, they help us to prioritise our work. The team should only work on things that meet validated user needs, and should work on the most important needs first.</p>
+      <p>Clearly stated and validated user needs help us to do less, but do to it better.</p>
+      <h2 id="user-needs-should-be-visible-to-the-team-at-all-times">User needs should be visible to the team at all times</h2>
+      <p>The service manager will be expected to talk about their users' needs in some detail at service assessments. They must be able to show evidence for user needs, and show how particular features (user stories) meet specific user needs.</p>
+      <p>Once your team has defined user needs, make sure they are used by doing hypothesis driven design.</p>
+      <p>Make posters to display user needs on your walls. Make sure that everyone on the team knows the most important user needs for the service, and uses them to inform their work.</p>
+      <p>Refer to user needs in:</p>
+      <ul>
+      <li>sprint planning meetings - does the story you’re about to prioritise meet a validated and understood user need?</li>
+      <li>design reviews - is this design element likely to meet known user needs?</li>
+      <li>user research playbacks - how does this insights support or challenge our current understanding of user needs?</li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 9678a226-e468-46f2-8be0-b423ce9d35f4
+  :title: Research in discovery
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:00+00:00'
+  :public_updated_at: '2015-11-04T12:09:00+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/research-in-discovery"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/research-in-discovery"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <h2 id="aims-of-discovery-research">Aims of discovery research</h2>
+      <p>You do user research in discovery to find out about user needs.</p>
+      <p>The 2 most important goals of the <a href="/service-phases-and-assessments/discovery-phase/">discovery phase</a> are:</p>
+      <ul>
+      <li>making sure that you understand what the <a href="/user-research/user-needs-an-introduction/">user needs</a> are</li>
+      <li>finding out whether the service you’re thinking of building really meets those user needs</li>
+      </ul>
+      <p>These insights will guide the early stages of designing the service.</p>
+      <h3 id="what-you-re-finding-out">What you're finding out</h3>
+      <p>Focus your research on behaviour rather than attitudes and opinions.</p>
+      <p>Discovery is not about asking end users:</p>
+      <ul>
+      <li>What do you want?</li>
+      <li>Do you want this thing that we want to make?</li>
+      </ul>
+      <p>Discovery is about finding out:</p>
+      <ul>
+      <li>Who are your users? What are they like? Where are they located?</li>
+      <li>What are your users’ needs?</li>
+      <li>What are your users currently doing to meet those needs?</li>
+      <li>How well is the current situation working?</li>
+      </ul>
+      <h3 id="who-should-do-the-research">Who should do the research</h3>
+      <p>Along with your user researcher get your product team involved in the discovery process. Having contact with users from the beginning gives designers, developers, content designers and product managers a feel for what they’re building.</p>
+      <h2 id="how-to-do-user-research-in-discovery">How to do user research in discovery</h2>
+      <p>Always do original user research in the discovery phase. This will build a connection with your end users that you should maintain going throughout the service design lifecycle.</p>
+      <p> Useful activities in discovery include:</p>
+      <ul>
+      <li>one-to-one interviews (in context is usually ideal for discovery)</li>
+      <li>shadowing</li>
+      <li>a day in the life</li>
+      <li>diary studies</li>
+      <li>journey mapping</li>
+      <li>desk research</li>
+      </ul>
+      <h3 id="where-to-do-the-research">Where to do the research</h3>
+      <p>Get as close as you can to the situations where people would be using the service. This will make your research more reliable.</p>
+      <p>###How long it should take</p>
+      <p>Give yourself time. Work out what your users don’t know yet, find out what they know and can tell you and look for things they might know but don’t realise you’re interested in.</p>
+      <h3 id="outputs-of-the-research">Outputs of the research</h3>
+      <p>Outputs of research in discovery are:</p>
+      <ul>
+      <li><a href="/user-research/user-needs-an-introduction/">user needs</a></li>
+      <li><a href="/agile-delivery/user-stories/">user stories</a></li>
+      <li><a href="/understanding-users/creating-journey-maps/">customer journey maps</a></li>
+      <li><a href="/understanding-users/creating-personas/">personas</a></li>
+      </ul>
+      <p>These should all continue to evolve over the life of the service.</p>
+      <p>At the end of the discovery phase, your team should be ready to start putting together design approaches to meet the user needs you’ve discovered and begun to understand.</p>
+      <h3 id="other-types-of-information-to-gather">Other types of information to gather</h3>
+      <p>Combine user research in discovery with:</p>
+      <ul>
+      <li>a review of existing secondary research (done by government or by other organisations)</li>
+      <li>a review of existing web analytics where there is an existing relevant web service</li>
+      <li>talking to front line, customer facing people who currently interact with users, like call centre operators and managers</li>
+      </ul>
+      <h2 id="an-example-identity-assurance">An example: Identity assurance</h2>
+      <p>During the discovery phase for a project on identity assurance, the team interviewed 78 participants over 3 weeks.</p>
+      <p>The entire team helped to carry out the research sessions, which meant everyone had first hand experience speaking to users.</p>
+      <p>The team was more invested in the outputs of the research and had a better understanding of user needs.</p>
+      <p><a href="https://identityassurance.blog.gov.uk/2014/02/13/organisation-and-authority-management-discovery/">Read about what they found in the blog post 'Organisation and authority management discovery'</a>.</p>
+      <h2 id="further-reading">Further reading</h2>
+      <ul>
+      <li>
+      <a href="https://dwpdigital.blog.gov.uk/2015/01/20/digital-academy-understanding-the-problem/">Digital academy: Understanding the problem</a> from the Department of Work and Pensions digital blog</li>
+      <li>
+      <a href="https://userresearch.blog.gov.uk/2015/05/27/doing-user-research-in-the-discovery-phase/">Doing user research in the discovery phase</a> from the government user research blog</li>
+      <li>
+      <a href="https://userresearch.blog.gov.uk/2015/03/18/so-youre-going-to-be-a-user-researcher-top-tips-to-get-you-going/">So, you’re going to be a user researcher: top tips to get you going</a> from the government user research blog</li>
+      <li>
+      <a href="https://userresearch.blog.gov.uk/2015/01/21/user-research-for-government-services-8-strategies-that-worked-for-us/">User research for government services: 8 strategies that worked for us</a> from the government user research blog</li>
+      </ul>
+      <h3 id="elsewhere-on-the-manual">Elsewhere on the manual</h3>
+      <ul>
+      <li><a href="/user-research/research-programmes/">Plan a research program</a></li>
+      <li><a href="/user-research/sharing-research/">Report and share research with your team</a></li>
+      <li><a href="/user-research/ethnographic-research/">Ethnographic research</a></li>
+      </ul>
+      <!-- ## Tags
+
+      <ol class="tags">
+        <li><a href="/tag/discovery-phase/">discovery phase</a></li>
+        <li><a href="/tag/user-needs/">user needs</a></li>
+      </ol> -->
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 5406c1cc-7675-49e6-ac60-683219b664f1
+  :title: Research in alpha and beta
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:01+00:00'
+  :public_updated_at: '2015-11-04T12:09:01+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/how-to-do-user-research-in-alpha-and-beta"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/how-to-do-user-research-in-alpha-and-beta"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <h2 id="researching-in-design-iterations">Researching in design iterations</h2>
+      <p>Don’t spend more than 2 weeks working on design without testing it with real end users.</p>
+      <p>There are many ways to create ‘experiments’ that will help you to answer questions about your product, your end users and your design ideas.</p>
+      <p>Your researcher will help choose the best research methods for answering each question. With their help, you’ll probably end up using a number of different techniques on your project.</p>
+      <p>Whatever your project, be sure to do fortnightly user research.</p>
+      <h2 id="fortnightly-user-research-eg-testing-tuesday-">Fortnightly user research (eg ‘Testing Tuesday’)</h2>
+      <p>In these sessions you’re able to:</p>
+      <ul>
+      <li>have people interact with the design you have been working on (usability testing)</li>
+      <li>explore any specific issues you‘d like to gather more information on through a depth interview (one-on-one interviews that produce deep insights on user needs and behaviours)</li>
+      </ul>
+      <p>Carry out research sessions with users every 2 weeks on the same day. Doing user testing at predictable and regular intervals means that your team members will be able to schedule time to watch sessions.</p>
+      <p>A good approach is to schedule 5 one-on-one interviews for that day, each interview being 1 hour in duration. (Schedule a 6th participant as a ‘spare’ in case some participants don’t attend earlier in the day or you have a poorly recruited participant).</p>
+      <p>Conduct these sessions in either:</p>
+      <ul>
+      <li>your own offices</li>
+      <li>a research laboratory (get one from a commercial supplier if there’s not one readily available)</li>
+      </ul>
+      <p>Make sure that you have both facilities booked and participants recruited as early in your project as possible for the expected duration of the alpha and beta phases.</p>
+      <h2 id="before-the-session">Before the session</h2>
+      <p>To prepare for these sessions, you need to:</p>
+      <ul>
+      <li>define your research questions — what do you want to learn from the round of user testing?</li>
+      <li>prepare some theories about your design, eg changing the words on the button will encourage people to read the page more carefully</li>
+      <li>decide how you’ll know when these theories have been proved or disproved, eg you’ll know this is true because you’ll observe people taking more time to read the page</li>
+      <li>decide the type and demographic of users you want to talk to eg age, location,  suitability to task</li>
+      <li>start recruitment at least a week before testing (GDS recommend that you find participants through a recruitment agency)</li>
+      <li>prepare a discussion guide that explains how the sessions should be run and the important research outcomes</li>
+      <li>create a participant release form that authorises the recording of the session</li>
+      <li>send a schedule for the day to project team members, inviting and strongly encouraging them to attend sessions</li>
+      <li>arrange for live streaming of the sessions online via a service such as GoToMeeting, so team members who can’t attend in person can still watch it</li>
+      </ul>
+      <p>Prepare your prototype for the sessions by making sure that it’s:</p>
+      <ul>
+      <li>ready to be seen by users</li>
+      <li>ready to be tested end-to-end</li>
+      <li>usable and accessible from the testing venue (eg firewall restrictions, screen resolutions, compatible browsers)</li>
+      </ul>
+      <h2 id="during-the-session">During the session</h2>
+      <p>In each user testing session:</p>
+      <ul>
+      <li>make sure the session is being recorded</li>
+      <li>make sure that the live stream of the session is available for external viewers</li>
+      <li>keep research theories at the top of your mind so you don’t forget any important topics</li>
+      <li>write down notes on post-its of important observations</li>
+      <li>use yellow, super-sticky post-it notes for observations</li>
+      <li>only 1 observation per post it note</li>
+      <li>use a marker pen and write in capital letters (easier to read when writing quickly)</li>
+      <li>if you’re not sure if it’s important, still write it down</li>
+      <li>get a written transcript of the session (either during the session or have it transcribed at a later time)</li>
+      </ul>
+      <p>A day of research should be followed by a period of analysis before making any significant design changes.</p>
+      <h2 id="guerrilla-research">Guerrilla research</h2>
+      <p>You can use the time between more formal testing to conduct some guerrilla-style testing, getting some initial feedback on your revised designs.</p>
+      <p>Guerrilla testing normally involves taking your prototype into a coffee shop or other public location and finding volunteers who’ll give you some quick feedback. Guerrilla testing participants aren’t necessarily representative of your target audience, but they can provide a quick sense-check in between formal testing sessions.</p>
+      <h2 id="other-research-methods">Other research methods</h2>
+      <p>There are many other research methods you can use to supplement your ‘in person’ qualitative research and to address specific research questions. Using a different technique can provide better insight into a particular research question, or validate insights from fortnightly research with a larger audience.</p>
+      <h2 id="learn">Learn</h2>
+      <p>Now it’s time to see what you can learn from your user testing and research. Make the best possible use of this information by:</p>
+      <ul>
+      <li>analysing</li>
+      <li>sharing</li>
+      <li>communicating</li>
+      </ul>
+      <h2 id="analysis">Analysis</h2>
+      <p>It’s important to properly debrief after spending a day doing user testing as you’ll have seen a lot of people and a lot of different reactions.</p>
+      <p>Although it takes time to analyse sessions in detail, doing so means that you’ll:</p>
+      <ul>
+      <li>have a clear understanding of what you have learned</li>
+      <li>know what the implications on design will be</li>
+      <li>be able to make sure that important observations are not lost</li>
+      </ul>
+      <h3 id="affinity-sorting">Affinity sorting</h3>
+      <p>To do this correctly, you need to:</p>
+      <ul>
+      <li>gather all the post-it note observations created during the testing sessions and stick them up on a big wall</li>
+      <li>group the observations into similar themes</li>
+      <li>create findings — a statement that summarises the observations — for each group, and write it down on a post-it note, sticking it on top of the group</li>
+      <li>try to address the theories and decide if you have enough information to state a theory is now proven or disproven</li>
+      <li>a theory needs further qualitative or quantitative testing</li>
+      </ul>
+      <p>At this stage you’re aiming to create a full set of insights (things that you’ve observed and learned), so don’t start designing solutions just yet. You should allow several hours for this analysis process.</p>
+      <p>Work with anyone that’s seen the user testing session to analyse observations, as it will help to:</p>
+      <ul>
+      <li>gather findings</li>
+      <li>confirm things that people have seen</li>
+      <li>form a consensus on the findings</li>
+      </ul>
+      <h3 id="actions">Actions</h3>
+      <p>Decide what you’re going to do about each finding, if anything, and when you’ve proven a theory, make sure that it’s recorded and shared with the project team.</p>
+      <p>If a finding needs further action, determine what is required to address it in the next design iteration. Write this on an orange post-it note and stick it on top of the finding.</p>
+      <h3 id="prioritisation">Prioritisation</h3>
+      <p>When you’ve decided on what actions to take, use a prioritisation method (like dot voting) to decide how you’ll spend your efforts for the next iteration.</p>
+      <h2 id="share-your-findings">Share your findings</h2>
+      <p>Put user testing findings and actions in a place that’s easily accessible to the project team, as it’s likely that you’ll come back to the findings to:</p>
+      <ul>
+      <li>remember what you discovered</li>
+      <li>see how a particular theme or feature has developed over the course of the design iterations</li>
+      </ul>
+      <p>You can document your findings for others to see in many different ways, like using a:</p>
+      <ul>
+      <li>shared document</li>
+      <li>blog</li>
+      <li>story wall (eg Trello)</li>
+      <li>research catalogue</li>
+      </ul>
+      <p>It’s also useful to keep a record of what you tested with users, eg if you’ve prototyped in code, keep a folder in your repository for each round. You may also like to keep screenshots of the prototype.</p>
+      <p>Keep your research findings in an accessible shared format so findings can be shared and learned from in the future. The findings should, wherever possible, be easily understood with no need for an explanation.</p>
+      <p>Move any actions onto your story wall so that the whole team can see what you’re working on and who’s working on it.</p>
+      <h3 id="video">Video</h3>
+      <p>Use videos to demonstrate findings and store the session videos in a safe place, ideally where they can be found and watched by team members. If you store the videos on a public service (like Vimeo), make sure they are adequately protected.</p>
+      <h2 id="communicating">Communicating</h2>
+      <p>You need to discuss the project and its progress with others. You can do this by:</p>
+      <ul>
+      <li>showcasing or presenting regular updates</li>
+      <li>always publishing the design</li>
+      <li>having retrospectives</li>
+      </ul>
+      <h3 id="showcase">Showcase</h3>
+      <p>Just as a product team often presents a showcase at the end of each iteration, so should the research and design team. This will make sure the wider project team has an understanding of:</p>
+      <ul>
+      <li>the research and design work being done</li>
+      <li>what has been learnt from research</li>
+      <li>how research is changing the design of the service</li>
+      </ul>
+      <p>This is an opportunity for members of the project team to catch up if they haven’t been able to attend user testing sessions, as well as an opportunity to ask questions.</p>
+      <p>Depending on how your team works, you might put your presentation into the project team’s showcase or you may have a showcase just for research and design.</p>
+      <h3 id="consider-your-more-distant-stakeholders">Consider your more distant stakeholders</h3>
+      <p>There may be other people beyond your more immediate project team who are interested in the outcomes of your work. You can communicate and/or work together with these people by:</p>
+      <ul>
+      <li>inviting them to your showcases</li>
+      <li>publishing a blog</li>
+      <li>maintaining a shared document</li>
+      <li>sending out regular update emails, using screenshots from the prototype to help people see what has been tested</li>
+      </ul>
+      <h3 id="publish-the-design-as-it-stands">Publish the design as it stands</h3>
+      <p>Make it possible for your team to always access the latest version of the prototype, but make sure it’s appropriately protected. Team members may need to check something or use the prototype to talk about the project with their own stakeholders.</p>
+      <p>Put a message across the top of the prototype to remind people that it’s a work in progress.</p>
+      <h2 id="retrospectives">Retrospectives</h2>
+      <p>It’s important to reflect on your progress at regular intervals. Schedule a retrospective where research and design team members have the chance to discuss the process openly and can suggest changes to the process. Assign owners and due dates to the actions to make sure that change occurs.</p>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: e8e5f4d3-1ab0-483d-a9c1-aa11b9e4f8cd
+  :title: Research on a live service
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:01+00:00'
+  :public_updated_at: '2015-11-04T12:09:01+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/research-for-a-live-service"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/research-for-a-live-service"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <p>Keep doing user research on your service when it’s live on GOV.UK to help you find areas to improve.  No service is ever perfect. Better services mean you can save more money on customer support.</p>
+      <p>Make sure the rest of your digital team, eg designers and developers, also continue to support the live service so development changes can be put in place.</p>
+      <p>Live services may need to be updated because of changing:</p>
+      <ul>
+      <li>user needs</li>
+      <li>policies</li>
+      <li>service design principles</li>
+      <li>technology</li>
+      </ul>
+      <p>Read an account of how the <a href="https://insidegovuk.blog.gov.uk/2013/10/23/finance-and-support-for-your-business-redesigned/">Government Digital Service carried out user research on its live business finance and support finder tool</a>.</p>
+      <h2 id="improve-a-live-service-for-users">Improve a live service for users</h2>
+      <p>The live phase is about continually making the service better for users.</p>
+      <p>More people use a live service than one in beta. This means you will get more understanding of how a service works when it is live.</p>
+      <p>You may often find out:</p>
+      <ul>
+      <li>the service is being used differently to how you expected</li>
+      <li>some of the service’s features are unnecessary</li>
+      <li>there are user needs you didn’t know about</li>
+      </ul>
+      <h2 id="doing-user-research-in-live">Doing user research in live</h2>
+      <p>Colleagues may be reluctant to make changes once a service is live because it can be stressful.</p>
+      <p>If you are working in an agile way and making changes often, it's easier for teams to handle change. Mitigate risks by rolling out a major change to a small percentage of people for a short period of time. Measure the effect. Agree what terrible looks like and make a decision on what to do about it.</p>
+      <p>Do user research every fortnight. You can do the same kind of research you did in alpha and beta, but you will also be able to add different techniques such as A/B testing and benchmarking.</p>
+      <p>Watch users use the live service, or test prototypes of improvements.</p>
+      <p>Don’t spend more than 2 weeks working on improving the service without testing with real users.</p>
+      <h2 id="adding-new-features-to-a-live-service">Adding new features to a live service</h2>
+      <p>People often want to add new features to a live service, especially if it has been around for a while. User research helps guard against ‘feature creep’ and makes sure each new feature meets a genuine user need.</p>
+      <p>User research can also help product teams prioritise which feature to add to the service first.</p>
+      <p>Research activities in live might include:</p>
+      <ul>
+      <li>think aloud</li>
+      <li>A/B testing</li>
+      <li>community research panel</li>
+      <li>remote research</li>
+      <li>pop-up research</li>
+      <li>unmoderated research</li>
+      <li>benchmarking your service every quarter to measure whether users are more or less able to complete the same set of tasks</li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: ab39d64d-36ee-418a-9901-0cd0a64ecdb3
+  :title: Plan a research program for a project
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:01+00:00'
+  :public_updated_at: '2015-11-04T12:09:01+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/research-programmes"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/research-programmes"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <h2 id="understand-the-vision">Understand the vision</h2>
+      <p>First, understand the vision for the new thing (service, content,  feature) and the desired outcomes. This will really help you know where to focus. The absence of declared vision and outcomes (beyond we're going to make an X) is a clue in itself.</p>
+      <h2 id="learn-about-the-users">Learn about the users</h2>
+      <p>Then learn about the users:</p>
+      <ul>
+      <li>Are the users "most UK adults" or a specialist group?</li>
+      <li>Are users' need likely to be  similar or are there subgroups/edge cases with different needs?</li>
+      <li>How many of your users will need assisted digital support?</li>
+      <li>How many of your users are digitally excluded?</li>
+      </ul>
+      <p>Get numbers and details. If you can't get good answers, then these may be your  first research questions.</p>
+      <h2 id="write-down-your-constraints">Write down your constraints</h2>
+      <p>Make a note of the constraints on your project.</p>
+      <h3 id="timeline">Timeline</h3>
+      <p>Is there a declared timeline for discovery, alpha,  beta, live you'll have to plan to? Is this fixed by legislation or other  constraints? Lack of agreement here is another clue.</p>
+      <h3 id="likely-challenges">Likely challenges</h3>
+      <p>Where should you focus your effort? What's likely to be  difficult for users? What will be hard for the team to do well? But be  careful not to let this blinker your thinking.</p>
+      <p>At this point, don't  talk about  scope. This encourages people to think waterfall,  requirements, system,  etc. rather than learning, people, design,  service, etc.</p>
+      <h2 id="look-for-any-existing-research">Look for any existing research</h2>
+      <p>Very few projects start completely from nothing. The chances are, there is some existing research that you can make use of. Be prepared to dig.</p>
+      <h2 id="create-a-list-of-questions-to-focus-a-research-plan">Create a list of questions to focus a research plan</h2>
+      <p>Now you can think about the topics that your  research is trying to investigate, the questions you are trying to  answer.</p>
+      <p>And from there the research methods you want to use in different stages (1-1, groups, face to face, remote,  unmoderated, quantitative,  survey, diary, ...), the lengths, shape and numbers of different activities.</p>
+      <h2 id="integrate-your-research-plan-with-the-project-rhythm">Integrate your research plan with the project rhythm</h2>
+      <p>Your plan needs to work with the rhythm for different stages of the project. Research isn't a  one off exercise, it's something that runs through the project.</p>
+      <p>Plan how you will get the team involved.  Attending research  activities, building prototypes and other stimulus,  analysing results,  etc.  Make sure that everyone understands that you are helping the team learn about the users, you're not doing that learning for them.</p>
+      <p>You'll need to have a plan for how you'll feed findings into story backlogs, prioritisation meetings, and the other ways in which the team decides on its work, and that the time they spend on preparing, attending, and analysing user research is time that is allocated within their planning.</p>
+      <p>You don't want to do huge  amounts of research that the team can't absorb and respond to. But you also don't want to become entirely reactive to a team that's moving ahead of you.</p>
+      <h2 id="create-a-budget">Create a budget</h2>
+      <p>You should now have an idea of the budget you will  need. Be prepared to fight for a good budget. Many projects are set up without considering user research and are surprised when you need money.</p>
+      <h2 id="start-procurement-immediately">Start procurement immediately</h2>
+      <p>Procurement has been difficult for many projects, although it is getting easier in some places as colleagues get used buying the services  we need, and as suitable suppliers get onto the right procurement  frameworks.</p>
+      <p>Start sending briefs out to suppliers and  booking resources at the first opportunity. Don't wait until you know  exactly what you'll want to do with them. There are always questions to  explore, prototypes that you want people to try, assumptions that need to be checked. Starting early on procurement will also save you from  sitting idle; procurement always takes longer than you thought.</p>
+      <p>Work out how your immediate team will help stakeholders to learn, too
+      Decide how your team will  share findings with wider stakeholders. Will you need to  produce materials and clips to present at show and tells? Will you need  to create more formal summary reports at keep stages - for example, for services  assessments? Make sure you include time for this in your plans.</p>
+      <h2 id="grab-your-wall-space-lab-time-and-other-resources">Grab your wall space, lab time, and other resources</h2>
+      <p>As well as booking the time your team will need for user research, make sure that you book:</p>
+      <ul>
+      <li>lab time if you're using a lab, or appropriate office space if you're not</li>
+      <li>meeting rooms for planning meetings and for analysis meetings (much easier to book them now and cancel them if plans change than the other way around)</li>
+      </ul>
+      <p>You'll also need:</p>
+      <ul>
+      <li>wall space for your research wall</li>
+      <li>plenty of sticky notes. Piles and piles of them. (We admit it: we prefer Post-Its if we can get them)</li>
+      <li>pens for writing on sticky notes.  (You need good-sized marker pens; we prefer Sharpies)</li>
+      <li>access to a printer for printing session guides and other paper materials for research sessions</li>
+      </ul>
+      <h2 id="find-a-research-buddy">Find a research buddy</h2>
+      <p>You'll need someone to act as your helper:</p>
+      <ul>
+      <li>taking notes when you're facilitating (or the other way around)</li>
+      <li>covering for you when you're on annual leave</li>
+      <li>proof-reading documents</li>
+      <li>generally bouncing ideas around with you</li>
+      </ul>
+      <p>Some projects are lucky enough to have 2 user researchers to share the load. On other projects, someone else has an affinity with user research and wants to 'learn by doing'. Or you may simply have to persuade someone to take on the role.</p>
+      <h2 id="get-started-be-flexible-and-have-fun">Get started, be flexible, and have fun</h2>
+      <p>As the user researcher, you've got the best job on the project: finding out whether what you're delivering really works. It's exciting, it's fun. And it will be completely different to how you expected it to be.</p>
+      <p>So get started, learn, and make sure  you do retrospectives like everyone else on the team.</p>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: b11f36fb-1ac1-49d2-b1eb-5450f4b449e8
+  :title: Prepare a day of research
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:01+00:00'
+  :public_updated_at: '2015-11-04T12:09:01+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/preparing-for-a-research-day"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/preparing-for-a-research-day"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <p>All user research should have clear objectives. When you prepare your day of research, you will make sure that everyone agrees on the objectives and that the day of research delivers on those objectives.</p>
+      <p>To prepare for making your test overview:</p>
+      <ul>
+      <li>make sure you have an overall [research program] for your project</li>
+      <li>gather any existing data - for example, refer to your user needs to identify tasks for usability testing</li>
+      <li>get together with your team - if you prepare together, your team will be more committed to the research</li>
+      </ul>
+      <h2 id="record-your-research-objectives">Record your research objectives</h2>
+      <p>Your research objectives are the things that you want to learn from the day:</p>
+      <ul>
+      <li>What are you trying to achieve - help your team understand the users, or try out a specific thing, or both?</li>
+      <li>What do you want to learn about?</li>
+      <li>What problems are you trying to solve?</li>
+      <li>What hypotheses (assumptions or beliefs about your users or project) do you want to prove and disprove?</li>
+      </ul>
+      <p>When you are setting objectives, keep them actionable and to the point. What does your team need to know now to be able to make an informed decision about what to do next?</p>
+      <p>You will turn these objectives into topics for the session when you [write your discussion guide].</p>
+      <p>Do a run-through to test your discussion guide and your session</p>
+      <h2 id="discuss-and-agree-the-best-research-methods-to-meet-these-objectives">Discuss and agree the best research methods to meet these objectives</h2>
+      <p>We mostly choose to do a mixture of a short interview and a usability test.
+      There are other things that you can choose.</p>
+      <h2 id="decide-on-your-participants">Decide on your participants</h2>
+      <p>You will need to consider:</p>
+      <ul>
+      <li>What kind of participants do you need to include?</li>
+      <li>How will you recruit them?</li>
+      <li>Is there a budget to support your research?</li>
+      </ul>
+      <p>Write a recruitment brief or screener.</p>
+      <h2 id="think-about-who-needs-to-learn-from-the-research-your-observers">Think about who needs to learn from the research: your observers</h2>
+      <p>Think - who needs to attend? e.g. product manager, designer, content designer, agency/department stakeholders</p>
+      <p>Make sure you schedule time for analysis after the research and put time in everyone’s calendars. Allow around an hour of analysis for every 2 hours of research.</p>
+      <h2 id="think-about-whether-you-need-a-prototype-or-other-materials">Think about whether you need a prototype or other materials</h2>
+      <h2 id="work-out-your-timings-for-the-day">Work out your timings for the day</h2>
+      <p>For lab research:</p>
+      <ul>
+      <li>plan for no more than 6 one hour sessions a day</li>
+      <li>allow at least 15 minutes between sessions</li>
+      <li>allow time for people to eat lunch.</li>
+      </ul>
+      <p>For research where you go to the users:</p>
+      <ul>
+      <li>plan for no more than 4 one hour sessions a day</li>
+      <li>allow at least 30 minutes between sessions plus the travelling time between sessions</li>
+      <li>
+      <p>allow yourself a break for lunch</p>
+      <h2 id="what-you-need-to-do-next">What you need to do next</h2>
+      </li>
+      <li>
+      <p>write a recruitment brief or screener</p>
+      </li>
+      <li>write a discussion guide</li>
+      <li>research materials and stimulus - make sure these are prepared</li>
+      </ul>
+      <h2 id="organise-your-observers-">Organise your observers:</h2>
+      <p>You will need to:</p>
+      <ul>
+      <li>invite observers</li>
+      <li>use a spreadsheet to make sure that you know who is turning up when and that you don't have too many people in the observation room</li>
+      <li>get a stash of sticky notes, markers, and sticky tack for the observers to make notes</li>
+      </ul>
+      <p>Decide whether to capture a transcript and if so who will do it. If there is someone on your team who can type quickly and reasonably accurately, then it's a good idea to get them to capture what the participant says. It's often quicker to review a transcript than to hunt through a video.</p>
+      <h3 id="appoint-an-observation-room-manager">Appoint an observation room manager</h3>
+      <p>You should appoint an observation room manager - this might be another researcher, but is more often your research buddy: a person who understands the aims of the research and is willing to help.</p>
+      <p>Brief your observation room manager: they are in charge of the observer experience, making sure notes are taken and coordinating any on-the-fly analysis, making sure that people are paying attention and answering observers' questions.</p>
+      <p>Do a run-through to test your discussion guide and your session
+      Print your consent forms</p>
+      <h2 id="appoint-a-participant-host">Appoint a participant host</h2>
+      <p>The host is the liaison for participants:</p>
+      <ul>
+      <li>greets them when they arrive at the building</li>
+      <li>escorts them to the room</li>
+      <li>chases them up if they are late</li>
+      <li>provides a contact phone number</li>
+      </ul>
+      <p>For internal or specialist participants, one person can combine the roles of host and observation room manager.</p>
+      <p>For external participants, it's best to have a person focus on the role of host. The host needs to offer a mobile number and to answer phone calls so can't usually be the test facilitator.</p>
+      <h2 id="final-checklist">Final checklist</h2>
+      <p>You'll need to make sure you:</p>
+      <ul>
+      <li>print your consent forms</li>
+      <li>make sure your research materials and stimulus are prepared</li>
+      <li>do a run-through to test your discussion guide and your session</li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 6f9fc994-1bc2-4593-a649-33c70dcf4250
+  :title: Choose where to do user research
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:01+00:00'
+  :public_updated_at: '2015-11-04T12:09:01+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/where-to-do-user-research"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/where-to-do-user-research"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <p class="lede">
+      There are many types of location you can use. Choose one that works best for the research you need to do.
+      </p> -->
+      <h2 id="you-can-run-user-research-in-many-different-places">You can run user research in many different places</h2>
+      <p>All locations have their strengths and weaknesses. Choose a location that will work best for your research. Remember it's still possible to get valuable feedback from anywhere with just a laptop or phone, so don't let the lack of dedicated facilities be a barrier to getting started.</p>
+      <p>The main locations are:</p>
+      <p>In here:</p>
+      <ul>
+      <li>dedicated research studio or lab</li>
+      <li>meeting rooms</li>
+      </ul>
+      <p>Out there:</p>
+      <ul>
+      <li>users' spaces (work and home)</li>
+      <li>public spaces (pop up research)</li>
+      </ul>
+      <p>Everywhere:</p>
+      <ul>
+      <li>remote</li>
+      </ul>
+      <h2 id="research-studio">Research studio</h2>
+      <p>A research studio (or usability lab) is a dedicated user research space. The studio will support a range of research activities, including interviews, usability tests with a variety of devices, focus groups and workshops.</p>
+      <p>Most external studios provide reception services to welcome participants, collect consent and handle incentive payments.</p>
+      <p>Observation and recording facilities are built-in, often including streaming to remote observers. This allows lots of your team to watch the sessions.</p>
+      <p>However, a research studio can cost around £1,000 per day. Studios are rarely available at short notice, so you need to book well in advance. Participants are taken out of their normal context, which can make them nervous and make it harder for them to remember important details. Participants must also travel to the studio.</p>
+      <h2 id="meeting-room">Meeting room</h2>
+      <p>A standard meeting room is a perfectly good location for many kinds of research, including interviews, simple usability tests, focus groups and workshops.</p>
+      <p>For usability testing, you will need to bring your own devices and manage your own recording. And for workshops, some venues don’t like visitors sticking worksheets or post its on meeting room walls.</p>
+      <p>Observation and streaming to remote observers can be difficult, but may be possible using services like GoToMeeting and JoinMe. You might need help to welcome participants, collect consent and handle payment for the participants' time.</p>
+      <h2 id="users-spaces-work-and-home-">Users' spaces (work and home)</h2>
+      <p>To understand how your service fits into your users’ everyday lives, their homes and workplaces are ideal research locations. You can do walkabout interviews with participants. They can show you how they use a current service, give feedback on concepts and prototypes, or test a new service.</p>
+      <p>The familiar context will make it easier for participants to remember details and provide rich feedback.</p>
+      <p>It can be hard to find suitable locations and get permission to visit them. Participants can feel uncomfortable having researchers in their home or at their workplace.</p>
+      <p>For your own security, always visit peoples’ homes with a colleague. When your research involves contact with children you may also need a <a href="https://www.gov.uk/disclosure-barring-service-check/overview">Disclosure and Barring Service (DBS) check</a>.</p>
+      <h2 id="public-spaces-pop-up-">Public spaces (pop-up)</h2>
+      <p>Do pop-up research in places where your users are likely to be to reach people with particular needs. You can get a lot of participants to take part in a short time. There are no costs aside from travel and your time.</p>
+      <p>Be prepared to improvise as you often won't know the place. Avoid entrances and exits, and places where people are in groups. Take care of your equipment and bags. Cold recruiting passers by can be exhausting. Be aware of the way in which you are recruiting (by convenience) may affect your results.</p>
+      <h2 id="remote-research">Remote research</h2>
+      <p>Research with users wherever they are by doing remote research. All you need is a laptop or a phone, or both. It can be easier to reach users who are busy or who are far away.</p>
+      <p>When you do remote research, you won't find out as much about your users' context.</p>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: d2f7142d-89f8-412d-8667-07bb3fe1a91c
+  :title: Write a recruitment brief and screener
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:01+00:00'
+  :public_updated_at: '2015-11-04T12:09:01+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/recruitment-briefs-and-screeners"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/recruitment-briefs-and-screeners"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <p class="lede">
+      Give clear instructions to any agency recruiting for you. They will prepare a script to screen potential participants.
+      </p> -->
+      <p>A recruitment brief is a set of instructions for an agency that recruits participants for user research.</p>
+      <p>You can use the brief to procure a recruitment agency.  The agency will use your brief to write a 'screener', a script that they will use to recruit from. Check the screener matches your needs. It's not unusual for the agency to miss some specific points you make in the brief.</p>
+      <p>In your brief, you should cover:</p>
+      <ul>
+      <li>research dates, times and length of each session</li>
+      <li>research location</li>
+      <li>number of participants you want to recruit</li>
+      <li>any specific criteria for your participants</li>
+      <li>incentives, for example, you can ask the agency to handle cash incentives</li>
+      </ul>
+      <p>You can decide whether to:</p>
+      <ul>
+      <li>ask participants to come in pairs, for example if a task would usually be tackled by a married couple working together</li>
+      <li>recruit participants who have cognitive, physical and sensory disabilities and who use assistive technology eg screen readers, screen magnification software, voice activated software, track ball, keyboard, switches only</li>
+      <li>recruit reserve participants in case one or more of your participants doesn't turn up
+      tell participants who the research is for during the recruitment process</li>
+      </ul>
+      <h2 id="typical-participant-criteria-for-research-in-government">Typical participant criteria for research in government</h2>
+      <p>You must:</p>
+      <ul>
+      <li>have an equal mix of male and female participants</li>
+      <li>have some participants who are non-frequent or low-confidence users of the Internet -  you'll be asking participants to try to use the Internet, so if they'd feel more comfortable with someone who usually helps them they're welcome to bring that helper along too</li>
+      <li>not have anyone involved in designing or building websites, blogging regularly, or involved in creating online government services</li>
+      <li>not have anyone who has participated in research for government in the last 6 months</li>
+      </ul>
+      <p>Your participants must:</p>
+      <ul>
+      <li>be willing to be recorded on video</li>
+      <li>bring their reading glasses if they use them</li>
+      </ul>
+      <p>Optional points that you can include:</p>
+      <ul>
+      <li>all participants must be willing to sign a non-disclosure agreement</li>
+      <li>participants should be willing to be photographed and filmed in their own surroundings</li>
+      <li>special requirements if you plan to visit the participants rather than have them come to our lab</li>
+      </ul>
+      <!-- ## Example recruitment briefs (NEED TO BE PUT INTO OPENDOC FORMAT)
+
+      [Example brief for research involving UK citizens]
+      [Example brief for research with people who work in aviation] -->
+      <h2 id="recruiting-participants-with-access-needs">Recruiting participants with access needs</h2>
+      <p>We encourage participants with disabilities, and ask that they inform us ahead of the session so that we can make sure they can participate. For example, participants may need to bring someone with them, use an assistive technology,  or may have a guide dog.</p>
+      <p>Recruiting participants with access needs includes digitally excluded citizens, those with poor literacy and digital skills, and people with disabilities.</p>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 8b023b9c-c406-4d0a-8938-3eebe7dc41a7
+  :title: Find research participants
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:02+00:00'
+  :public_updated_at: '2015-11-04T12:09:02+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/recruiting-research-participants"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/recruiting-research-participants"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <p>All user research needs people to take part. In planning your research you must decide who you want to participate and how you will recruit them.</p>
+      <p>We actively encourage including participants from the socio-economic groups D and E as well as those who have a diverse range of skills and experience.</p>
+      <p>This includes citizens who are digitally excluded, as well as those who have poor literacy, low digital skills, and those that use assistive technology.</p>
+      <h2 id="decide-who-to-research-with">Decide who to research with</h2>
+      <p>Write down the criteria that define the participants you want. Use existing research and data to help you, for example, user personas, analytics and general population statistics.</p>
+      <p>Depending on the subject of your research, the criteria might be:</p>
+      <ul>
+      <li>a particular demographic (eg women under 30 years of age)</li>
+      <li>a specific target user group (eg small business owners, job centre staff)</li>
+      <li>particular circumstances or abilities (eg recently moved home, low literacy skills)</li>
+      <li>level on the digital inclusion scale (eg have basic online skills)</li>
+      </ul>
+      <p>Define a representative spread of age, gender, social and economic status, ethnicity, education level, geography, etc.</p>
+      <p>The research methods you are using determine the number of participants that you need, for example, more than 250 participants for benchmarking or 6 participants per round of user research in an agile sprint.</p>
+      <p>Review your recruitment criteria with your team. Are these the right people for our research?</p>
+      <h2 id="finding-and-incentivising-your-participants">Finding and incentivising your participants</h2>
+      <p>It’s normal for members of the general public to get an incentive in return for their time. When you use an agency to recruit participants, the incentive is typically cash. How much the cash incentive is, will depend on the type of participant and the length of the research session.</p>
+      <p>Avoid handling cash incentive payments yourself. On request, recruitment agencies can send the cash incentive directly to the participants once the research is complete. Alternatively, they can also provide a 'host' to manage your participants and hand over the cash incentives on your behalf. There is an additional cost associated to this and you should factor in incentives, handling and host fees in your research budget.</p>
+      <p>To recruit participants you can:</p>
+      <ul>
+      <li>use a research recruitment agency</li>
+      <li>go through a gatekeeper</li>
+      <li>create a panel</li>
+      <li>do it yourself</li>
+      </ul>
+      <p>A good recruitment agency can provide participants quickly and reliably.  An agency typically take 10 days to recruit participants. You will need to provide them with a recruitment brief. Work closely with the recruitment agency to ensure that they fully understand and can meet your brief.</p>
+      <p>Sometimes the people you want are not easily available to a commercial recruiter, for example, members of a professional body, staff of a government agency, or clients of a government service. In this case, ask a gatekeeper within that organisation to provide participants.</p>
+      <p>If you plan to do regular research with a specific group of people, it can help to build up a panel of potential participants.</p>
+      <p>DIY recruiting works well for pop-up research as you should be at a place where your target users are likely to be eg a library, college or community group. You can also ask a gatekeeper at the venue to help find participants.</p>
+      <h2 id="avoid-bias-in-recruitment">Avoid bias in recruitment</h2>
+      <p>Make sure that you are not creating a biased sample of participants by checking the processes a recruitment company uses to register, select and schedule participants. They may exclude people with low digital and literacy skills, or over-recruit people with flexible work patterns.</p>
+      <p>Be careful how you describe your research to potential participants - some recruiters describe all research as market research. This can put off members of a professional body who would be interested in helping to improve a government service they use regularly. To avoid biasing responses, don’t reveal too much about the subject of your research before participants come to their session.</p>
+      <p>To recap:</p>
+      <ul>
+      <li>use a research recruitment company to quickly and reliably recruit members of the general public</li>
+      <li>go through a gatekeeper to recruit members or professional bodies, government staff and other groups</li>
+      <li>create a panel if you are doing frequent research with a specific type or group of participants</li>
+      <li>do it yourself if you are at a venue with lots of potential participants</li>
+      </ul>
+      <h2 id="recommended-recruitment-agencies">Recommended recruitment agencies</h2>
+      <p>These recruitment agencies use mixed methods to recruit participants for user research, including off-line approaches such as face to face, telephone and direct contact with specialist groups:</p>
+      <h3 id="propeller-research">Propeller Research</h3>
+      <p>Contact: Stuart Bolitho
+      Recruitment:</p>
+      <ul>
+      <li>telephone, face to face and online</li>
+      <li>most likely to send recruiters to jobcentres, 3rd sector organisations etc</li>
+      <li>have recruited for Go On UK - so familiar recruiting people with low digital skills, digitally excluded, specialist groups</li>
+      </ul>
+      <h3 id="criteria">Criteria</h3>
+      <p>Contact James Sainsbury
+      Recruitment:</p>
+      <ul>
+      <li>mixed methods, including offline approaches</li>
+      <li>have recruited people with low digital skills for Register to Vote and Renew a Passport services</li>
+      </ul>
+      <h3 id="acumen-fieldwork">Acumen Fieldwork</h3>
+      <p>Contact: Amy Middleton
+      Recruitment:</p>
+      <ul>
+      <li>telephone, face to face and online recruitment</li>
+      <li>at least 2-3 weeks to recruit digitally excluded (with no internet access)</li>
+      <li>DE socio-economic segment, 50 plus age range</li>
+      <li>specialist networks for access needs and sheltered housing citizens</li>
+      </ul>
+      <h3 id="childwise">Childwise</h3>
+      <p>Contact: None yet
+      Recruitment:</p>
+      <ul>
+      <li>specialist research agency for children and young people</li>
+      </ul>
+      <h3 id="the-field">The Field</h3>
+      <p>Contact: None yet
+      Recruitment:</p>
+      <ul>
+      <li>apparently good track record reaching some unusual user groups - "as long as they have mobile phones and email, she can get them."</li>
+      </ul>
+      <h3 id="crag-ross-dawson">Crag Ross Dawson</h3>
+      <p>Contact: Elizabeth Jones
+      Recruitment:</p>
+      <ul>
+      <li>good track record reaching digitally excluded users</li>
+      </ul>
+      <h2 id="recommended-reading">Recommended reading</h2>
+      <p><a href="https://www.mrs.org.uk/pdf/Code%20of%20Conduct%20(2012%20rebrand">Market Research Society Code of Conduct</a>.pdf)</p>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 409db78e-79c5-4e32-b8d1-22ce916d69c2
+  :title: Write a discussion guide
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:02+00:00'
+  :public_updated_at: '2015-11-04T12:09:02+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/discussion-guides"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/discussion-guides"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <p class="lede">
+      Create an agenda for your session to help you prepare, rehearse, and run your research.
+      </p> -->
+      <p>A discussion guide is an agenda for a research session. A good discussion guide will help you to:</p>
+      <ul>
+      <li>prepare</li>
+      <li>rehearse</li>
+      <li>run your research</li>
+      </ul>
+      <h2 id="plan-your-topics-before-writing-your-discussion-guide">Plan your topics before writing your discussion guide</h2>
+      <p>Think about your research objectives and list the topics you want to cover in the session</p>
+      <p>For each topic, write down:</p>
+      <ul>
+      <li>what you are trying to learn</li>
+      <li>the approach you will take: is this an interview question, a task, or something else such as card sorting?</li>
+      <li>the rough amount of time you want to spend on it</li>
+      </ul>
+      <h2 id="write-a-discussion-guide">Write a discussion guide</h2>
+      <ol>
+      <li>Recap the specific research objectives for this day of research</li>
+      <li>Include a standard introduction to a research session: welcome, scene-setting, logistics and obtaining consent</li>
+      <li>Initial interview questions:</li>
+      <li>find out more about your research participants</li>
+      <li>why and how they use the service you will be testing with them</li>
+      <li>any other starter and follow up questions that you are most likely to ask.</li>
+      <li>Instructions for each task you want to the participant to try:</li>
+      <li>decide if you need to provide anything to help them complete the task e.g. dummy data for them to use on a form</li>
+      <li>include the link to the prototype, webpage or other materials for the task</li>
+      <li>Final questions:</li>
+      <li>add any wrap up questions, for example how satisfied they are with their experience or any additional feedback they may wish to give</li>
+      <li>thank the participant and tell them what will happen next</li>
+      </ol>
+      <h2 id="test-your-discussion-guide">Test your discussion guide</h2>
+      <p>Test your discussion guide by going over the session in your head and with your test materials. Walk through each activity and the different ways that people might respond.</p>
+      <p>Revise your guide until you feel that the session has a good pace, a logical flow, and is focussed on the most important topics. If this is difficult, reconsider your objectives and approach.</p>
+      <p>For more complex research sessions, test your discussion guide in a pilot. Ideally with real participants rather than colleagues, but any testing is better than none (for discussion guides just like for everything).</p>
+      <p>Experienced researchers will have a preferred layout for their discussion guides that fits their research style. Use your rehearsals and pilots to achieve a format that works well for you.</p>
+      <h2 id="the-discussion-guide-is-a-prompt">The discussion guide is a prompt</h2>
+      <p>In your research sessions, use the discussion guide as a prompt:</p>
+      <ul>
+      <li>it’s a guide, not a rigid script</li>
+      <li>in the first few sessions, you'll probably want to follow the guide quite closely</li>
+      <li>it’s also valuable at the end of a long day when you’re tired and can stumble over questions and instructions</li>
+      <li>be prepared to follow the participant’s lead in how you order and approach the topics</li>
+      </ul>
+      <h2 id="other-benefits-of-your-discussion-guide">Other benefits of your discussion guide</h2>
+      <p>A discussion guide also:</p>
+      <ul>
+      <li>gives stakeholders something to review,</li>
+      <li>supports consistency across a team of researchers</li>
+      <li>provides a good record of previous research.</li>
+      </ul>
+      <h2 id="related-topics">Related topics</h2>
+      <ol class="tags">
+        <li><a href="/tag/user-research-plan/">user research plan</a></li>
+        <li><a href="/tag/user-research-sessions/">user research sessions</a></li>
+      </ol>
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 5107f397-5c1b-42cf-80db-3de2e2ad5706
+  :title: Consent forms and talking about consent
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:02+00:00'
+  :public_updated_at: '2015-11-04T12:09:02+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/user-consent"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/user-consent"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <h2 id="understanding-consent">Understanding consent</h2>
+      <p>If you are collecting personal data, whether you are recording it or keeping paper notes, you must obtain consent.</p>
+      <p>The <a href="https://www.gov.uk/data-protection/the-data-protection-act">Data Protection Act</a> sets out the legal requirements for getting consent when you are collecting information, and for looking after that data properly. The act lists 6 areas where there is stronger legal protection for sensitive information, such as ethnic background. If your research project includes any of these sensitive areas then your research team will need to have a plan for dealing with this.</p>
+      <p>The <a href="https://www.mrs.org.uk/pdf/mrs%20code%20of%20conduct%202014.pdf">Market Research Society Code of Conduct</a> sets out the types of data for which you need to get informed consent and guidelines for treating research participants appropriately.</p>
+      <p>Neither the act or code says exactly how to obtain consent.</p>
+      <h2 id="explain-what-you-re-doing-and-the-information-people-will-give">Explain what you're doing and the information people will give</h2>
+      <p>You must explain to the participant who you are, what you're researching and how the information is going to be used. They need to understand and agree to this.</p>
+      <h2 id="you-must-record-the-consent">You must record the consent</h2>
+      <p>You must record the consent in the same format as your  other notes. If you are making audio or video recordings, you must make sure that you also record the participant's consent (verbal). If you are making paper notes, you need a paper form with the participant's consent (written).</p>
+      <h2 id="you-may-choose-to-do-both-verbal-and-written-consent">You may choose to do both verbal and written consent</h2>
+      <p>If the research is complicated then giving people a form to read and sign can be easier for them to understand than a long verbal consent, so you may decide to do both verbal and written consent.</p>
+      <p>Many agencies require that participants  read and sign a paper form that confirms that they understand the  research and what they are agreeing to.</p>
+      <p>If you have written consent, then make sure that you have spare copies in case the participant wants one to take away.</p>
+      <h2 id="you-may-choose-to-confirm-consent-at-the-end-of-the-session">You may choose to confirm consent at the end of the session</h2>
+      <p>If the session is a long one or there is any doubt at all that the participant might feel uncomfortable about the data you have collected, then you may choose to confirm consent at the end of the session.</p>
+      <h2 id="if-in-doubt-don-t-collect-the-data">If in doubt, don't collect the data</h2>
+      <p>If you or the participant has any doubt at all about whether you have consent to collect the data, then don't record it.</p>
+      <p>Delete the recording. Dispose of paper notes in confidential waste.</p>
+      <h2 id="checklist-for-consent">Checklist for consent</h2>
+      <p>Make sure you cover:</p>
+      <ul>
+      <li>who is carrying out the research</li>
+      <li>the research topic</li>
+      <li>how the findings will be used</li>
+      <li>whether it's being recorded or observed, or both</li>
+      <li>an assurance that any personal information they give will be held in confidence and not  shared</li>
+      <li>what they see in the session is also confidential and cannot be shared by them (optional)</li>
+      </ul>
+      <h2 id="other-resources">Other resources</h2>
+      <p><a href="https://drive.google.com/file/d/0B6-ZG5f8qQ5NUVFpWUpwYVZQWDNDaVpyOUJTLUZvQmJBbzdz/edit?usp=sharing">Land Registry: Informed Consent and Information Sheet</a> (GDrive PDF)</p>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: d47933d7-597e-47d5-8196-6a35ec977b3b
+  :title: Run a research session (moderation techniques)
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:02+00:00'
+  :public_updated_at: '2015-11-04T12:09:02+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/running-research-sessions"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/running-research-sessions"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <p class="lede">
+      Use the right moderation techniques to get honest, accurate and useful feedback from users.
+      </p> -->
+      <h2 id="be-friendly-but-neutral">Be friendly, but neutral</h2>
+      <p>User research is artificial, we can’t change that.  You want your user to behave as normally as they can.  Don’t rush them, offer them a drink, keep the setting relaxed and and the tone amicable.</p>
+      <p>Make sure your test plan provides some simple scene setting and a reminder that you’re testing the system and not the user.  A few simple questions about their computer use gets them talking without any challenge and hopefully it lowers any barriers.</p>
+      <p>You want build rapport with the participant but avoid being too friendly.  As the test progresses you can give encouragement with nods, but too much encouragement.  Repeatedly saying “great”, “well done” can encourage the user to seek your affirmation and not do what was natural to them.</p>
+      <p>Often users will be unable to complete a task.  Don’t jump right in with help or clues, wait and see if they find the right path by themselves.  This is exactly why user testing is done.</p>
+      <p>If the user says they don’t know what to do, ask them what they’d do if you weren’t there?  Or ask what are they expecting to see at that point?</p>
+      <h2 id="ask-questions-carefully">Ask questions carefully</h2>
+      <p>Hopefully you have a great test script packed with prompts and well-written questions.  But your user will do or say something you didn’t anticipate and you’ll need to ask them for more information.</p>
+      <p>Make sure your questioning is open and encourages more than one word responses:</p>
+      <ul>
+      <li>Can you tell me more about that?</li>
+      <li>Why did you do that?</li>
+      </ul>
+      <p>Focus your questions on the user’s behaviour, what they have done in the session or in the recent past, not on their opinions and what they might do, for example, 'tell me about how you applied for a TV licence?'.</p>
+      <h3 id="avoid-leading-questions-and-the-bias-they-create">Avoid leading questions and the bias they create</h3>
+      <ul>
+      <li>How easy did you find this section of the site?</li>
+      <li>Why didn’t you click that button, did you not see it?</li>
+      </ul>
+      <h3 id="avoid-using-trigger-words-that-are-on-the-page">Avoid using trigger words that are on the page</h3>
+      <ul>
+      <li>Can you add something to your basket?</li>
+      <li>Where do you find the contact us section?</li>
+      </ul>
+      <p>Keep aware of when usability issues are being encountered.  Sometimes this means that you make a note, mark a recording or maybe re-question the participant to make it very clear to observers and get a good quote.  You’ll be glad of the signpost when you come to the analysis.</p>
+      <h2 id="be-sure-to-listen">Be sure to listen</h2>
+      <p>The test is not about you, make sure you’re hearing from the user most of the time, and think about how much you’re speaking.</p>
+      <p>When the user tells you something pause for a few seconds, they may well add to their comments.  A strategic gulp of water or glance at notes will help make the time.</p>
+      <p>Sometimes you’ll want the participant to expand on what they’ve said, or you need to be sure you’ve understood things.  This is a good time to replay to them what you’ve heard, reframed a little and encouraging them to add to it:  “What I’m hearing is that you….”</p>
+      <h2 id="stay-flexible">Stay flexible</h2>
+      <p>Be ready to move away from the script.  Prototypes go wrong, users take unexpected paths, new questions come from observers.  Some users complete tasks at light speed, others deliberate far more carefully than you ever expected.</p>
+      <p>Fall back tasks and questions should be at the facilitators finger-tips.  Back-up test stimuli are crucial and should be dealt with in the planning stage.</p>
+      <h2 id="plan-and-prepare">Plan and prepare</h2>
+      <p>Good facilitation depends on good preparation.  Recruitment, test facilities and the test scripts are all covered elsewhere but a good facilitator makes sure they're all over the planning details before something goes awry.</p>
+      <p>In the end the only thing better than a good facilitator is 2 good facilitators and user research is a team sport.  If you have the luxury of choice consider rotating who note takes, this can even out any bias from the questions and keep someone fresh for the next session.</p>
+      <h2 id="further-reading">Further reading</h2>
+      <ul>
+      <li><a href="http://www.measuringusability.com/blog/20-usability-tips.php">20 tips for your next moderated usability test</a></li>
+      <li><a href="http://www.prwd.co.uk/user-research/7-tips-for-moderating-user-research-sessions/">7 tips for moderating user research sessions</a></li>
+      <li><a href="http://www.userfocus.co.uk/articles/listening.html">What every usability test moderator ought to know about good listening</a></li>
+      <li><a href="http://www.mindtools.com/CommSkll/ActiveListening.htm">Active listening</a></li>
+      <li><a href="http://www.gv.com/lib/how-to-hack-your-body-language-for-better-interviews">How to hack your body language for better interviews</a></li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: d4a0acde-e6f6-4a75-b422-0f9841dcc215
+  :title: What to say at the beginning of a research session (standard intro)
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:02+00:00'
+  :public_updated_at: '2015-11-04T12:09:02+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/introducing-research-sessions"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/introducing-research-sessions"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <p>Your introduction to a research session will cover:</p>
+      <ul>
+      <li>who are you and where are you from</li>
+      <li>what will we be doing today (just enough to make people feel comfortable)</li>
+      <li>we’re testing the design, not you</li>
+      <li>if you can’t do something, it’s the design’s fault not yours</li>
+      <li>we want to learn about what’s not working, so you won’t offend anyone if you don’t like it</li>
+      <li>feel free to ask questions, but I might not give a very helpful answer (and explain why, for example,  lack of domain expertise or I need it to be like it would be if I wasn’t here helping)</li>
+      <li>people might be in the observation room watching</li>
+      <li>we're recording this and would like to use this to show our colleagues and other people so that we can help design better government services, is this ok? (confirm consent)</li>
+      <li>when we’re planning to finish the session (in case they have time they need to be out)</li>
+      <li>if appropriate can you switch off your mobile phone</li>
+      <li>encourage people to think aloud</li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: ef45ad6d-0faa-498a-92ca-c6bb15252e66
+  :title: Observing user research
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:02+00:00'
+  :public_updated_at: '2015-11-04T12:09:02+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/observing-user-research"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/observing-user-research"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <p>The observation room should be a productive and useful environment for your team and your research.</p>
+      <h2 id="observation-room-facilitator">Observation room facilitator</h2>
+      <p>Your team should assign someone to facilitate the observation room. This person should:</p>
+      <ul>
+      <li>help observers observe the observation room etiquette</li>
+      <li>ensure that observers understand the context of the research (is this a prototype testing a possible future idea or is this the thing you expect to go live next week?)</li>
+      <li>coordinate research note taking</li>
+      <li>coordinate any 'on-the-fly' analysis</li>
+      <li>answer any questions from observers</li>
+      </ul>
+      <h2 id="observation-room-etiquette">Observation room etiquette</h2>
+      <p>Everyone in the observation room should follow these rules:</p>
+      <ul>
+      <li>if you've agreed to arrive for a particular time slot, arrive in good time, quietly, and keep a low volume in the room as noise can carry into the research room</li>
+      <li>don’t spend the whole time you’re in the observation room on your phone or laptop: be present in the room and actively participating - if you're doing your emails, you are not observing. Let someone else have the seat.</li>
+      <li>you may be asked to help by taking notes on post-it -  the best way to do this is to record actual quotes and actions that participants performed (e.g. participant hovered over a particular link, but didn’t click - appeared uncertain) rather than your interpretation of the events</li>
+      <li>you may be asked to type ‘verbatim’ notes - just let the researcher know if you’re not able to type at this speed</li>
+      <li>do discuss points with the people in the room, but save longer chats for the 15 minute gaps in between sessions</li>
+      <li>keep discussions limited to the research at hand, not to other project matters, or how longs it’s been since you saw everyone</li>
+      <li>be considerate of other people in the room (eg don’t eat pungent food) - it can be cramped and hot!</li>
+      <li>let the researchers know if you have any questions or anything you’d like to ask the participants</li>
+      <li>be impartial, professional, and prepared to be surprised</li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 9c635477-ee26-48c7-9e1d-889fb19d53af
+  :title: Note taking during research
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:02+00:00'
+  :public_updated_at: '2015-11-04T12:09:02+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/note-taking-during-research"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/note-taking-during-research"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <h2 id="lab-based-research">Lab-based research</h2>
+      <p>Analysis relies on good note taking during the research sessions. Note taking should be done on post it notes and ideally a transcript of the interview captured (however this can be done retrospectively).</p>
+      <p>Post it notes trump transcripts.</p>
+      <p>The members of the team do the note taking (not the facilitator)</p>
+      <h2 id="how-to-take-notes">How to take notes</h2>
+      <p>Take notes on a post it note (ideally yellow):</p>
+      <ul>
+      <li>make a post it note whenever a participant says something interesting or relevant or does something interesting or relevant</li>
+      <li>make one post it note per observation</li>
+      <li>don’t interpret what things mean when you are note taking, just take the notes of what you see and hear</li>
+      <li>mark each post it note with a participant ID so that you can identify which participants said what when doing the research</li>
+      <li>use yellow post it notes for observations although some people like to use different colours for quotes and good and bad things</li>
+      <li>make a post it for any highlights in the interviews that will make good video clips - you can either do this by just using an asterisk and using the transcript to refind it quickly or you can use a stopwatch or other way of timing the session and mark down the time</li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: b41c25fd-ed1c-4cc2-a11e-c7833c325920
+  :title: Analyse research
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:03+00:00'
+  :public_updated_at: '2015-11-04T12:09:03+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/analysing-research"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/analysing-research"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <p>Analysing data captured in qualitative research well means:</p>
+      <ul>
+      <li>you don’t do it alone</li>
+      <li>sorting through the data generated in research sessions so that you can make sense of what you’ve learned and what actions you should take in response</li>
+      <li>start doing the analysis during the research sessions but allowing time after the research sessions have finished to ensure you get the most from the research you’ve done</li>
+      <li>good note taking during the research sessions</li>
+      </ul>
+      <h2 id="during-the-research">During the research</h2>
+      <p>During the research you can start to group the observations into themes.
+      These themes might be common topics that are coming up or they might be observations and actions that map to specific interface elements. Printing out the interface to help group the observations can be very useful.</p>
+      <h2 id="after-the-research">After the research</h2>
+      <p>After the research, expect to allow at least an hour of analysis for every 2 hours of research conducted.</p>
+      <p>Affinity sorting is a group activity. Encourage people who observed the research to participate in the analysis. This way you can ensure that the research findings are widely accepted and understood by the team.</p>
+      <p>After the research, use affinity sorting to do your research analysis. You do this by making groups of the post it note observations into groups with similar themes and then labeling that group with a title. You will usually have to do this a few times until you end up with a label that represents the insight you’ve gained from the research.</p>
+      <p>Once you have got the insights you can then (use orange post its) to make actions, additional questions and design hypothesis in response to each insight (although some insights will not require an orange post it).</p>
+      <h3 id="prioritising-actions-and-hypotheses">Prioritising actions and hypotheses</h3>
+      <p>Get the entire team to prioritise the actions and hypotheses from the research as a joint activity so that the most important things are done first.</p>
+      <p>Generally, issues that affect many participants are a higher priority than those that affect just one or two.</p>
+      <p>Generally, issues that would cause a participant to fail to complete their task are a higher priority than preference expressed by participants that would impact completion.</p>
+      <h3 id="capturing-and-analysing-insights">Capturing and analysing insights</h3>
+      <p>There will usually be 2 different kinds of insights that you will gain from your research:</p>
+      <ul>
+      <li>propositional and strategic</li>
+      <li>usability and tactical</li>
+      </ul>
+      <p>It is important that both are captured and analysed.</p>
+      <p>Propositional and strategic insights are very important to creating personas, mental models, concept maps etc and feeding back to policy people and service managers.</p>
+      <p>Usability insights are vital to improving the interaction design of the service.</p>
+      <h2 id="related-reading">Related reading</h2>
+      <ul>
+      <li><a href="https://userresearch.blog.gov.uk/2014/06/05/how-we-do-research-analysis-in-agile/">How we do research analysis in agile</a></li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 4d17aff7-2674-40b1-8695-3cb0798a4f8b
+  :title: Report and share research with your team
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:03+00:00'
+  :public_updated_at: '2015-11-04T12:09:03+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/sharing-research"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/sharing-research"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <p>Regularly share what you’ve found in your research with your team. Your insights and ideas can help them prioritise changes to their product or services.</p>
+      <h2 id="playback-what-came-our-of-research-at-regular-meetings">Playback what came our of research at regular meetings</h2>
+      <p>A playback session is a good way to present insights from your research to members of your team who don’t already know what you’ve been working on.</p>
+      <p>Talk through what’s happening to make sure that everyone understands what you’ve been working on. Leave time for questions, both throughout and at the end of the session.</p>
+      <p>For a playback session, you can use a slide deck to:</p>
+      <ul>
+      <li>recap where you’ve visited</li>
+      <li>talk about the kind of research you’ve been doing, iInclude photos if it helps to tell a story</li>
+      <li>highlight or describe each theme or insight</li>
+      </ul>
+      <p>Your playback can also include:</p>
+      <ul>
+      <li>data from analytics that support or quantify your insights</li>
+      <li>hypotheses and questions to encourage discussion</li>
+      <li>references to the service manual or style guides where you need to support your insights</li>
+      <li>design work or sketches for any potential solutions</li>
+      <li>short video clips from your research - between 1 to 3 minutes is usually enough to communicate observations without being repetitive</li>
+      <li>summary of other research relevant to what your team is working on</li>
+      </ul>
+      <h2 id="set-up-a-rhythm-for-research-playbacks">Set up a rhythm for research playbacks</h2>
+      <p>Have a fixed time for team playback sessions.</p>
+      <p>If your research is part of a sprint, share it as soon as possible. This leaves time to talk about what you’ve found or do more research before you and the team prioritise what changes to make to the service.</p>
+      <p>Use a combination of prepared slides and video. This means you can easily repeat sessions if scheduling is difficult.</p>
+      <p>Share your research beyond the project team. Think about inviting people from across the organisation such as contact centre, processing, management and IT or security teams. The broader the range of people in the room, the better for any discussion and feedback opportunities.</p>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: ad43e6eb-c833-414c-83e5-0d502ff9058f
+  :title: Evidence-based personas
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:03+00:00'
+  :public_updated_at: '2015-11-04T12:09:03+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/creating-personas"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/creating-personas"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <h2 id="what-a-persona-is">What a persona is</h2>
+      <p>A persona is a fictitious individual, based on a composite of the characteristics of a group of real users who use a service in a similar way. A particular service or interface will generally have a maximum of 5 or 6 personas, each representing a different type of user.</p>
+      <h2 id="what-a-persona-should-include">What a persona should include</h2>
+      <p>A persona should:</p>
+      <ul>
+      <li>be 1 to 2 pages long</li>
+      <li>include a photo</li>
+      <li>provide personal details such as name, hobbies, family</li>
+      <li>include descriptions of their characteristics such as demographics, knowledge, digital proficiency, behaviours and attitudes</li>
+      </ul>
+      <p>Personas are used for walking through a proposed interface, in the shoes of a given persona to identify where they would find it difficult to use and missing information.
+      Personas are also used to build empathy for users within the development team.</p>
+      <h2 id="use-insights-gathered-from-real-people-to-develop-personas">Use insights gathered from real people to develop personas</h2>
+      <p>Data-driven personas are developed from information about real people, from interviews or other research methods. Snippets from the data should be included.</p>
+      <p>It is important to include a photograph, which should not be of a real user, but rather use a photo (which you have the rights to) to represent the persona in their environment.</p>
+      <h2 id="ad-hoc-personas">Ad-hoc personas</h2>
+      <p>Ad-hoc personas can be used in the initial stage of a project, or if there hasn’t been enough user research to develop full data-driven personas. They are based on assumptions, and should be iterated as more data is uncovered.</p>
+      <p>Problems this can solve are:</p>
+      <ul>
+      <li>increased empathy for users within a team</li>
+      <li>understanding the different types of user</li>
+      </ul>
+      <h2 id="recommended-reading">Recommended reading</h2>
+      <ul>
+      <li><a href="http://www.cooper.com/journal/2008/05/the_origin_of_personas">The origin of personas</a></li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 567d2b80-8c13-4ba6-9f94-b3899c5ca1a6
+  :title: User journey maps
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:03+00:00'
+  :public_updated_at: '2015-11-04T12:09:03+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/creating-journey-maps"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/creating-journey-maps"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <p>User journey mapping is a technique that helps teams to understand the full experience that users have of their service throughout the lifecycle of engaging with the service and across all the channels and touchpoints.</p>
+      <p>They are very useful for making sure that important experiences don't get lost in between organisational silos (teams often look after sections of the experience but no one looks after the hand overs - this can cause problems for our users).</p>
+      <p>They are also very useful for helping us to understand where we should be focusing our attention to get the best results for our end users.</p>
+      <h2 id="how-to-create-a-user-journey-map">How to create a user journey map</h2>
+      <p>Making a user journey map should be a collaborative experience for the team. The process of making the journey map is at least as valuable as the output of the activity.</p>
+      <p>Adaptive Path have published a very good <a href="http://mappingexperiences.com/">guide to doing journey mapping</a> that you can download for free.</p>
+      <h2 id="more-reading">More Reading</h2>
+      <ul>
+      <li><a href="https://gcn.civilservice.gov.uk/guidance/customer-journey-mapping/">Customer journey mapping</a></li>
+      <li><a href="http://www.adaptivepath.com/ideas/the-anatomy-of-an-experience-map/">The anatomy of an experience map</a></li>
+      <li><a href="http://www.pinterest.com/ddeboard/ux-customer-experience-maps/">UX and customer experience maps</a></li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 36d0f499-5cc4-47ce-82dd-459420e2732a
+  :title: A/B and multivariate testing
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:03+00:00'
+  :public_updated_at: '2015-11-04T12:09:03+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/ab-and-multivariate-testing"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/ab-and-multivariate-testing"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <!-- <p class="lede">
+        Show randomly assigned groups of users two versions of the same page and see which version performs better.
+      </p> -->
+      <p>A/B tests are controlled experiments on the web. You show two randomly assigned groups of users two different designs of a page. Through collecting enough individual measurements (like clicks or page views) to be statistically certain that your results are from design changes, not chance. This helps you design around user needs, and take away bias, personal politics and confusion when you’re making decisions about design.</p>
+      <p>This is what A/B tests look like:</p>
+      <p>Before test:</p>
+      <p><img src="/public/images/a-b-testing-1.png" alt="A/B testing"></p>
+      <p>After test:</p>
+      <p><img src="/public/images/a-b-testing-2.png" alt="A/B testing"></p>
+      <p>Say the existing design gets 10,000 unique visitors per month and the button has a current click rate of 20%, meaning it gets clicked 2,000 times a month. If we have determined beforehand that we want to detect a 25% change in click rate (i.e. whether the click rate increases 5% to at least 2,500 times per month) and we are happy with a 95% certainty that our result is statistically valid (a standard threshold), then we need to run the experiment for 10 days. It is important to calculate how many trials (visitors to the site) are needed to reach statistical significance, otherwise we lose the scientific power of this approach.</p>
+      <p>Therefore, after 10 days we have measured about 1,700 views each of A and B (3,400 total) we find that users clicked the next button 20% of the time (340 times) when shown A, and 26% of the time (442 times) when shown B.</p>
+      <p>This result, statistically speaking, is actually 99% likely to be due to our design change (i.e. only 1% likely to be due to chance). Generally, any result which is more than 95% (i.e. has a probability, or p-value, of less than 5%) is deemed to be sufficient evidence for rejecting the null hypothesis–i.e. we can reasonably say that the outcome is due to our change in design.</p>
+      <h2 id="how-to-do-an-a-b-test-in-5-steps">How to do an A/B test in 5 steps</h2>
+      <ol>
+      <li>
+      <p>Decide on your goal and how you’ll measure it
+      For example: you want to increase the number of people using our service. We can measure this through Google Analytics.</p>
+      </li>
+      <li>
+      <p>How long will you have to run the test for it to be statistically valid?
+      The tool available at <a href="http://www.exp-platform.com/Pages/tools.aspx">http://www.exp-platform.com/Pages/tools.aspx</a> can help you determine how many trials of your experiment you need.</p>
+      </li>
+      <li>
+      <p>Build your alternative design (treatment condition), configure your A/B testing tool, and start the experiment.</p>
+      <ul>
+      <li>GOV.UK provides an A/B testing tool through it’s front-end toolkit. You could also use Google Analytics.</li>
+      </ul>
+      </li>
+      <li>
+      <p>Run the experiment</p>
+      <ul>
+      <li>Don’t look at the results before the experiment is over, lest you be tempted to end it prematurely.</li>
+      </ul>
+      </li>
+      <li>
+      <p>Analyse the results and determine which design in the winner</p>
+      <ul>
+      <li>If a statistical test of the results reveals a 95% confidence level for your outcome, you can say the design was successful.</li>
+      </ul>
+      </li>
+      </ol>
+      <p>There are many guides available for A/B testing on the internet. Be careful when applying them to government services as the kinds of things we are interested in measuring may be different from what commercial sites would be interested in.</p>
+      <h2 id="a-b-testing-the-gov-uk-contact-page">A/B testing the GOV.UK contact page</h2>
+      <p>From January to February 2014, the User Support team in GOV.UK tested 4 different designs for the landing page for the Contact section. Analysing the results revealed a clear winner, one which was a surprise to the team.  The winning design was made the new default for the GOV.UK contact page.</p>
+      <p>This was a slightly more complicated test than is recommended, due to the difficulty in interpreting the results caused by having 4 variants. It’s preferable, when possible, to test just one design against another at a time.</p>
+      <h2 id="recommended-reading">Recommended reading</h2>
+      <ul>
+      <li><a href="http://www.smashingmagazine.com/2010/06/24/the-ultimate-guide-to-a-b-testing/">Smashing Magazine’s guide to A/B testing</a></li>
+      <li><a href="https://support.google.com/analytics/answer/1745147">Google Experiments</a></li>
+      <li><a href="http://www.exp-platform.com/Pages/hippo_long.aspx">The Microsoft Experimentation Platform guide to controlled experiments on the web</a></li>
+      <li><a href="http://www.evanmiller.org/ab-testing/sample-size.html">How many subjects are needed for an A/B test</a></li>
+      <li><a href="http://nerds.airbnb.com/experiments-at-airbnb">Experiments at Airbnb</a></li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: d53a190a-bfff-41ee-94a3-67bdfb10e2a9
+  :title: Community research panel
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:03+00:00'
+  :public_updated_at: '2015-11-04T12:09:03+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/community-research-panels"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/community-research-panels"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <p>A community research panel is a group of pre-selected users who have agreed to participate in research activities on a more regular basis. Often the panel is managed using online tools.</p>
+      <p>Your research panel should draw on a cross-section of users from the target groups you are designing for. Typically the panel will be a private community, often have between 300-500 members and focus on building relationships between participants.</p>
+      <h2 id="research-panels-are-good-for-getting-regular-input-from-users">Research panels are good for getting regular input from users</h2>
+      <p>Research panels are often used for diary studies, but they can also be great for gathering quick, regular feedback on a service people are using during alpha, beta and live.</p>
+      <p>Other uses include:</p>
+      <ul>
+      <li>exploring your users’ mental models, and interactions with your service during their day to day business</li>
+      <li>helping with idea generation, concept development and prototype testing
+      conducting quantitative surveys (where the panel size is large)</li>
+      </ul>
+      <h2 id="setting-up-a-research-panel">Setting up a research panel</h2>
+      <p>When recruiting users to participate in your panel you should ensure you get a spread that is representative of the people you are designing for. You may want to take into account demographic data, your user personas, specific target groups, for example tax professionals, and particular circumstances or abilities.</p>
+      <p>Sometimes users will participate in a panel for free because they are invested in the service you are delivering and would like the opportunity to give feedback. If you take this approach, bear in mind that the most eager voices may participate most frequently. You should make sure you balance this research approach to include other, less well-represented voices. On other occasions, it may make sense to incentivise participants to ensure you get the right spread of users and to fairly compensate them for the time they will give to the project.</p>
+      <p>Short-term research panels can be managed through email or a free tool like google groups, but if you plan something more formalised it’s worth using a software tool which is designed to support research with an online community.  There are a number of tools which include built-in support for different research activities, as well as the ability to manage the community and analyse the data you are gathering.</p>
+      <p>The tasks given to a research panel differ in format and can include; online forums, blogs, polls, surveys, instant chat and more. Tasks are often creative, and ask different questions relating to the research objective/s.</p>
+      <p>The main benefits of running a panel are:</p>
+      <ul>
+      <li>rapid speed (questions are answered in real time, research team can react rapidly to internal demands)</li>
+      <li>cost effective when up and running</li>
+      <li>flexibility</li>
+      <li>availability</li>
+      <li>rich outputs (visual content such as video is regularly used and is impactful)</li>
+      <li>deep insights</li>
+      <li>raises profile of research internally when insight is relevant and timely</li>
+      </ul>
+      <h2 id="considerations-when-using-online-research-groups">Considerations when using online research groups</h2>
+      <p>Research panels require time for community management, moderation and analysis of the data.  It helps to keep the community engaged if you plan regular research activities and also participate in discussions around these. You may consider outsourcing the community management aspect to a third party agency or moderator.</p>
+      <p>Expect a greater drop off rate in participation over time. You may want to regularly refresh participants to ensure you don’t lose fresh perspectives as existing participants become more familiar with your service.</p>
+      <h2 id="how-we-have-used-panels-in-government">How we have used panels in government</h2>
+      <p>The Rural Payments Agency use a research panel, because farmers are a very specific target group who’re highly invested in the agency’s services.</p>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 99324e0f-3612-428b-bd46-6ac0f874e89c
+  :title: Depth interviews
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:03+00:00'
+  :public_updated_at: '2015-11-04T12:09:03+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/depth-interviews"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/depth-interviews"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <h2 id="what-depth-interviews-are">What depth interviews are</h2>
+      <p>Depth interviews are a semi-structured conversation that help us learn about users’ needs. They are ideal for exploring users’ attitudes, aspirations and preferences. And for understanding users’ knowledge and thought processes (their mental models).</p>
+      <p>Interviews are not about asking users what they want. They’re a way to see things through your users’ eyes; to develop empathy and understanding.</p>
+      <p>Most interviews are one to one. But you can also interview people in pairs or small groups to understand how they live or work together. The participants in pairs and small groups should know each other, such as a parent and child, or three members of a work team.</p>
+      <p>You can also do interviews remotely, by phone or using video conferencing and screen sharing.</p>
+      <h2 id="why-do-depth-interviews">Why do depth interviews</h2>
+      <p>Depth interviews help you to get deeper insight into your users' behaviours and motivations. They can be time-consuming: setting them up, doing them and analysing the data afterwards. But the quality of data and depth of insight makes them a very valuable activity to include in your research plan.</p>
+      <p>Use them during:</p>
+      <ul>
+      <li>discovery, to develop your understanding of your users</li>
+      <li>alpha, as a complement to concept testing</li>
+      <li>beta and live, as a complement to think aloud usability testing</li>
+      </ul>
+      <h2 id="how-to-do-them">How to do them</h2>
+      <p>First think about your objectives. Why are you doing the interviews? Who do you want to speak to? What do you hope to discover?</p>
+      <p>Then recruit your participants. This takes about 2 weeks if you use an external recruiter, and can take longer if you are using other approaches.</p>
+      <p>Prepare your interview by writing a discussion guide. Think about what topics to explore, the questions or hypotheses you want to dig into, and any activities you might want to include.</p>
+      <p>Interviews are often a mix of asking questions and observing behaviour. You might ask the user to take you on a guided tour of a process as part of the interview or take part in an activity to help you understand an aspect of their life, such as a day in the life.</p>
+      <p>Depth interviews can run from 30 minutes to 2 hours. Consider what you can cover in the time available and prioritise the most important things against your objectives.</p>
+      <p>Interviews can take place anywhere. In the user’s home, over the phone, or at a neutral space such as a research studio, cafe or public library. If you are meeting the user outside of their familiar environment, consider how this will affect the tone and dynamic of the interview. You may need to invest more time making them feel comfortable.</p>
+      <p>Before you start an interview, you’ll need to get consent from your participant.</p>
+      <h3 id="set-a-comfortable-tone-and-listen-actively">Set a comfortable tone and listen actively</h3>
+      <p>During the interview, get participants talking with open, neutral starter questions. Then encourage them to give more detail with simple follow up questions. Focus on stories and real examples. Avoid generalities and how things ‘should’ happen.</p>
+      <p>Make sure you really listen. Show the participant that you are interested in what they are saying, and that you understand what they have said.</p>
+      <p>And don’t change the flow of the interview abruptly. If the participants goes a long way off topic, wait for a natural break and gently bring them back to what you want to talk about.</p>
+      <p>Use your discussion guide to help you remember what you want to cover, but don’t let it constrain the interview. Let the conversation develop naturally, and be prepared to dig into any new and interesting issues that come up.</p>
+      <h3 id="recording-your-interview">Recording your interview</h3>
+      <p>You can take notes during the interview but don’t let this distract you from the conversation. If there are two researchers, one of you can take notes while the other focuses on asking questions and building rapport with the participant.</p>
+      <p>Audio or video recordings of your interviews help make sure you don’t miss small details. And clips of participants make your insights much more compelling. If you do plan to record your interviews, include details of how you will use the recording in the consent form. Recording audio and taking a few photos can feel less intrusive than recording video.</p>
+      <h2 id="example-cabinet-office-technology-transformation-programme">Example:  Cabinet Office Technology Transformation programme</h2>
+      <p>The Technology Transformation programme interviewed civil servants across different departments and functions to understand how they work with digital documents as part of their day to day job. The insights have been used to support the definition of standards for the formats of digital documents produced in the government.</p>
+      <p>Anna Wojnarowska explains <a href="https://userresearch.blog.gov.uk/2014/10/09/doing-user-research-on-a-technology-transformation-programme/">how they did it.</a></p>
+      <h2 id="further-reading">Further reading</h2>
+      <p>Interviewing users, a book by Steve Portigal
+      Professional Interviewing (International Series on Communication Skills), Miller, Hargie, Crute</p>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 3d7ca14c-8ea9-48d2-bbe5-071d4abcfdc5
+  :title: Ethnographic research
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:04+00:00'
+  :public_updated_at: '2015-11-04T12:09:04+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/ethnographic-research"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/ethnographic-research"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <h2 id="what-ethnographic-research-is">What ethnographic research is</h2>
+      <p>Ethnographic research is sometimes called contextual research or contextual inquiry.</p>
+      <p>It can help you understand how your users’ context influences the activity or task you are researching. In user research, context means things like physical environment, the tools and materials that users have and how the task or service fits in users’ daily lives.</p>
+      <h2 id="why-do-ethnographic-research">Why do ethnographic research</h2>
+      <p>Ethnographic research is useful at an early stage in the design process, for example during the <a href="/service-phases-and-assessments/discovery-phase/">discovery phase</a>. It helps you find out what users need the service or website to do which gives you an idea of what you’re going to build.</p>
+      <h2 id="how-to-do-ethnographic-research">How to do ethnographic research</h2>
+      <h3 id="set-your-research-objectives">Set your research objectives</h3>
+      <p>For example: uncovering user pain-points around the service or website you’re researching. Pain-points are parts of the service which don’t seem to be working the way you want them too, or where users take an unexpectedly long time to complete a task</p>
+      <h3 id="where-to-do-the-research">Where to do the research</h3>
+      <p>Do this type of research where users actually use the website or service. For example, where they live, socialise or shop.</p>
+      <h3 id="do-some-background-research-about-where-you-ll-be-doing-your-research">Do some background research about where you’ll be doing your research</h3>
+      <p>Do some internet searches to find out what the place looks like, how to behave in those settings. If working with a recruiter, ask them about particulars of the people you’re meeting with.</p>
+      <p>This places your research in a broader perspective. It also helps users feel more comfortable during your visit.</p>
+      <h3 id="listen-watch-and-record-what-the-users-do-and-where-they-do-it">Listen, watch and record what the users do, and where they do it</h3>
+      <p>Many research tools are used in ethnographic research, including:</p>
+      <ul>
+      <li>open-ended <a href="/user-research/discussion-guides/">discussion guides</a>
+      </li>
+      <li>observational frameworks</li>
+      <li>participant diaries</li>
+      <li>exercises like creating <a href="/user-research/creating-journey-maps/">user journey maps</a> and social network diagrams</li>
+      </ul>
+      <p>There’s very little structured questioning, because you’re trying to find out what users do without being prompted.</p>
+      <h3 id="capture-users-behaviours-and-environment">Capture users’ behaviours and environment</h3>
+      <p>Depending on setting and on permission from users, you can record your users' behaviour and environment when they're related to the tasks you’re researching:</p>
+      <ul>
+      <li>take pictures</li>
+      <li>make audio or video recordings</li>
+      <li>collect or copy things</li>
+      </ul>
+      <h3 id="do-several-visits-if-you-can">Do several visits if you can</h3>
+      <p>Field visits often last several hours (or longer). It is always useful to visit a participant several times to build up a detailed understanding of their life.</p>
+      <h3 id="things-to-think-about">Things to think about</h3>
+      <ul>
+      <li>
+      <p>Personal safety – You might want to go to sessions in pairs when you’re doing home or office research. Make sure any research partners accompanying you understand the importance of not intruding or of directing the user.</p>
+      </li>
+      <li>
+      <p>Equipment – Consider beforehand whether taking video or audio recording equipment would be appropriate to the context, and how you can use it without disturbing the research.</p>
+      </li>
+      <li>
+      <p>Time – Make sure the session will be long enough for you to get all the information you need - remember this will probably be longer than a lab based session.</p>
+      </li>
+      <li>
+      <p>Analysis – Consider the time you’ll need for analysis. Many long sessions will generate a lot of data, so build in enough analysis time for your research objective</p>
+      </li>
+      </ul>
+      <h2 id="example-rural-payments-service">Example: Rural Payments Service</h2>
+      <p>User researcher Emily Ball describes how the team went into the homes of the farmers to see how they use the service in their own environment.</p>
+      <p>Read about their experiences in their blog post <a href="https://userresearch.blog.gov.uk/2015/03/11/the-right-place-to-do-rural-research/">The right place to do rural research</a>.</p>
+      <h2 id="further-reading">Further reading</h2>
+      <p>Here are some ways companies from Mozilla through to the BBC are using ethnography. Being included on this list does not mean that the UK Government endorses the company.</p>
+      <ul>
+      <li><a href="https://blog.mozilla.org/ux/2013/09/poland-hungary-series-1-understanding-how-people-use-their-mobile-phones/">Mozilla and ethnographic research: Understanding how people use their mobile phones in Hungary and Poland</a></li>
+      <li><a href="http://livingroomexperience.wikispaces.com/file/view/tvux2013_submission_1.pdf/419517128/tvux2013_submission_1.pdf%20">Authentication on Everyday Services and Devices – An Ethnographic Study by BBC Research and Development</a></li>
+      <li><a href="http://ethnographymatters.net/blog/2014/02/17/strategic-ethnography-reinvigorating-the-core-of-a-retail-giant-tesco-plc/">Strategic Ethnography: Reinvigorating the Core of a Retail Giant, Tesco</a></li>
+      <li><a href="http://ethnographymatters.net/2014/02/17/ethnography-of-bus-travel/%20">Ethnographers creating a better bus riding experience for a diverse set of passengers</a></li>
+      <li><a href="http://ethnographymatters.net/2014/02/13/a-case-study-on-inclusive-design-ethnography-and-energy-use/">A case study on inclusive design: ethnography and energy use</a></li>
+      </ul>
+      <h3 id="elsewhere-on-the-manual">Elsewhere on the manual</h3>
+      <ul>
+      <li><a href="/user-research/research-in-discovery/">Research in discovery</a></li>
+      <li><a href="/user-research/user-consent/">Consent forms and talking about consent</a></li>
+      <li><a href="/user-research/sharing-research/">Report and share research with your team</a></li>
+      </ul>
+      <!-- ## Tags
+      <ol class="tags">
+        <li><a href="/tag/user-research-methods/">user research methods</a></li>
+        <li><a href="/tag/contextual-research/">contextual research</a></li>
+      </ol> -->
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 89820b97-bfe1-4469-ac31-7916b0b4c1cd
+  :title: Pop-up research
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:04+00:00'
+  :public_updated_at: '2015-11-04T12:09:04+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/pop-up-research"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/pop-up-research"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <h2 id="taking-research-to-where-users-are">Taking research to where users are</h2>
+      <p>In pop-up research, we take our questions and prototypes to where our target users are likely to be, like libraries, day centres and colleges. Or places where government agencies, charities and other organisations offer services and support.</p>
+      <h2 id="why-is-pop-up-user-research-useful-">Why is pop-up user research useful?</h2>
+      <p>You can use pop-up research to:</p>
+      <ul>
+      <li>better understand the needs of specific user groups</li>
+      <li>validate new service concepts and propositions</li>
+      <li>identify barriers and pain points for specific user groups</li>
+      <li>reach people in the boundaries between digital and assisted digital services</li>
+      <li>do research when you’re short of time</li>
+      </ul>
+      <p>Pop-up research works best:</p>
+      <ul>
+      <li>with services and research topics that are relatively short and conceptually simple</li>
+      <li>with services that have a broad audience with lots of niche groups and edge cases</li>
+      <li>for users with lower digital skills, lower literacy, and with physical and cognitive disabilities</li>
+      </ul>
+      <p>You can run pop-up research around the country. This addresses people’s concerns about regional differences.</p>
+      <p>A noisy and distracting venue is often a more realistic and challenging environment than the calm of a usability lab.</p>
+      <p>You can use pop-up research independently, or combine with other research activities.</p>
+      <h2 id="why-we-call-it-pop-up-research-not-guerilla-testing">Why we call it pop-up research, not guerilla testing</h2>
+      <p>Note that pop-up research is sometimes called ‘guerilla testing’ in the UX (user experience) industry. ‘Guerilla testing’ suggests researchers use this method when they lack the money or organisational support to do ‘proper’ research. We believe pop-up research is an important and valid research approach.</p>
+      <h2 id="how-to-do-pop-up-research">How to do pop-up research</h2>
+      <h3 id="preparation">Preparation</h3>
+      <p>Pop-up research is quick and easy to prepare.</p>
+      <p>Identify where the people you want to meet are likely to go. Find people at those venues who can give you permission and help out with your visit. Line up a couple of venues and dates.</p>
+      <p>Short interviews and surveys, quick tests of paper or digital prototypes, or existing digital services are the best activities for pop-up research. Aim for around 10 minutes. Once people are engaged with the research they are often happy to stay longer.</p>
+      <p>If your test involves information that a person might not have with them, mock up the required data, such as a dummy passport page or driving license.</p>
+      <h3 id="on-the-day">On the day</h3>
+      <p>Set up where people are likely to pause and have some free time, like a break out area or café. Make yourself visible with banners and signs. Place yourself so people passing by can see people doing a research session.</p>
+      <p>You’ll need to get consent from participants,  just as you would for a lab study.</p>
+      <p>Simple data capture sheets can make it easier for you to take notes.</p>
+      <p>Recording is possible in pop-up research but can be a sensitive issue. Be prepared not to record. If you do record, Silverback or Camtasia can record screen activity, the participant’s face and your conversation. Simple voice recording and still photographs can also be useful.</p>
+      <p>We usually don’t offer money incentives for pop-up research. Sometimes we tempt people to participate with chocolates, biscuits, etc.</p>
+      <p>You can do pop-up research on your own, but it’s easier with two people taking turns.</p>
+      <p>While you’re at a venue, look around. Talk to people informally, including the staff. Take photos. Pick up interesting artefacts. Thank everybody for their time and support. Ask if you can come back.</p>
+      <h2 id="how-we-ve-used-pop-up-research-in-government">How we’ve used pop-up research in government</h2>
+      <p>We asked 16 teenagers in the canteen of a further education college in Nottingham to evaluate the National Citizen Service website. Usability and editorial issues were discovered. We fed back the results to the development teams. The whole process took 2 days.</p>
+      <p>For the register to vote project we needed to make sure the new service worked well for under-registered groups. We used pop-up research to reach specific groups of users, find out more about them and have them try out the service. We visited a day centre for older people, a further education college, a university, a library, a day centre for people with disabilities, an education centre for homeless people, a youth parliament, a government office, an army base and two consulates.</p>
+      <h2 id="recommended-reading">Recommended reading</h2>
+      <ul>
+      <li><a href="http://www.uxbooth.com/articles/the-art-of-guerilla-usability-testing/">The art of Guerilla Usability Testing</a></li>
+      <li><a href="http://uxmag.com/articles/getting-guerrilla-with-it">Getting Guerilla with it</a></li>
+      <li><a href="http://undercoverux.com/">Undercover UX</a></li>
+      <li><a href="https://gds.blog.gov.uk/2013/11/22/reaching-all-our-users/">Reaching all our users</a></li>
+      <li>
+      <a href="http://silverbackapp.com/">SilverbackApp</a> (low cost recording software)</li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 07d6773d-4be0-4253-ae1f-68891c1738a5
+  :title: Remote user research
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:04+00:00'
+  :public_updated_at: '2015-11-04T12:09:04+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/remote-user-research"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/remote-user-research"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <p>Any user research that would normally be conducted in person can alternatively be done over the phone or using a VoIP system (eg Skype). Depending on the method, it can often be carried out in conjunction with a screen sharing tool. We use remote research when:</p>
+      <ul>
+      <li>you want to reach users that aren’t located close to you. You can even conduct research internationally</li>
+      <li>if time is short you can produce quick results as remote research is easier to schedule</li>
+      <li>this method can also be relatively cheap compared with conducting face to face user testing</li>
+      </ul>
+      <h2 id="doing-research-over-the-phone-during-discovery">Doing research over the phone during discovery</h2>
+      <p>Phone interviews can be really useful in the discovery phase to find out more detailed information about your users.</p>
+      <p>They normally take about 30 mins to an hour.</p>
+      <p>You will probably need to speak with between 6 and 10 users to get started, but this will depend on how broad your user base is or how big the scope of the project.</p>
+      <h2 id="remote-usability-testing">Remote Usability Testing</h2>
+      <p>Remote usability testing can be used when you need to get quick user feedback on concepts or design.</p>
+      <p>It might be helpful to use a screen sharing tool so that you can watch the user interact with the page. Free services like Join.me even allow you to share mouse control so you can look at a prototype on your machine but let your participant choose what to click on</p>
+      <p>They normally take about 30 mins to an hour and take around 6-8 users to reach convergence.</p>
+      <h2 id="practical-considerations-for-remote-research">Practical considerations for remote research</h2>
+      <p>As long as your participant gives consent, always record the audio from remote research. When you're doing research remotely, it's easy to miss something during the flow of the session and the recording will help you capture everything. If you have the budget to support it, get your audio professionally transcribed.</p>
+      <p>You can also look at carrying out remote usability testing asynchronously using a tool like usertesting.com or whatusersdo.com. These services let you set up a series of tasks online along with a basic screener for the kind of participants you want.</p>
+      <p>Participants are recruited from their panel and do the tasks from their home. The whole test is captured on video which you can review afterwards. It's relatively cheap and fast, and can add a new dimension to your research as it is unmoderated.</p>
+      <p>Even if you have carried out research remotely, you can still analyse your research using the same methods as you would for face to face research.</p>
+      <h2 id="recommended-reading">Recommended reading</h2>
+      <p><a href="http://www.amazon.com/gp/product/1933820772/ref=as_li_qf_sp_asin_il_tl?ie=UTF8&amp;camp=1789&amp;creative=9325&amp;creativeASIN=1933820772&amp;linkCode=as2&amp;tag=frogdesign-20">Remote Research: Real Users, Real Time, Real Research</a> by Nate Bolt</p>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 03651843-cc3a-4332-8ab7-577b2c5fc34f
+  :title: Surveys and questionnaires
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:04+00:00'
+  :public_updated_at: '2015-11-04T12:09:04+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/surveys-and-questionnaires"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/surveys-and-questionnaires"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <p>A survey is user research that includes a questionnaire</p>
+      <p>We can find out things from users by asking them. A ‘survey’ can be:</p>
+      <ul>
+      <li>a questionnaire</li>
+      <li>a process where you setting goals and gives you new insights about the topic(s) in the survey</li>
+      </ul>
+      <p>At best, these insights can be generalised to a group of people you’re interested in finding out about</p>
+      <p>A solid survey isn’t easy. Useful, yes. Easy, no.</p>
+      <h2 id="to-do-a-good-survey-start-by-setting-goals">To do a good survey, start by setting goals</h2>
+      <p>Setting goals for the survey will help you define and prioritise the questions you want to ask.</p>
+      <p>Ask yourself:</p>
+      <ul>
+      <li>Is a survey the right way to find out what we want to know?</li>
+      <li>What decisions will we take based on the data gathered?</li>
+      <li>Do we have any of the answers already?</li>
+      <li>Have we already done any interviews with users about what’s in the surveys?</li>
+      </ul>
+      <h2 id="decide-who-you-are-going-to-ask-to-complete-the-survey">Decide who you are going to ask to complete the survey</h2>
+      <p>There’s a temptation to ‘ask everyone’. Don’t. All that does is wear down the users’ patience. 30 responses from a properly chosen probability sample are more statistically useful than 30,000 responses from a biased, self-selected sample.</p>
+      <p>What’s a ‘probability sample’? In a probability sample, each person in the target audience has a known, non-zero probability of being selected. The best known method of doing this is a ‘simple random sample’. If you’re not sure how to get a probability sample, either:</p>
+      <ul>
+      <li>get help from a sampling expert straight away</li>
+      <li>test your survey on a small number of people to find out if it’s likely to deliver the results you need - then worry about sorting out the sampling for your next iteration.</li>
+      </ul>
+      <h2 id="create-a-set-of-questions">Create a set of questions</h2>
+      <p>Question development is about combining:</p>
+      <ul>
+      <li>what people want to tell you (maybe they don't feel like telling you anything, or want to tell you stuff that you're not interested in)</li>
+      <li>how you want to use the answers</li>
+      <li>the work you have to do to transform the answers you get into the data, and ideally the insight, that you want</li>
+      </ul>
+      <h2 id="kinds-of-questions">Kinds of questions</h2>
+      <p>The kinds of questions you can ask are:</p>
+      <ul>
+      <li>single response questions: let the respondent only pick one answer</li>
+      <li>multiple choice questions: respondents can choose more than one answer</li>
+      <li>open ended questions: respondents can write a response</li>
+      <li>scale questions: respondents asked if they agree or disagree with a statement</li>
+      </ul>
+      <h3 id="closed-or-open-questions-">Closed or open questions?</h3>
+      <p>If you’re sending your survey to hundreds or even thousands of people, open questions will make  analysing your data unwieldy.</p>
+      <p>The problem with closed questions is that you can easily limit your survey to your own assumptions. You suggest a set of answers you think people are looking for. If they sound reasonable, respondents will tend to choose them. This makes your results less reliable.</p>
+      <p>Testing your survey with a small sample of people can help you improve your questions and avoid some of these problems.</p>
+      <p>Start with a short questionnaire with a few open questions. Using these results makes it easier to put together a mixed set of closed and open of questions. Sometimes, you need several rounds of testing before the questionnaire can be sent to the full sample size.</p>
+      <h2 id="get-your-survey-to-your-users">Get your survey to your users</h2>
+      <p>As well as a questionnaire, you’ll need:</p>
+      <ul>
+      <li>an invitation, asking people to take the survey and explaining why it’s worthwhile</li>
+      <li>a thank you page, which tell people how you’ll use their answers</li>
+      </ul>
+      <h2 id="do-something-with-the-answers">Do something with the answers</h2>
+      <p>When your answers arrive, you will find that they’re not neat and tidy. Set aside time to sort out:</p>
+      <ul>
+      <li>any missing data</li>
+      <li>repeated answers (2 complete answers that are identical)</li>
+      <li>inconsistent or mis-formatted answers</li>
+      </ul>
+      <p>Doing this to 1,000 responses to a substantial survey can easily take a week.</p>
+      <p>Then, you’re ready for the interesting part: finding insights in the data.</p>
+      <h2 id="problems-surveys-can-solve">Problems surveys can solve</h2>
+      <p>A properly conducted survey can give you data to help you make major decisions. A survey can answer questions like:</p>
+      <ul>
+      <li>how many people have this particular need?</li>
+      <li>are users happy with the service we provide? If not, what can we do about it?</li>
+      </ul>
+      <h2 id="how-we-ve-used-it-in-government">How we’ve used it in government</h2>
+      <p>The Rural Payments Agency (RPA) did a telephone survey of people who claim subsidies under the European Union Common Agricultural Policy (CAP) to establish how many of them have assisted digital needs. This helped the CAP delivery team plan their assisted digital programme.</p>
+      <h2 id="recommended-reading">Recommended reading</h2>
+      <p>Sudman, S., N. M. Bradburn and N. Schwarz (1996). Thinking about answers : the application of cognitive processes to survey methodology. San Francisco, Jossey-Bass Publishers.</p>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 84b4ce86-bf82-42eb-8137-148709a1c8fb
+  :title: Unmoderated research
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:04+00:00'
+  :public_updated_at: '2015-11-04T12:09:04+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/unmoderated-research"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/unmoderated-research"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <p>Unmoderated usability research is where the user attempts a task or series of tasks alone and the moderator observes in a separate room.</p>
+      <p>It’s a useful counterpoint to moderated research where the user thinks aloud. It helps prevent users from post-rationalising what they are doing as they do it. You can get closer to seeing what they do, rather than what they think about what they are doing.</p>
+      <p>Unmoderated research can create a more natural environment where the user forgets that they are being observed.</p>
+      <p>Government Digital Service recently used unmoderated research to test new designs for navigation on GOV.UK  and to test the design of a new 'services and information' page. Unmoderated testing is regularly used in the quarterly benchmarking for GOV.UK.</p>
+      <h2 id="think-about-what-you-are-testing">Think about what you are testing</h2>
+      <p>If you are testing a transaction, recruit users who need to do that transaction. Consider whether you need to set a scenario or constraints when the user attempts the transaction.</p>
+      <p>If you are testing finding information, you will probably want to set some tasks based on things you know users need to find. Randomise the order users attempt tasks. This reduces the effect on your task success and failure rates as users "learn" the system. A simple way to do this is to print each task on paper and shuffle them.</p>
+      <p>Ask users to read out the task when they attempt it so you know which one they are trying.</p>
+      <p>Systems like Morae which allow you to set up and record tasks on the computer may not include the possibility to randomise. Bear in mind the effect this will have on your results.</p>
+      <h2 id="getting-users-set-up">Getting users set up</h2>
+      <p>Without a moderator sitting next to the them, users need some instructions on what to do.</p>
+      <p>Tell your user where you’d like them to start from. Ask them to only spend as long attempting a task or transaction as they would normally spend on it.</p>
+      <p>If you are doing a series of tasks you will need to give users a place to return to before they start each task. Save the place you want your users to start each task from in your browser bookmarks labelled “Start here”. Make sure the bookmarks bar on the browser is visible so users can see that link.</p>
+      <p>Is there anything you don’t want people to do? For example you may want to ask them to browse rather than search. Remember there’s a trade off, this will make the experience more artificial for your users.</p>
+      <p>If you are using eye-tracking make sure it is calibrated.</p>
+      <h2 id="gather-structured-data-on-success-and-failure">Gather structured data on success and failure</h2>
+      <p>During unmoderated testing users are usually not thinking aloud. Make the most of this by focusing your attention on what they do.</p>
+      <p>Capture information about the user journey, degree of success, time on each task or step and their attitude e.g. if they are sighing a lot you can take that as an indication they’re not finding it very easy.</p>
+      <p>There a different types of success or failure to look out for. Did the user find what they were looking for (success) or did they find something closely related to it (partial success)? Did they know they know they failed to find something (failure) or did they think they found the right thing (disaster)?</p>
+      <h2 id="find-out-how-your-user-perceived-their-experience">Find out how your user perceived their experience</h2>
+      <p>Recording what happens is only one part of the picture. Find out how your user perceived their experience. You can ask users to rate each task or step as easy / moderate / hard as they do it, you can also ask them to measure their satisfaction at the end.</p>
+      <p>At the end of the session, go back into the room and talk about their experience. It can help to go back over parts they found hard and find out what they were thinking.</p>
+      <h2 id="other-ways-of-doing-unmoderated-research">Other ways of doing unmoderated research</h2>
+      <p>You can do unmoderated research remotely where users attempt tasks from their own computer, tablet or phone. Normally users record what they do and you observe afterwards. It’s easier to run tests with more users for shorter periods of time for each test. Each user has less chance to learn the system and so you get closer to their natural behaviours.</p>
+      <p>As users can do this in their own time and own environment it can help make their experience less artificial. The downside is that you can’t ask them why they did certain things afterwards.</p>
+      <p>Unmoderated research also works really well with pairs. For example, if you are researching with low confidence internet users you can recruit them with the person who usually helps them.</p>
+      <p>When you do research with pairs you learn as much from how the pair interact together as you learn from what they do.</p>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: fbfd6573-6cb7-4489-8212-8926e6308f1a
+  :title: Find training on user research
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:04+00:00'
+  :public_updated_at: '2015-11-04T12:09:04+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/user-research-training"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/user-research-training"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <h2 id="training-courses-real-life-">Training courses (real life)</h2>
+      <ul>
+      <li>Nielson Norman Group 'Usability Week'  - comes to London a few times a year and offers a good range of high quality training courses</li>
+      <li>Webcredible Training Academy - good range of general UX and user research courses</li>
+      </ul>
+      <h2 id="training-courses-online-">Training courses (online)</h2>
+      <ul>
+      <li>Interaction Design Foundation has a range of online courses about how people interact with technology that is relevant to user research</li>
+      <li>Human Computer Interaction, Stanford University - as a user researcher it is useful to understand how perception and cognition impacts on the success of interaction design</li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services
+- :content_id: 7582685a-1791-4c1c-b9ab-6ccb7e1d9c73
+  :title: User research learning materials
+  :description: "-"
+  :format: service_manual_guide
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:05+00:00'
+  :public_updated_at: '2015-11-04T12:09:05+00:00'
+  :update_type: minor
+  :phase: beta
+  :base_path: "/service-manual/user-research/books-articles-blogs-and-forums"
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research/books-articles-blogs-and-forums"
+  :details:
+    :body: |-
+      <div class="markdown">
+              <h2 id="blogs">Blogs</h2>
+      <ul>
+      <li>subscribe to the <a href="http://linkydink.io/groups/user-research-links">user research linkydink</a> to get good user research links to your inbox regularly</li>
+      <li><a href="https://userresearch.blog.gov.uk/">Government Digital Service's user research blog</a></li>
+      <li><a href="https://medium.com/@lauraklein">Laura Klein on Medium</a></li>
+      </ul>
+      <h2 id="books">Books</h2>
+      <ul>
+      <li>Don't Make Me Think by Steve Krug</li>
+      <li>Rocket Surgery Made Easy by Steve Krug</li>
+      <li>Interviewing Users by Steve Portigal</li>
+      <li>Just Enough Research by Erika Hall</li>
+      <li>Interviewing for Research by Andrew Travers</li>
+      <li>The Design of Everyday Things  by Donald Norman</li>
+      <li>A Web for Everyone by Sarah Horton &amp; Whitney Quesenberg</li>
+      <li>Moment of Clarity: Using the Human Sciences to solve your toughest business
+      problems by Christian Masberg and Mikkel B. Rasmussen</li>
+      <li>Observing the User Experience by Mike Kuniavsky</li>
+      <li>Remote Research by Nate Bolt</li>
+      <li>Universal Methods of Design: 100 Ways to Research Complex Problems, Develop Innovative Ideas, and Design Effective Solutions</li>
+      </ul>
+      <h2 id="videos">Videos</h2>
+      <ul>
+      <li>
+      <a href="http://teamtreehouse.com/library/researching-user-needs">Researching user needs</a>, Treehouse by Tomer Sharon (Google)</li>
+      </ul>
+
+
+            </div>
+    :header_links: []
+    :publisher:
+      :name: Agile Community
+      :href: http://sm-11.herokuapp.com/agile-delivery/agile-and-government-services

--- a/lib/tasks_data/guides.yml
+++ b/lib/tasks_data/guides.yml
@@ -7,7 +7,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:52+00:00'
   :public_updated_at: '2015-11-04T12:08:52+00:00'
   :update_type: minor
   :phase: beta
@@ -67,7 +66,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:52+00:00'
   :public_updated_at: '2015-11-04T12:08:52+00:00'
   :update_type: minor
   :phase: beta
@@ -169,7 +167,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:52+00:00'
   :public_updated_at: '2015-11-04T12:08:52+00:00'
   :update_type: minor
   :phase: beta
@@ -213,7 +210,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:52+00:00'
   :public_updated_at: '2015-11-04T12:08:52+00:00'
   :update_type: minor
   :phase: beta
@@ -311,7 +307,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:53+00:00'
   :public_updated_at: '2015-11-04T12:08:53+00:00'
   :update_type: minor
   :phase: beta
@@ -372,7 +367,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:53+00:00'
   :public_updated_at: '2015-11-04T12:08:53+00:00'
   :update_type: minor
   :phase: beta
@@ -485,7 +479,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:53+00:00'
   :public_updated_at: '2015-11-04T12:08:53+00:00'
   :update_type: minor
   :phase: beta
@@ -517,7 +510,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:53+00:00'
   :public_updated_at: '2015-11-04T12:08:53+00:00'
   :update_type: minor
   :phase: beta
@@ -580,7 +572,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:53+00:00'
   :public_updated_at: '2015-11-04T12:08:53+00:00'
   :update_type: minor
   :phase: beta
@@ -634,7 +625,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:53+00:00'
   :public_updated_at: '2015-11-04T12:08:53+00:00'
   :update_type: minor
   :phase: beta
@@ -682,7 +672,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:53+00:00'
   :public_updated_at: '2015-11-04T12:08:53+00:00'
   :update_type: minor
   :phase: beta
@@ -780,7 +769,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:54+00:00'
   :public_updated_at: '2015-11-04T12:08:54+00:00'
   :update_type: minor
   :phase: beta
@@ -836,7 +824,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:54+00:00'
   :public_updated_at: '2015-11-04T12:08:54+00:00'
   :update_type: minor
   :phase: beta
@@ -898,7 +885,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:54+00:00'
   :public_updated_at: '2015-11-04T12:08:54+00:00'
   :update_type: minor
   :phase: beta
@@ -958,7 +944,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:54+00:00'
   :public_updated_at: '2015-11-04T12:08:54+00:00'
   :update_type: minor
   :phase: beta
@@ -998,7 +983,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:54+00:00'
   :public_updated_at: '2015-11-04T12:08:54+00:00'
   :update_type: minor
   :phase: beta
@@ -1097,7 +1081,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:55+00:00'
   :public_updated_at: '2015-11-04T12:08:55+00:00'
   :update_type: minor
   :phase: beta
@@ -1186,7 +1169,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:55+00:00'
   :public_updated_at: '2015-11-04T12:08:55+00:00'
   :update_type: minor
   :phase: beta
@@ -1304,7 +1286,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:56+00:00'
   :public_updated_at: '2015-11-04T12:08:56+00:00'
   :update_type: minor
   :phase: beta
@@ -1353,7 +1334,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:56+00:00'
   :public_updated_at: '2015-11-04T12:08:56+00:00'
   :update_type: minor
   :phase: beta
@@ -1525,7 +1505,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:57+00:00'
   :public_updated_at: '2015-11-04T12:08:57+00:00'
   :update_type: minor
   :phase: beta
@@ -1580,7 +1559,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:57+00:00'
   :public_updated_at: '2015-11-04T12:08:57+00:00'
   :update_type: minor
   :phase: beta
@@ -1649,7 +1627,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:57+00:00'
   :public_updated_at: '2015-11-04T12:08:57+00:00'
   :update_type: minor
   :phase: beta
@@ -1745,7 +1722,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:57+00:00'
   :public_updated_at: '2015-11-04T12:08:57+00:00'
   :update_type: minor
   :phase: beta
@@ -1836,7 +1812,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:57+00:00'
   :public_updated_at: '2015-11-04T12:08:57+00:00'
   :update_type: minor
   :phase: beta
@@ -1939,7 +1914,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:57+00:00'
   :public_updated_at: '2015-11-04T12:08:57+00:00'
   :update_type: minor
   :phase: beta
@@ -1997,7 +1971,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:58+00:00'
   :public_updated_at: '2015-11-04T12:08:58+00:00'
   :update_type: minor
   :phase: beta
@@ -2089,7 +2062,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:58+00:00'
   :public_updated_at: '2015-11-04T12:08:58+00:00'
   :update_type: minor
   :phase: beta
@@ -2161,7 +2133,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:58+00:00'
   :public_updated_at: '2015-11-04T12:08:58+00:00'
   :update_type: minor
   :phase: beta
@@ -2226,7 +2197,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:58+00:00'
   :public_updated_at: '2015-11-04T12:08:58+00:00'
   :update_type: minor
   :phase: beta
@@ -2309,7 +2279,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:58+00:00'
   :public_updated_at: '2015-11-04T12:08:58+00:00'
   :update_type: minor
   :phase: beta
@@ -2441,7 +2410,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:59+00:00'
   :public_updated_at: '2015-11-04T12:08:59+00:00'
   :update_type: minor
   :phase: beta
@@ -2510,7 +2478,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:59+00:00'
   :public_updated_at: '2015-11-04T12:08:59+00:00'
   :update_type: minor
   :phase: beta
@@ -2569,7 +2536,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:59+00:00'
   :public_updated_at: '2015-11-04T12:08:59+00:00'
   :update_type: minor
   :phase: beta
@@ -2621,7 +2587,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:59+00:00'
   :public_updated_at: '2015-11-04T12:08:59+00:00'
   :update_type: minor
   :phase: beta
@@ -2718,7 +2683,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:59+00:00'
   :public_updated_at: '2015-11-04T12:08:59+00:00'
   :update_type: minor
   :phase: beta
@@ -2798,7 +2762,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:59+00:00'
   :public_updated_at: '2015-11-04T12:08:59+00:00'
   :update_type: minor
   :phase: beta
@@ -2873,7 +2836,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:00+00:00'
   :public_updated_at: '2015-11-04T12:09:00+00:00'
   :update_type: minor
   :phase: beta
@@ -2982,7 +2944,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:00+00:00'
   :public_updated_at: '2015-11-04T12:09:00+00:00'
   :update_type: minor
   :phase: beta
@@ -3075,7 +3036,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:00+00:00'
   :public_updated_at: '2015-11-04T12:09:00+00:00'
   :update_type: minor
   :phase: beta
@@ -3150,7 +3110,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:00+00:00'
   :public_updated_at: '2015-11-04T12:09:00+00:00'
   :update_type: minor
   :phase: beta
@@ -3190,7 +3149,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:00+00:00'
   :public_updated_at: '2015-11-04T12:09:00+00:00'
   :update_type: minor
   :phase: beta
@@ -3299,7 +3257,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:01+00:00'
   :public_updated_at: '2015-11-04T12:09:01+00:00'
   :update_type: minor
   :phase: beta
@@ -3465,7 +3422,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:01+00:00'
   :public_updated_at: '2015-11-04T12:09:01+00:00'
   :update_type: minor
   :phase: beta
@@ -3529,7 +3485,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:01+00:00'
   :public_updated_at: '2015-11-04T12:09:01+00:00'
   :update_type: minor
   :phase: beta
@@ -3615,7 +3570,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:01+00:00'
   :public_updated_at: '2015-11-04T12:09:01+00:00'
   :update_type: minor
   :phase: beta
@@ -3725,7 +3679,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:01+00:00'
   :public_updated_at: '2015-11-04T12:09:01+00:00'
   :update_type: minor
   :phase: beta
@@ -3791,7 +3744,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:01+00:00'
   :public_updated_at: '2015-11-04T12:09:01+00:00'
   :update_type: minor
   :phase: beta
@@ -3863,7 +3815,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:02+00:00'
   :public_updated_at: '2015-11-04T12:09:02+00:00'
   :update_type: minor
   :phase: beta
@@ -3974,7 +3925,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:02+00:00'
   :public_updated_at: '2015-11-04T12:09:02+00:00'
   :update_type: minor
   :phase: beta
@@ -4056,7 +4006,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:02+00:00'
   :public_updated_at: '2015-11-04T12:09:02+00:00'
   :update_type: minor
   :phase: beta
@@ -4112,7 +4061,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:02+00:00'
   :public_updated_at: '2015-11-04T12:09:02+00:00'
   :update_type: minor
   :phase: beta
@@ -4184,7 +4132,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:02+00:00'
   :public_updated_at: '2015-11-04T12:09:02+00:00'
   :update_type: minor
   :phase: beta
@@ -4224,7 +4171,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:02+00:00'
   :public_updated_at: '2015-11-04T12:09:02+00:00'
   :update_type: minor
   :phase: beta
@@ -4273,7 +4219,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:02+00:00'
   :public_updated_at: '2015-11-04T12:09:02+00:00'
   :update_type: minor
   :phase: beta
@@ -4313,7 +4258,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:03+00:00'
   :public_updated_at: '2015-11-04T12:09:03+00:00'
   :update_type: minor
   :phase: beta
@@ -4371,7 +4315,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:03+00:00'
   :public_updated_at: '2015-11-04T12:09:03+00:00'
   :update_type: minor
   :phase: beta
@@ -4421,7 +4364,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:03+00:00'
   :public_updated_at: '2015-11-04T12:09:03+00:00'
   :update_type: minor
   :phase: beta
@@ -4473,7 +4415,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:03+00:00'
   :public_updated_at: '2015-11-04T12:09:03+00:00'
   :update_type: minor
   :phase: beta
@@ -4511,7 +4452,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:03+00:00'
   :public_updated_at: '2015-11-04T12:09:03+00:00'
   :update_type: minor
   :phase: beta
@@ -4590,7 +4530,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:03+00:00'
   :public_updated_at: '2015-11-04T12:09:03+00:00'
   :update_type: minor
   :phase: beta
@@ -4646,7 +4585,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:03+00:00'
   :public_updated_at: '2015-11-04T12:09:03+00:00'
   :update_type: minor
   :phase: beta
@@ -4707,7 +4645,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:04+00:00'
   :public_updated_at: '2015-11-04T12:09:04+00:00'
   :update_type: minor
   :phase: beta
@@ -4802,7 +4739,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:04+00:00'
   :public_updated_at: '2015-11-04T12:09:04+00:00'
   :update_type: minor
   :phase: beta
@@ -4876,7 +4812,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:04+00:00'
   :public_updated_at: '2015-11-04T12:09:04+00:00'
   :update_type: minor
   :phase: beta
@@ -4923,7 +4858,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:04+00:00'
   :public_updated_at: '2015-11-04T12:09:04+00:00'
   :update_type: minor
   :phase: beta
@@ -5018,7 +4952,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:04+00:00'
   :public_updated_at: '2015-11-04T12:09:04+00:00'
   :update_type: minor
   :phase: beta
@@ -5071,7 +5004,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:04+00:00'
   :public_updated_at: '2015-11-04T12:09:04+00:00'
   :update_type: minor
   :phase: beta
@@ -5107,7 +5039,6 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:05+00:00'
   :public_updated_at: '2015-11-04T12:09:05+00:00'
   :update_type: minor
   :phase: beta

--- a/lib/tasks_data/section_hierarchy.yml
+++ b/lib/tasks_data/section_hierarchy.yml
@@ -1,0 +1,361 @@
+---
+- :content_id: ab9f43be-0ea9-4a60-a8af-96b7ee349d2b
+  :title: Agile delivery
+  :base_path: "/service-manual/agile-delivery"
+  :description: Agile methods and tools explained, including what assurance and reporting
+    to use.
+  :format: service_manual_section
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:52+00:00'
+  :public_updated_at: '2015-11-04T12:08:52+00:00'
+  :details:
+    :link_groups:
+    - :title: Agile and government services
+      :description: Why use agile methodology, features of agile, signs of not being
+        agile.
+      :linked_items:
+      - c28c2fbf-86f6-4bfb-adaa-1dd20f0a0429
+      - 1a76a03c-4298-459c-827e-38497203e467
+      - ab7f03c6-ec30-4a14-84ed-cffabdd3e075
+    - :title: Agile methods
+      :description: Agile ceremonies for planning and reviewing work, including user
+        stories and retrospectives.
+      :linked_items:
+      - 45eb482c-5328-484b-93d8-684fd87e434e
+      - adcff8ab-c40d-4f23-b831-f03c35e7a8b0
+      - 8adca8f7-203d-4147-97cd-c1361c8988bf
+      - 9351e0c3-d921-42f6-bb6c-8c8972eec845
+      - b202dea8-bdf0-4f1a-a0c0-4b993dbeef9d
+      - 514a2199-8f93-448b-a21f-0866590ccac1
+      - 9ce4c8aa-742a-4852-a523-7134fedcc65b
+      - 6adf9af0-7897-466b-a1ba-589488ecc1fe
+    - :title: Governing an agile service
+      :description: Assurance, funding and reporting for services.
+      :linked_items:
+      - 899cae02-1648-4e1b-b5cb-61da8263130a
+      - e14067c4-088b-4cf8-9530-ff6d78e6998e
+      - 66e30ed2-f1a4-4cdc-b8ae-8add35e245aa
+    - :title: Learn more about agile
+      :description: Training courses you can book.
+      :linked_items:
+      - 0f9899fb-1802-4073-a830-43eaf8e44f9f
+      - 5a8a1f7f-ad9e-4e6a-aa67-7614eebafd4a
+      - 261807d1-29bb-4e51-9c3e-a69baccb4525
+      - 0a37bae2-e1e9-4c9a-ba2a-0c01e44fabc4
+  :links:
+    :linked_items:
+    - c28c2fbf-86f6-4bfb-adaa-1dd20f0a0429
+    - 1a76a03c-4298-459c-827e-38497203e467
+    - ab7f03c6-ec30-4a14-84ed-cffabdd3e075
+    - 45eb482c-5328-484b-93d8-684fd87e434e
+    - adcff8ab-c40d-4f23-b831-f03c35e7a8b0
+    - 8adca8f7-203d-4147-97cd-c1361c8988bf
+    - 9351e0c3-d921-42f6-bb6c-8c8972eec845
+    - b202dea8-bdf0-4f1a-a0c0-4b993dbeef9d
+    - 514a2199-8f93-448b-a21f-0866590ccac1
+    - 9ce4c8aa-742a-4852-a523-7134fedcc65b
+    - 6adf9af0-7897-466b-a1ba-589488ecc1fe
+    - 899cae02-1648-4e1b-b5cb-61da8263130a
+    - e14067c4-088b-4cf8-9530-ff6d78e6998e
+    - 66e30ed2-f1a4-4cdc-b8ae-8add35e245aa
+    - 0f9899fb-1802-4073-a830-43eaf8e44f9f
+    - 5a8a1f7f-ad9e-4e6a-aa67-7614eebafd4a
+    - 261807d1-29bb-4e51-9c3e-a69baccb4525
+    - 0a37bae2-e1e9-4c9a-ba2a-0c01e44fabc4
+  :routes:
+  - :type: exact
+    :path: "/service-manual/agile-delivery"
+- :content_id: 7ed34986-239d-4ef3-aff7-b90270bd26c6
+  :title: Designing services
+  :base_path: "/service-manual/designing-services"
+  :description: How to turn user research into simple, clear services, including resources
+    for designers and content designers.
+  :format: service_manual_section
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:55+00:00'
+  :public_updated_at: '2015-11-04T12:08:55+00:00'
+  :details:
+    :link_groups: []
+  :links:
+    :linked_items: []
+  :routes:
+  - :type: exact
+    :path: "/service-manual/designing-services"
+- :content_id: b8fd6bf5-16a3-455a-8bea-d7e38a261238
+  :title: Funding and procurement
+  :base_path: "/service-manual/funding-and-procurement"
+  :description: How to get money, buy things and use the Digital Marketplace.
+  :format: service_manual_section
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:55+00:00'
+  :public_updated_at: '2015-11-04T12:08:55+00:00'
+  :details:
+    :link_groups: []
+  :links:
+    :linked_items: []
+  :routes:
+  - :type: exact
+    :path: "/service-manual/funding-and-procurement"
+- :content_id: 6dc28a8b-37f0-4fd1-8eef-68989e2bb779
+  :title: Measuring success
+  :base_path: "/service-manual/measuring-success"
+  :description: What key performance indicators to measure and how, includes getting
+    on the Performance Platform.
+  :format: service_manual_section
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:55+00:00'
+  :public_updated_at: '2015-11-04T12:08:55+00:00'
+  :details:
+    :link_groups: []
+  :links:
+    :linked_items: []
+  :routes:
+  - :type: exact
+    :path: "/service-manual/measuring-success"
+- :content_id: 8d723356-25df-4880-9156-1821c2a53674
+  :title: Service phases and assessments
+  :base_path: "/service-manual/service-phases-and-assessments"
+  :description: What your service will be assessed on and what the team needs to do
+    at each phase, and how to book an assessment.
+  :format: service_manual_section
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:55+00:00'
+  :public_updated_at: '2015-11-04T12:08:55+00:00'
+  :details:
+    :link_groups:
+    - :title: Discovery phase
+      :description: Includes preparing for discovery, the team, outputs and governing
+        the team.
+      :linked_items: []
+    - :title: Alpha phase
+      :description: Includes what you’ll be doing, outputs and governing the team.
+      :linked_items: []
+    - :title: Beta phase
+      :description: Includes the team, public and private beta, outputs and governing
+        the team.
+      :linked_items: []
+    - :title: Live phase
+      :description: Preparing to go live and what to do when a service is live.
+      :linked_items: []
+    - :title: Retirement phase
+      :description: What you need to do to retire a service, including redirects,
+        communicating change and managing data.
+      :linked_items: []
+    - :title: Service assessments
+      :description: How and why services are assessed, includes how to book and prepare
+        for an assessment.
+      :linked_items:
+      - 2c3dd929-e410-480f-a14a-e172c187ab4c
+      - 1c3f9fa3-3a19-4cc7-b9e6-648cf4fb9adb
+      - 89838854-ee86-4018-9802-f59dd2166d23
+      - 60d2f9d5-b25c-4f71-9624-4ec13c3ddf98
+  :links:
+    :linked_items:
+    - 2c3dd929-e410-480f-a14a-e172c187ab4c
+    - 1c3f9fa3-3a19-4cc7-b9e6-648cf4fb9adb
+    - 89838854-ee86-4018-9802-f59dd2166d23
+    - 60d2f9d5-b25c-4f71-9624-4ec13c3ddf98
+  :routes:
+  - :type: exact
+    :path: "/service-manual/service-phases-and-assessments"
+- :content_id: 6ef6df68-7824-4856-866c-3e6f8f449dd1
+  :title: The team
+  :base_path: "/service-manual/the-team"
+  :description: What roles you need and how to recruit them, including job descriptions
+    and training.
+  :format: service_manual_section
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:08:57+00:00'
+  :public_updated_at: '2015-11-04T12:08:57+00:00'
+  :details:
+    :link_groups:
+    - :title: Getting a team for each delivery phase
+      :description: Setting up a team, recruiting people, and changing the size of
+        the team, includes job descriptions.
+      :linked_items:
+      - 86fd6b62-5d50-433c-a656-cb5f14688926
+      - 62b23226-7ed9-41df-8be3-9420c2c57d22
+      - bde2ed45-898d-4a55-9b26-a38d61be97cf
+    - :title: Roles in a service team
+      :description: The different roles you need to build a service.
+      :linked_items:
+      - cd98eebb-98ed-4119-a931-3abd56e2577d
+      - ee461709-05c4-4f61-b4e7-a54c9db028ff
+      - 415ffa6c-734e-4c15-8425-49e1a8b6c63e
+      - 88bf8754-b3b8-4ed2-b87c-7d922cbaa1db
+      - 12b40ea4-4a45-4058-8ddd-8125c23b3059
+      - 7a2bd696-fccc-45b2-8212-df31669ff051
+      - acc4eec2-8a8d-4f62-9082-10bd07dc524d
+      - 898bacec-43a9-413b-9d2e-6b7a36c7b36c
+      - 3a7bc265-f524-4f4f-a741-012607ac3a66
+      - 7f5d3479-2c0b-43f3-bf75-d6c319f4680d
+      - 67b66612-5d06-4b92-8003-25c718cb6ebc
+    - :title: Managing a service team
+      :description: Running one or more teams, and working with external suppliers.
+      :linked_items:
+      - d49769c9-4713-47eb-a7cf-f675d5521b21
+      - 6f61860e-6ca3-465f-a605-8c0684c3f41c
+  :links:
+    :linked_items:
+    - 86fd6b62-5d50-433c-a656-cb5f14688926
+    - 62b23226-7ed9-41df-8be3-9420c2c57d22
+    - bde2ed45-898d-4a55-9b26-a38d61be97cf
+    - cd98eebb-98ed-4119-a931-3abd56e2577d
+    - ee461709-05c4-4f61-b4e7-a54c9db028ff
+    - 415ffa6c-734e-4c15-8425-49e1a8b6c63e
+    - 88bf8754-b3b8-4ed2-b87c-7d922cbaa1db
+    - 12b40ea4-4a45-4058-8ddd-8125c23b3059
+    - 7a2bd696-fccc-45b2-8212-df31669ff051
+    - acc4eec2-8a8d-4f62-9082-10bd07dc524d
+    - 898bacec-43a9-413b-9d2e-6b7a36c7b36c
+    - 3a7bc265-f524-4f4f-a741-012607ac3a66
+    - 7f5d3479-2c0b-43f3-bf75-d6c319f4680d
+    - 67b66612-5d06-4b92-8003-25c718cb6ebc
+    - d49769c9-4713-47eb-a7cf-f675d5521b21
+    - 6f61860e-6ca3-465f-a605-8c0684c3f41c
+  :routes:
+  - :type: exact
+    :path: "/service-manual/the-team"
+- :content_id: e13de701-c6a5-495b-a302-99d6ee68b0e6
+  :title: Technical development
+  :base_path: "/service-manual/technical-development"
+  :description: How to build or buy systems and software that are secure, sustainable
+    and cost-effective.
+  :format: service_manual_section
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:00+00:00'
+  :public_updated_at: '2015-11-04T12:09:00+00:00'
+  :details:
+    :link_groups: []
+  :links:
+    :linked_items: []
+  :routes:
+  - :type: exact
+    :path: "/service-manual/technical-development"
+- :content_id: d56a2861-eef4-43be-91d2-17a279d6e8b9
+  :title: User research
+  :base_path: "/service-manual/user-research"
+  :description: How to understand what users need and improve your service through
+    continuous research.
+  :format: service_manual_section
+  :publishing_app: service-manual-publisher
+  :rendering_app: government-frontend
+  :need_ids: []
+  :locale: en
+  :updated_at: '2015-11-04T12:09:00+00:00'
+  :public_updated_at: '2015-11-04T12:09:00+00:00'
+  :details:
+    :link_groups:
+    - :title: Understand user needs
+      :description: Researching and writing user needs, and how the team should use
+        them.
+      :linked_items:
+      - 97044d4d-8617-459f-baa7-a037e2d3b7ea
+      - 8c691bd4-1e88-47f4-9cc6-ee7880eacf2d
+      - 68f516ff-ccf1-492e-b7a1-560ce661ffe4
+    - :title: Research at each service phase
+      :description: Research during discovery, alpha, beta and live.
+      :linked_items:
+      - 9678a226-e468-46f2-8be0-b423ce9d35f4
+      - 5406c1cc-7675-49e6-ac60-683219b664f1
+      - e8e5f4d3-1ab0-483d-a9c1-aa11b9e4f8cd
+    - :title: Planning your research
+      :description: Preparing to do research, includes finding participants and writing
+        discussion guides.
+      :linked_items:
+      - ab39d64d-36ee-418a-9901-0cd0a64ecdb3
+      - b11f36fb-1ac1-49d2-b1eb-5450f4b449e8
+      - 6f9fc994-1bc2-4593-a649-33c70dcf4250
+      - d2f7142d-89f8-412d-8667-07bb3fe1a91c
+      - 8b023b9c-c406-4d0a-8938-3eebe7dc41a7
+      - 409db78e-79c5-4e32-b8d1-22ce916d69c2
+      - 5107f397-5c1b-42cf-80db-3de2e2ad5706
+    - :title: During a session
+      :description: How to run a research session, includes observing and note taking.
+      :linked_items:
+      - d47933d7-597e-47d5-8196-6a35ec977b3b
+      - d4a0acde-e6f6-4a75-b422-0f9841dcc215
+      - ef45ad6d-0faa-498a-92ca-c6bb15252e66
+      - 9c635477-ee26-48c7-9e1d-889fb19d53af
+    - :title: Using what you found out
+      :description: Analysing research and sharing it with your team, includes user
+        journey mapping and personas.
+      :linked_items:
+      - b41c25fd-ed1c-4cc2-a11e-c7833c325920
+      - 4d17aff7-2674-40b1-8695-3cb0798a4f8b
+      - ad43e6eb-c833-414c-83e5-0d502ff9058f
+      - 567d2b80-8c13-4ba6-9f94-b3899c5ca1a6
+    - :title: User research methods
+      :description: Different types of research, includes pop-up research and A/B
+        testing.
+      :linked_items:
+      - 36d0f499-5cc4-47ce-82dd-459420e2732a
+      - d53a190a-bfff-41ee-94a3-67bdfb10e2a9
+      - 99324e0f-3612-428b-bd46-6ac0f874e89c
+      - 3d7ca14c-8ea9-48d2-bbe5-071d4abcfdc5
+      - 89820b97-bfe1-4469-ac31-7916b0b4c1cd
+      - 07d6773d-4be0-4253-ae1f-68891c1738a5
+      - 03651843-cc3a-4332-8ab7-577b2c5fc34f
+      - 84b4ce86-bf82-42eb-8137-148709a1c8fb
+    - :title: Learn more about user research
+      :description: Training courses, books, blogs and videos.
+      :linked_items:
+      - fbfd6573-6cb7-4489-8212-8926e6308f1a
+      - 7582685a-1791-4c1c-b9ab-6ccb7e1d9c73
+  :links:
+    :linked_items:
+    - 97044d4d-8617-459f-baa7-a037e2d3b7ea
+    - 8c691bd4-1e88-47f4-9cc6-ee7880eacf2d
+    - 68f516ff-ccf1-492e-b7a1-560ce661ffe4
+    - 9678a226-e468-46f2-8be0-b423ce9d35f4
+    - 5406c1cc-7675-49e6-ac60-683219b664f1
+    - e8e5f4d3-1ab0-483d-a9c1-aa11b9e4f8cd
+    - ab39d64d-36ee-418a-9901-0cd0a64ecdb3
+    - b11f36fb-1ac1-49d2-b1eb-5450f4b449e8
+    - 6f9fc994-1bc2-4593-a649-33c70dcf4250
+    - d2f7142d-89f8-412d-8667-07bb3fe1a91c
+    - 8b023b9c-c406-4d0a-8938-3eebe7dc41a7
+    - 409db78e-79c5-4e32-b8d1-22ce916d69c2
+    - 5107f397-5c1b-42cf-80db-3de2e2ad5706
+    - d47933d7-597e-47d5-8196-6a35ec977b3b
+    - d4a0acde-e6f6-4a75-b422-0f9841dcc215
+    - ef45ad6d-0faa-498a-92ca-c6bb15252e66
+    - 9c635477-ee26-48c7-9e1d-889fb19d53af
+    - b41c25fd-ed1c-4cc2-a11e-c7833c325920
+    - 4d17aff7-2674-40b1-8695-3cb0798a4f8b
+    - ad43e6eb-c833-414c-83e5-0d502ff9058f
+    - 567d2b80-8c13-4ba6-9f94-b3899c5ca1a6
+    - 36d0f499-5cc4-47ce-82dd-459420e2732a
+    - d53a190a-bfff-41ee-94a3-67bdfb10e2a9
+    - 99324e0f-3612-428b-bd46-6ac0f874e89c
+    - 3d7ca14c-8ea9-48d2-bbe5-071d4abcfdc5
+    - 89820b97-bfe1-4469-ac31-7916b0b4c1cd
+    - 07d6773d-4be0-4253-ae1f-68891c1738a5
+    - 03651843-cc3a-4332-8ab7-577b2c5fc34f
+    - 84b4ce86-bf82-42eb-8137-148709a1c8fb
+    - fbfd6573-6cb7-4489-8212-8926e6308f1a
+    - 7582685a-1791-4c1c-b9ab-6ccb7e1d9c73
+  :routes:
+  - :type: exact
+    :path: "/service-manual/user-research"

--- a/lib/tasks_data/section_hierarchy.yml
+++ b/lib/tasks_data/section_hierarchy.yml
@@ -9,7 +9,7 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:52+00:00'
+  :update_type: 'minor'
   :public_updated_at: '2015-11-04T12:08:52+00:00'
   :details:
     :link_groups:
@@ -78,7 +78,7 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:55+00:00'
+  :update_type: 'minor'
   :public_updated_at: '2015-11-04T12:08:55+00:00'
   :details:
     :link_groups: []
@@ -96,7 +96,7 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:55+00:00'
+  :update_type: 'minor'
   :public_updated_at: '2015-11-04T12:08:55+00:00'
   :details:
     :link_groups: []
@@ -115,7 +115,7 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:55+00:00'
+  :update_type: 'minor'
   :public_updated_at: '2015-11-04T12:08:55+00:00'
   :details:
     :link_groups: []
@@ -134,7 +134,7 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:55+00:00'
+  :update_type: 'minor'
   :public_updated_at: '2015-11-04T12:08:55+00:00'
   :details:
     :link_groups:
@@ -183,7 +183,7 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:08:57+00:00'
+  :update_type: 'minor'
   :public_updated_at: '2015-11-04T12:08:57+00:00'
   :details:
     :link_groups:
@@ -244,7 +244,7 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:00+00:00'
+  :update_type: 'minor'
   :public_updated_at: '2015-11-04T12:09:00+00:00'
   :details:
     :link_groups: []
@@ -263,7 +263,7 @@
   :rendering_app: government-frontend
   :need_ids: []
   :locale: en
-  :updated_at: '2015-11-04T12:09:00+00:00'
+  :update_type: 'minor'
   :public_updated_at: '2015-11-04T12:09:00+00:00'
   :details:
     :link_groups:


### PR DESCRIPTION
:warning: Don't merge, this is for discussion only

Since we can't use any existing publishers for Service Manual Section pages ([an example of a section page](http://sm-11.herokuapp.com/agile-delivery/)) and don't want to build our own just yet, I suggest we use a rake task that publishes a hardcoded Service Manual Section payloads. This spike is intended as a proof of concept. There are two YAML files produced by scraping http://sm-11.herokuapp.com: one with a list of Guide payloads, and one with a list of Section page payloads. 

Interesting points:

- It does not have any data that deals with breadcrumbs, publishing platform
  team is working on it.
- It is using links hash with content IDs alongside `details -> link_groups  -> linked items`,
  the former allows the front-end to get all required info about linked items (title, href) and the later is used for grouping the linked items.
- Guides are scraped just to have some real content to link to from the Section pages: guides are not persisted locally, their bodies are HTML, not GOVSPEAK, there are no sidebar links etc but it is all irrelevant as we'll have real Guide pages saved when we do the real thing :)
- It posts links alongside content. In v2 APIs linking/tagging is a separate step so the process in real application would involve more steps.

The remaining part of this spike that renders this data in the front end is here:
https://github.com/alphagov/government-frontend/compare/service_manual_section_spike

## How to try this out locally

```
cd government-frontend
git checkout service_manual_section_spike
cd service-manual-publisher
git pull --rebase
git checkout section_hierarchy_spike
# run/restart both apps
rake hierarchy_spike:publish_guides
rake hierarchy_spike:publish_sections
```

Now you should be able to visit section and guide pages that just got published. Their base paths correspond to the ones in http://sm-11.herokuapp.com, but start with http://government-frontend.dev.gov.uk/service-manual i.e. to see [Agile Delivery](sm-11.herokuapp.com/agile-delivery) equivalent, visit http://government-frontend.dev.gov.uk/service-manual/agile-delivery

## The way this could work

Once we have a section with a few content items we're happy to publish in the publisher app, we could create a rake task similar to the one proposed here that would know which persisted content guides fall under which section. Based on hardcoded base_paths or titles it would fetch content IDs from either a local database or content store and compile a Service Manual Section payload that could then be published via the publishing-api. 

In order to make changes in the hierarchy we'd need to update the rake task in git, deploy and re-run it, but it should be ok for initial stages.

