### PR TITLE
Allow markdown in change notes, and auto link urls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'acts_as_commentable', '~> 4.0.2'
 gem 'active_link_to', '~> 1.0.3'
 gem 'select2-rails', '~> 4.0.0'
 gem 'diffy', '~> 3.0', '>= 3.0.7'
+gem 'redcarpet', '~> 3.3.3'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,6 +203,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     raindrops (0.15.0)
     rake (10.4.2)
+    redcarpet (3.3.3)
     request_store (1.2.0)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -298,6 +299,7 @@ DEPENDENCIES
   plek (~> 1.10)
   pry
   rails (= 4.2.4)
+  redcarpet (~> 3.3.3)
   rspec-rails (~> 3.3)
   sass-rails (~> 5.0)
   select2-rails (~> 4.0.0)

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -69,6 +69,15 @@ class Edition < ActiveRecord::Base
     guide.editions.published.where("id < ?", id).order(id: :desc).first
   end
 
+  def change_note_html
+    Redcarpet::Markdown.new(
+      Redcarpet::Render::HTML,
+      extensions = {
+        autolink: true,
+      },
+    ).render(change_note)
+  end
+
 private
 
   def published_cant_change

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -41,7 +41,7 @@
       </div>
       <% if @edition.change_note.present? %>
         <div class="panel-body">
-          <%= @edition.change_note %>
+          <%= @edition.change_note_html.html_safe %>
         </div>
       <% end %>
       <div class="panel-body">

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -154,4 +154,16 @@ RSpec.describe Edition, type: :model do
       end
     end
   end
+
+  describe "#change_note_html" do
+    it "renders markdown" do
+      edition = Edition.new(change_note: "# heading")
+      expect(edition.change_note_html).to eq "<h1>heading</h1>\n"
+    end
+
+    it "auto links" do
+      edition = Edition.new(change_note: "http://example.org")
+      expect(edition.change_note_html).to eq "<p><a href=\"http://example.org\">http://example.org</a></p>\n"
+    end
+  end
 end


### PR DESCRIPTION
Content editors often paste urls into change notes, so render change
notes as markdown and use auto linking.