### PR TITLE
Create new edition drafts lazily

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -18,6 +18,7 @@ class Edition < ActiveRecord::Base
   validates_presence_of [:state, :phase, :description, :title, :update_type, :body, :publisher_title, :publisher_href, :user]
   validates_inclusion_of :state, in: %w(draft published review_requested approved)
   validates :change_note, presence: true, if: :major?
+  validate :published_cant_change
 
   before_validation :assign_publisher_href
 
@@ -66,6 +67,12 @@ class Edition < ActiveRecord::Base
   end
 
 private
+
+  def published_cant_change
+    if state_was == 'published' && changes.except('updated_at').present?
+      errors.add(:base, "can not be changed after it's been published. Perhaps someone has published it whilst you were editing it.")
+    end
+  end
 
   def assign_publisher_href
     self.publisher_href = PUBLISHERS[publisher_title] if publisher_title.present?

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -22,4 +22,14 @@ class Guide < ActiveRecord::Base
   def comments_for_rendering
     latest_edition.comments.for_rendering
   end
+
+  def latest_editable_edition
+    return Edition.new unless latest_edition
+
+    if latest_edition.published?
+      latest_edition.dup
+    else
+      latest_edition
+    end
+  end
 end

--- a/app/views/editions/_header_with_navigation.html.erb
+++ b/app/views/editions/_header_with_navigation.html.erb
@@ -15,15 +15,7 @@
 <p>
   <ul class="nav nav-tabs">
     <%= active_link_to 'Show', edition_path(edition), wrap_tag: :li %>
-    <% if guide.latest_edition.published? %>
-      <li>
-        <%= form_for :drafts, url: guide_drafts_path(guide_id: guide.id) do |f| %>
-          <%= f.submit "Create new edition", class: 'btn btn-link' %>
-        <% end %>
-      </li>
-    <% else %>
-      <%= active_link_to "Edit", edit_guide_path(guide), wrap_tag: :li %>
-    <% end %>
+    <%= active_link_to "Edit", edit_guide_path(guide), wrap_tag: :li %>
     <%= active_link_to 'History', guide_editions_path(guide), wrap_tag: :li %>
   </ul>
 </p>

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -9,7 +9,7 @@
       </div>
     </fieldset>
 
-    <%= f.fields_for :editions, guide.latest_edition do |editions_form| %>
+    <%= f.fields_for :editions, guide.latest_editable_edition do |editions_form| %>
       <fieldset class='meta'>
         <legend>Meta</legend>
         <div class='form-group'>

--- a/app/views/guides/edit.html.erb
+++ b/app/views/guides/edit.html.erb
@@ -1,16 +1,8 @@
 <%= render 'editions/header_with_navigation', edition: @guide.latest_edition, guide: @guide %>
 
-<% if @guide.latest_edition.published? %>
-  <div class="alert alert-info">
-    Looks like the latest draft of this guide has been published
-  </div>
-  <%= form_for :drafts, url: guide_drafts_path(guide_id: @guide.id) do |f| %>
-    <%= f.submit "Create new edition", class: 'btn btn-default' %>
-  <% end %>
-<% else %>
-  <%= render 'form', guide: @guide%>
+<%= render 'form', guide: @guide%>
 
-  <%= render 'editions/comments', edition: @guide.latest_edition, comments: @comments %>
-<% end %>
+<%= render 'editions/comments', edition: @guide.latest_edition, comments: @comments %>
+
 
 

--- a/app/views/guides/index.html.erb
+++ b/app/views/guides/index.html.erb
@@ -24,9 +24,7 @@
         </td>
         <td class='content-controls'>
           <% if guide.latest_edition.published? %>
-            <%= form_for :drafts, url: guide_drafts_path(guide_id: guide.id), html: {style: "display: inline;"} do |f| %>
-              <%= f.submit("Create new edition", class: 'btn btn-default btn-xs') %>
-            <% end %>
+            <%= link_to "Create new edition", edit_guide_path(guide), class: 'btn btn-default btn-xs' %>
           <% else %>
             <%= link_to "Continue editing", edit_guide_path(guide), class: 'btn btn-default btn-xs' %>
           <% end %>

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -14,37 +14,48 @@ RSpec.describe Edition, type: :model do
       expect(edition.errors.full_messages_for(:user).size).to eq 1
     end
 
-    it "allows 'published' state" do
+    it "does not allow updating already published editions" do
       edition = Generators.valid_published_edition
-      edition.valid?
-      expect(edition.errors.full_messages_for(:state).size).to eq 0
+      edition.save!
+
+      edition.update_attributes(title: "Republishing")
+
+      expect(edition.errors.full_messages_for(:base).size).to eq 1
     end
 
-    valid_states = %w(draft review_requested approved)
-    valid_states.each do |valid_state|
-      it "allows '#{valid_state}' state" do
-        edition = Generators.valid_edition(state: valid_state)
+    describe "state" do
+      it "allows 'published' state" do
+        edition = Generators.valid_published_edition
         edition.valid?
         expect(edition.errors.full_messages_for(:state).size).to eq 0
       end
-    end
 
-    it "does not allow arbitrary values" do
-      edition = Generators.valid_edition(state: 'invalid state')
-      edition.valid?
-      expect(edition.errors.full_messages_for(:state).size).to eq 1
-    end
+      valid_states = %w(draft review_requested approved)
+      valid_states.each do |valid_state|
+        it "allows '#{valid_state}' state" do
+          edition = Generators.valid_edition(state: valid_state)
+          edition.valid?
+          expect(edition.errors.full_messages_for(:state).size).to eq 0
+        end
+      end
 
-    it "does not allow empty change_note when the update_type is 'major'" do
-      edition = Generators.valid_edition(update_type: "major", change_note: "")
-      edition.valid?
-      expect(edition.errors.full_messages_for(:change_note)).to eq ["Change note can't be blank"]
-    end
+      it "does not allow arbitrary values" do
+        edition = Generators.valid_edition(state: 'invalid state')
+        edition.valid?
+        expect(edition.errors.full_messages_for(:state).size).to eq 1
+      end
 
-    it "allows empty change_note when the update_type is 'minor'" do
-      edition = Generators.valid_edition(update_type: "minor", change_note: "")
-      edition.valid?
-      expect(edition.errors.full_messages_for(:change_note).size).to eq 0
+      it "does not allow empty change_note when the update_type is 'major'" do
+        edition = Generators.valid_edition(update_type: "major", change_note: "")
+        edition.valid?
+        expect(edition.errors.full_messages_for(:change_note)).to eq ["Change note can't be blank"]
+      end
+
+      it "allows empty change_note when the update_type is 'minor'" do
+        edition = Generators.valid_edition(update_type: "minor", change_note: "")
+        edition.valid?
+        expect(edition.errors.full_messages_for(:change_note).size).to eq 0
+      end
     end
   end
 

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -17,4 +17,22 @@ RSpec.describe Guide do
       expect(edition.errors.full_messages_for(:slug)).to eq ["Slug must be be prefixed with /service-manual/"]
     end
   end
+
+  describe "#latest_editable_edition" do
+    it "returns the latest edition if it's not published" do
+      guide = Guide.create(slug: "/service-manual/ediatble", editions: [Generators.valid_edition])
+      expect(guide.latest_editable_edition).to eq guide.reload.latest_edition
+    end
+
+    it "returns an unsaved copy of the latest edition if the latter is published" do
+      guide = Guide.create(slug: "/service-manual/ediatble", editions: [Generators.valid_published_edition(title: "Agile Methodologies")])
+
+      expect(guide.latest_editable_edition).to be_a_new_record
+      expect(guide.latest_editable_edition.title).to eq "Agile Methodologies"
+    end
+
+    it "returns a new edition for a guide with no latest edition" do
+      expect(Guide.new.latest_editable_edition).to be_a_new_record
+    end
+  end
 end


### PR DESCRIPTION
After trying out creating new draft editions as soon as the user clicks on the
"Create new edition" links  we decided not to use this approach anymore because
views needed to be aware of the current state of the latest edition and show
either a link or a form button. This makes view code more complicated and is
hard to style consistently.

Moving the logic deeper into the back-end makes the code simpler and more
robust (e.g. validations at the model level).

Gotcha: this creates a chance for unlikely race-conditions i.e. if two content
designers click "Create new edition" links at the same time, they will each
create a new draft edition on clicking "Save Draft". This should not be a big
problem as both editions will be visible in history, but only the latest
edition will be editable. Also, publishing-api should soon implement optimistic
locking that would eliminate this problem.