### PR TITLE
Do not allow modifying URL slugs for guides

### DIFF
--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -5,7 +5,7 @@
       <div class='form-group'>
         <%= f.label :slug  %>
         <%= f.error_list :slug  %>
-        <%= f.text_field :slug, class: 'input-md-12 form-control' %>
+        <%= f.text_field :slug, class: 'input-md-12 form-control guide-slug', disabled: guide.persisted? %>
       </div>
     </fieldset>
 

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -120,6 +120,12 @@ RSpec.describe "creating guides", type: :feature do
   end
 
   context "when updating a guide" do
+    it "prevents users from editing the url slug" do
+      guide = Guide.create!(slug: "/service-manual/something", latest_edition: Generators.valid_edition)
+      visit edit_guide_path(guide)
+      expect(find('input.guide-slug')['disabled']).to be_present
+    end
+
     context "when publishing raises an exception" do
       let :api_error do
         GdsApi::HTTPClientError.new(422, "Error message stub", "error" => { "message" => "Error message stub" })


### PR DESCRIPTION
Publishing API already prevents that [1], avoid user errors by disabling the
input field for persisted Guides.

[1] - https://github.com/alphagov/publishing-api/blob/6181c79701e06f77ce785d7cf2e829af66d2d51e/spec/commands/v2/put_content_spec.rb#L26-L32