### PR TITLE
Add .html to old slug urls when seeding slug migrations

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -82,6 +82,6 @@ end
 if Rails.env.development?
   all_old_guides.each do |old_guide|
     next if SlugMigration.find_by_slug(old_guide[:url]).present?
-    SlugMigration.create!(slug: old_guide[:url])
+    SlugMigration.create!(slug: "#{old_guide[:url]}.html")
   end
 end


### PR DESCRIPTION
All the jekyll urls have .html suffix.