### PR TITLE
Redirect to the guide edition show after approving

### DIFF
--- a/app/controllers/approvals_controller.rb
+++ b/app/controllers/approvals_controller.rb
@@ -4,6 +4,6 @@ class ApprovalsController < ApplicationController
     edition.approvals.build(user: current_user)
     edition.state = "approved"
     edition.save!
-    redirect_to root_path, notice: "Thanks for approving this guide"
+    redirect_to edition_path(edition), notice: "Thanks for approving this guide"
   end
 end

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -177,6 +177,9 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
         visit guides_path
         click_link "Standups"
         click_button "Mark as Approved"
+
+        expect(current_path).to eq edition_path(edition)
+
         expect(page).to have_content "Thanks for approving this guide"
         expect(page).to have_content "Approved"
       end


### PR DESCRIPTION
Keep it consistent with other workflow actions

cc @AndrewVos 