### PR TITLE
Set phase for guide editions to 'alpha' by default

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -85,7 +85,6 @@ private
         :body,
         :description,
         :publisher_title,
-        :phase,
         :related_discussion_href,
         :related_discussion_title,
         :update_type,

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -31,12 +31,6 @@
         </div>
 
         <div class='form-group'>
-          <%= editions_form.label :phase %>
-          <%= editions_form.error_list :phase %>
-          <%= editions_form.select :phase, [['Alpha', 'alpha'], ['Beta', 'beta'], ['Live', 'live']], class: 'input-md-12 form-control' %>
-        </div>
-
-        <div class='form-group'>
           <%= editions_form.label :description %>
           <%= editions_form.error_list :description %>
           <%= editions_form.text_area :description, rows: 4, class: 'input-md-12 form-control' %>

--- a/db/migrate/20151110135512_set_default_phase.rb
+++ b/db/migrate/20151110135512_set_default_phase.rb
@@ -1,0 +1,5 @@
+class SetDefaultPhase < ActiveRecord::Migration
+  def change
+    change_column :editions, :phase, :text, default: 'alpha'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151105142126) do
+ActiveRecord::Schema.define(version: 20151110135512) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,13 +42,13 @@ ActiveRecord::Schema.define(version: 20151105142126) do
     t.text     "description"
     t.text     "body"
     t.string   "update_type"
-    t.string   "phase"
+    t.text     "phase",                    default: "alpha"
     t.text     "publisher_title"
     t.text     "publisher_href"
     t.text     "related_discussion_href"
     t.text     "related_discussion_title"
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
+    t.datetime "created_at",                                 null: false
+    t.datetime "updated_at",                                 null: false
     t.text     "state"
     t.text     "change_note"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -43,7 +43,7 @@ if Rails.env.development? || ENV["GOVUK_APP_DOMAIN"] == "preview.alphagov.co.uk"
       edition = Edition.new(
         title:           title,
         state:           state.present? ? state : "draft",
-        phase:           "beta",
+        phase:           "alpha",
         description:     "Description",
         update_type:     "minor",
         body:            body,

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe "creating guides", type: :feature do
     expect(edition.related_discussion_title).to eq "Discussion on HackPad"
     expect(edition.related_discussion_href).to eq "https://designpatterns.hackpad.com/"
     expect(edition.publisher_title).to eq "Design Community"
-    expect(edition.phase).to eq "beta"
     expect(edition.title).to eq "First Edition Title"
     expect(edition.body).to eq "## First Edition Title"
     expect(edition.update_type).to eq "major"
@@ -184,7 +183,6 @@ private
     fill_in "Related discussion title", with: "Discussion on HackPad"
     fill_in "Link to related discussion", with: "https://designpatterns.hackpad.com/"
     select "Design Community", from: "Published by"
-    select "Beta", from: "Phase"
     fill_in "Description", with: "This guide acts as a test case"
 
     fill_in "Title", with: "First Edition Title"

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Edition, type: :model do
+  describe "#phase" do
+    it "defaults to 'alpha'" do
+      expect(Edition.new.phase).to eq 'alpha'
+    end
+  end
+
   describe "validations" do
     it "requires user to be present" do
       edition = Generators.valid_edition(user: nil)


### PR DESCRIPTION
This field was first introduced because it's a required field by default in
govuk-content-schemas. It has now become clear that we'll only use it to
indicate to the front-end application whether it should display an alpha/beta
banner. The banner would always be the same across all Service Manual content
so there is no need to display it in the UI. I've set it to 'alpha' initially,
once we decide to migrate to beta we'll need to do it with all persisted guides
locally as well as migrating published guides via publishing-api.

As a part of this effort https://github.com/alphagov/government-frontend/pull/65 will need to be updated to respect the `phase` field value.