### PR TITLE
Editors can leave a change note on editions

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,15 @@
+// This is a manifest file that'll be compiled into application.js, which will include all the files
+// listed below.
+//
+// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, vendor/assets/javascripts,
+// or any plugin's vendor/assets/javascripts directory can be referenced here using a relative path.
+//
+// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
+// compiled file.
+//
+// Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
+// about supported directives.
+//
+//= require jquery
+//= require jquery_ujs
+//= require_tree .

--- a/app/assets/javascripts/guide.js
+++ b/app/assets/javascripts/guide.js
@@ -1,0 +1,15 @@
+$(function() {
+  $(".update-type-select").change(toggleChangeNote);
+  toggleChangeNote();
+});
+
+function toggleChangeNote() {
+  var value = $(".update-type-select").val();
+  var changeNote = $(".change-note-form-group");
+
+  if (value == "major") {
+    changeNote.show();
+  } else {
+    changeNote.hide();
+  }
+}

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -17,8 +17,15 @@ class Edition < ActiveRecord::Base
 
   validates_presence_of [:state, :phase, :description, :title, :update_type, :body, :publisher_title, :publisher_href, :user]
   validates_inclusion_of :state, in: %w(draft published review_requested approved)
+  validates :change_note, presence: true, if: :major?
 
   before_validation :assign_publisher_href
+
+  %w{minor major}.each do |s|
+    define_method "#{s}?" do
+      update_type == s
+    end
+  end
 
   def draft?
     state == 'draft'

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -9,7 +9,7 @@ class Guide < ActiveRecord::Base
   has_many :editions
   has_one :latest_edition, -> { order(created_at: :desc) }, class_name: "Edition"
 
-  accepts_nested_attributes_for :latest_edition
+  accepts_nested_attributes_for :editions
 
   before_validation on: :create do |object|
     object.content_id = SecureRandom.uuid

--- a/app/models/guide_publisher.rb
+++ b/app/models/guide_publisher.rb
@@ -8,6 +8,9 @@ class GuidePublisher
   def process
     publishing_api = GdsApi::PublishingApiV2.new(Plek.new.find('publishing-api'))
 
+    if @guide.persisted?
+      @guide.reload
+    end
     latest_edition = @guide.latest_edition
 
     data = GuidePresenter.new(@guide, latest_edition).exportable_attributes

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -5,16 +5,18 @@
 
 <div class='well'>
   <%= form_for guide do |f| %>
-    <fieldset class='meta'>
-      <legend>Meta</legend>
+    <fieldset class='guide'>
+      <legend>Guide</legend>
       <div class='form-group'>
         <%= f.label :slug  %>
         <%= f.error_list :slug  %>
         <%= f.text_field :slug, class: 'input-md-12 form-control' %>
       </div>
+    </fieldset>
 
-      <%= f.fields_for :latest_edition do |editions_form| %>
-
+    <%= f.fields_for :editions, guide.latest_edition do |editions_form| %>
+      <fieldset class='meta'>
+        <legend>Meta</legend>
         <div class='form-group'>
           <%= editions_form.label :related_discussion_title %>
           <%= editions_form.error_list :related_discussion_title %>
@@ -44,12 +46,11 @@
           <%= editions_form.error_list :description %>
           <%= editions_form.text_area :description, rows: 4, class: 'input-md-12 form-control' %>
         </div>
-      <% end %>
-    </fieldset>
+
+      </fieldset>
 
     <fieldset class='inputs'>
       <legend>Content</legend>
-      <%= f.fields_for :latest_edition do |editions_form| %>
         <div class="form-group">
           <%= editions_form.label :title %>
           <%= editions_form.error_list :title %>
@@ -60,28 +61,33 @@
           <%= editions_form.error_list :body %>
           <%= editions_form.text_area :body, class: 'input-md-12 form-control', rows: 14 %>
         </div>
-      <% end %>
-
     </fieldset>
+
 
     <fieldset class='update'>
+      <legend>Content</legend>
       <div class='form-group'>
-        <%= f.fields_for :latest_edition do |editions_form| %>
-          <div class='form-group'>
-            <%= editions_form.label :update_type %>
-            <%= editions_form.error_list :update_type %>
-            <%= editions_form.select :update_type, [["Major", "major"], ["Minor", "minor"], ["Republish", "republish"]], include_blank: true, class: 'input-md-12 form-control' %>
-          </div>
-        <% end %>
+        <%= editions_form.label :update_type %>
+        <%= editions_form.error_list :update_type %>
+        <%= editions_form.select :update_type, [["Major", "major"], ["Minor", "minor"]], {}, {class: 'update-type-select input-md-12 form-control'} %>
       </div>
-      <div class='form-group'>
-        <%= f.submit "Save Draft", class: 'btn btn-success', name: :save_draft, data: disable_if_new_record(guide) %>
-        <%= f.submit "Save Draft and Preview", class: 'btn btn-default', name: :save_draft_and_preview, data: disable_if_new_record(guide) %>
-        <% if guide.latest_edition.present? && guide.latest_edition.approved? %>
-          <%= f.submit "Publish", class: 'btn btn-success', name: :publish %>
-        <% end %>
+      <div class="form-group change-note-form-group">
+        <%= editions_form.label :change_note %>
+        <%= editions_form.text_area :change_note, class: 'input-md-12 form-control', rows: 5 %>
       </div>
     </fieldset>
+
+      <fieldset class='publication'>
+        <legend>Publication</legend>
+        <div class='form-group'>
+          <%= f.submit "Save Draft", class: 'btn btn-success', name: :save_draft, data: disable_if_new_record(guide) %>
+          <%= f.submit "Save Draft and Preview", class: 'btn btn-default', name: :save_draft_and_preview, data: disable_if_new_record(guide) %>
+          <% if guide.latest_edition.present? && guide.latest_edition.approved? %>
+            <%= f.submit "Publish", class: 'btn btn-success', name: :publish %>
+          <% end %>
+        </div>
+      </fieldset>
+    <% end %>
   <% end %>
 
   <% if guide.can_request_review? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,7 @@
 <%# blocks for govuk_admin_template %>
 <% content_for :head do %>
   <%= stylesheet_link_tag "application", media: "all" %>
+  <%= javascript_include_tag "application" %>
   <%= csrf_meta_tag %>
 <% end %>
 <% content_for :app_title do %>GOV.UK Service Manual Publisher<% end %>

--- a/db/migrate/20151105142126_add_change_note_to_editions.rb
+++ b/db/migrate/20151105142126_add_change_note_to_editions.rb
@@ -1,0 +1,5 @@
+class AddChangeNoteToEditions < ActiveRecord::Migration
+  def change
+    add_column :editions, :change_note, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151103120443) do
+ActiveRecord::Schema.define(version: 20151105142126) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 20151103120443) do
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
     t.text     "state"
+    t.text     "change_note"
   end
 
   create_table "guides", force: :cascade do |t|

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe "creating guides", type: :feature do
     expect(edition.phase).to eq "beta"
     expect(edition.title).to eq "First Edition Title"
     expect(edition.body).to eq "## First Edition Title"
-    expect(edition.update_type).to eq "minor"
+    expect(edition.update_type).to eq "major"
+    expect(edition.change_note).to eq "Change Note"
     expect(edition.draft?).to eq true
     expect(edition.published?).to eq false
 
@@ -67,7 +68,7 @@ RSpec.describe "creating guides", type: :feature do
                             .with(an_instance_of(String), be_valid_against_schema('service_manual_guide'))
     expect(api_double).to receive(:publish)
                             .once
-                            .with(an_instance_of(String), 'minor')
+                            .with(an_instance_of(String), 'major')
 
     click_button "Save Draft"
     guide = Guide.first
@@ -189,6 +190,7 @@ private
     fill_in "Title", with: "First Edition Title"
     fill_in "Body", with: "## First Edition Title"
 
-    select "Minor", from: "Update type"
+    select "Major", from: "Update type"
+    fill_in "Change note", with: "Change Note"
   end
 end

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -28,5 +28,17 @@ RSpec.describe Edition, type: :model do
       edition.valid?
       expect(edition.errors.full_messages_for(:state).size).to eq 1
     end
+
+    it "does not allow empty change_note when the update_type is 'major'" do
+      edition = Generators.valid_edition(update_type: "major", change_note: "")
+      edition.valid?
+      expect(edition.errors.full_messages_for(:change_note)).to eq ["Change note can't be blank"]
+    end
+
+    it "allows empty change_note when the update_type is 'minor'" do
+      edition = Generators.valid_edition(update_type: "minor", change_note: "")
+      edition.valid?
+      expect(edition.errors.full_messages_for(:change_note).size).to eq 0
+    end
   end
 end

--- a/spec/support/generators.rb
+++ b/spec/support/generators.rb
@@ -6,6 +6,7 @@ class Generators
       phase:           "beta",
       description:     "Description",
       update_type:     "major",
+      change_note:     "change note",
       body:            "# Heading",
       publisher_title: Edition::PUBLISHERS.keys.first,
       user:            User.new(name: "Generated User")


### PR DESCRIPTION
```
As someone working on a government service
I want to know what has changed and why
So that I can see if it is relevant to me/understand more about I need to do
```

Provide a summary of what has changed and why.

- If a user selects a 'major change' then a change note field is shown. (either on a new edition or a new draft).
- Change notes are a mandatory field.
- New drafts have change notes

Also:

- Move all edition fields into one #fields_for (was getting a bit
unwieldy).
- Stop using `fields_for :latest_edition`, instead use `fields_for :editions` because latest_edition was acting inconsistently with the has_one association.
- Remove the "Republish" and empty options from `update_type`, as
  they're not in the spec.