### PR TITLE
Use /tmp for db:seed script

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,12 +1,14 @@
 if Rails.env.development?
-  unless Dir.exist?("../government-service-design-manual")
+  directory = File.join(Dir.mktmpdir("government-service-design-manual"), "git")
+  unless Dir.exist?(directory)
     print "Cloning repository..."
-    sh "cd ../ && git clone https://github.com/alphagov/government-service-design-manual"
+    sh "git clone https://github.com/alphagov/government-service-design-manual #{directory}"
     puts " [done]"
   end
-  objects = Dir.glob("../government-service-design-manual/service-manual/**/*.md")
+
+  objects = Dir.glob("#{directory}/service-manual/**/*.md")
   .map do |path|
-    url = path.gsub("../government-service-design-manual", "")
+    url = path.gsub(directory, "")
     url = url.gsub(".md", "")
     url = url.gsub(/\/index$/, '')
     {


### PR DESCRIPTION
We're going to be running this script in a preview environment, so it
would be safer if we only used tmp directories. We don't want to
overwrite anything.
