### PR TITLE
Rename publisher_* to content_owner_*

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -83,7 +83,7 @@ private
         :title,
         :body,
         :description,
-        :publisher_title,
+        :content_owner_id,
         :related_discussion_href,
         :related_discussion_title,
         :update_type,

--- a/app/models/content_owner.rb
+++ b/app/models/content_owner.rb
@@ -1,0 +1,2 @@
+class ContentOwner < ActiveRecord::Base
+end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -1,26 +1,21 @@
 class Edition < ActiveRecord::Base
   acts_as_commentable
 
-  PUBLISHERS = {
-    "Design Community" => "http://sm-11.herokuapp.com/designing-services/design-community/",
-    "Agile Community" => "http://sm-11.herokuapp.com/agile-delivery/agile-community"
-  }.freeze
-
   belongs_to :guide, touch: true
   belongs_to :user
 
   has_many :approvals
 
+  belongs_to :content_owner
+
   scope :draft, -> { where(state: 'draft') }
   scope :published, -> { where(state: 'published') }
   scope :review_requested, -> { where(state: 'review_requested') }
 
-  validates_presence_of [:state, :phase, :description, :title, :update_type, :body, :publisher_title, :publisher_href, :user]
+  validates_presence_of [:state, :phase, :description, :title, :update_type, :body, :content_owner, :user]
   validates_inclusion_of :state, in: %w(draft published review_requested approved)
   validates :change_note, presence: true, if: :major?
   validate :published_cant_change
-
-  before_validation :assign_publisher_href
 
   %w{minor major}.each do |s|
     define_method "#{s}?" do

--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -34,9 +34,9 @@ private
     details = {
       body: govspeak_body.to_html,
       header_links: level_two_headers,
-      publisher: {
-        name: edition.publisher_title,
-        href: edition.publisher_href
+      content_owner: {
+        title: edition.content_owner.title,
+        href: edition.content_owner.href
       }
     }
 

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -26,7 +26,7 @@
       <ul class="list-group">
         <li class="list-group-item">
           <label>Published by:</label>
-          <%= link_to @edition.publisher_title, @edition.publisher_href %>
+          <%= link_to @edition.content_owner.title, @edition.content_owner.href %>
         </li>
         <% if @edition.related_discussion_href.present? %>
           <li class="list-group-item">

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -25,9 +25,9 @@
         </div>
 
         <div class='form-group'>
-          <%= editions_form.label :publisher_title, "Published by" %>
-          <%= editions_form.error_list :publisher_title %>
-          <%= editions_form.select :publisher_title, Edition::PUBLISHERS.keys, class: 'input-md-12 form-control' %>
+          <%= editions_form.label :content_owner_id, "Published by" %>
+          <%= editions_form.error_list :content_owner_id %>
+          <%= editions_form.select :content_owner_id, ContentOwner.all.pluck(:title, :id), class: 'input-md-12 form-control' %>
         </div>
 
         <div class='form-group'>

--- a/db/migrate/20151112133846_create_content_owners.rb
+++ b/db/migrate/20151112133846_create_content_owners.rb
@@ -1,0 +1,18 @@
+class CreateContentOwners < ActiveRecord::Migration
+  def change
+    create_table :content_owners do |t|
+      t.string :title, null: false
+      t.string :href, null: false
+    end
+
+    execute "INSERT INTO content_owners (title, href) VALUES ('Design Community', 'http://sm-11.herokuapp.com/designing-services/design-community/')"
+    execute "INSERT INTO content_owners (title, href) VALUES ('Agile Community', 'http://sm-11.herokuapp.com/agile-delivery/agile-community')"
+
+    remove_column :editions, :publisher_title, :content_owner_title
+    remove_column :editions, :publisher_href, :content_owner_href
+
+    add_column :editions, :content_owner_id, :integer, null: true
+    execute "UPDATE editions SET content_owner_id = (SELECT id FROM content_owners LIMIT 1) WHERE content_owner_id IS NULL"
+    change_column_null :editions, :content_owner_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151110135512) do
+ActiveRecord::Schema.define(version: 20151112133846) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,11 @@ ActiveRecord::Schema.define(version: 20151110135512) do
   add_index "comments", ["commentable_type"], name: "index_comments_on_commentable_type", using: :btree
   add_index "comments", ["user_id"], name: "index_comments_on_user_id", using: :btree
 
+  create_table "content_owners", force: :cascade do |t|
+    t.string "title", null: false
+    t.string "href",  null: false
+  end
+
   create_table "editions", force: :cascade do |t|
     t.integer  "guide_id"
     t.integer  "user_id"
@@ -43,14 +48,13 @@ ActiveRecord::Schema.define(version: 20151110135512) do
     t.text     "body"
     t.string   "update_type"
     t.text     "phase",                    default: "alpha"
-    t.text     "publisher_title"
-    t.text     "publisher_href"
     t.text     "related_discussion_href"
     t.text     "related_discussion_title"
     t.datetime "created_at",                                 null: false
     t.datetime "updated_at",                                 null: false
     t.text     "state"
     t.text     "change_note"
+    t.integer  "content_owner_id",                           null: false
   end
 
   create_table "guides", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -46,14 +46,14 @@ if Rails.env.development? || ENV["GOVUK_APP_DOMAIN"] == "preview.alphagov.co.uk"
       end
 
       edition = Edition.new(
-        title:           title,
-        state:           state.present? ? state : "draft",
-        phase:           "alpha",
-        description:     "Description",
-        update_type:     "minor",
-        body:            body,
-        publisher_title: Edition::PUBLISHERS.keys.first,
-        user:            author
+        title:         title,
+        state:         state.present? ? state : "draft",
+        phase:         "alpha",
+        description:   "Description",
+        update_type:   "minor",
+        body:          body,
+        content_owner: ContentOwner.first,
+        user:          author
       )
       guide = Guide.create!(slug: object[:url], content_id: nil, latest_edition: edition)
 

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "creating guides", type: :feature do
   let(:api_double) { double(:publishing_api) }
 
   before do
+    ContentOwner.create!(title: "Design Community", href: "http://sm-11.herokuapp.com/designing-services/design-community/")
     visit root_path
     click_link "Create a Guide"
   end
@@ -34,7 +35,8 @@ RSpec.describe "creating guides", type: :feature do
     expect(content_id).to be_present
     expect(edition.related_discussion_title).to eq "Discussion on HackPad"
     expect(edition.related_discussion_href).to eq "https://designpatterns.hackpad.com/"
-    expect(edition.publisher_title).to eq "Design Community"
+    expect(edition.content_owner.title).to eq "Design Community"
+    expect(edition.content_owner.href).to eq "http://sm-11.herokuapp.com/designing-services/design-community/"
     expect(edition.title).to eq "First Edition Title"
     expect(edition.body).to eq "## First Edition Title"
     expect(edition.update_type).to eq "major"

--- a/spec/presenters/guide_presenter_spec.rb
+++ b/spec/presenters/guide_presenter_spec.rb
@@ -3,15 +3,14 @@ require 'rails_helper'
 RSpec.describe GuidePresenter do
   let(:edition) do
     Edition.new(
-      title:           "The Title",
-      state:           "draft",
-      phase:           "beta",
-      description:     "Description",
-      update_type:     "major",
-      body:            "# Heading",
-      publisher_title: "Publisher Name",
-      publisher_href: "http://gov.uk",
-      updated_at: Time.now
+      title:               "The Title",
+      state:               "draft",
+      phase:               "beta",
+      description:         "Description",
+      update_type:         "major",
+      body:                "# Heading",
+      content_owner:       ContentOwner.new(title: "Publisher Name", href: "http://gov.uk"),
+      updated_at:          Time.now
     )
   end
 

--- a/spec/support/generators.rb
+++ b/spec/support/generators.rb
@@ -1,15 +1,17 @@
 class Generators
   def self.valid_edition(attributes = {})
+    content_owner = ContentOwner.first || ContentOwner.create(title: "content owner title", href: "content_owner_href")
+
     attributes = {
-      title:           "The Title",
-      state:           "draft",
-      phase:           "beta",
-      description:     "Description",
-      update_type:     "major",
-      change_note:     "change note",
-      body:            "# Heading",
-      publisher_title: Edition::PUBLISHERS.keys.first,
-      user:            User.new(name: "Generated User")
+      title:         "The Title",
+      state:         "draft",
+      phase:         "beta",
+      description:   "Description",
+      update_type:   "major",
+      change_note:   "change note",
+      body:          "# Heading",
+      content_owner: content_owner,
+      user:          User.new(name: "Generated User")
     }.merge(attributes)
 
     Edition.new(attributes)


### PR DESCRIPTION
We have realised that using publisher to indicate the group responsible for a
piece of content can be ambiguous because within GOV.UK we use the term
"publisher" to name applications that publish content.

Other repos that need this renaming: govuk-content-schemas, government-frontend

We will not need to sync deploys or update because none of those are used in
production.

The build will go green once https://github.com/alphagov/govuk-content-schemas/pull/150 gets merged

/cc @KushalP 