### PR TITLE
Enable changes tab for new guides

### DIFF
--- a/app/controllers/edition_changes_controller.rb
+++ b/app/controllers/edition_changes_controller.rb
@@ -1,6 +1,10 @@
 class EditionChangesController < ApplicationController
   def show
-    old_edition = Edition.find(params[:old_edition_id])
+    old_edition = if params[:old_edition_id]
+      Edition.find(params[:old_edition_id])
+    else
+      Edition.new
+    end
     @edition = Edition.find(params[:new_edition_id])
     @edition_diff = EditionDiff.new(old_edition: old_edition, new_edition: @edition)
     @comments = @edition.comments.for_rendering

--- a/app/views/editions/_header_with_navigation.html.erb
+++ b/app/views/editions/_header_with_navigation.html.erb
@@ -15,13 +15,7 @@
 <p>
   <ul class="nav nav-tabs">
     <%= active_link_to "Show", edition_path(edition), wrap_tag: :li %>
-    <% if edition.previously_published_edition %>
-      <%= active_link_to "Changes", edition_changes_path(old_edition_id: edition.previously_published_edition, new_edition_id: edition.id), wrap_tag: :li %>
-    <% else %>
-      <li class="disabled" title="No previous editions to compare against">
-        <a>Changes</a>
-      </li>
-    <% end %>
+    <%= active_link_to "Changes", edition_changes_path(old_edition_id: edition.previously_published_edition, new_edition_id: edition.id), wrap_tag: :li %>
     <%= active_link_to "Edit", edit_guide_path(guide), wrap_tag: :li %>
     <%= active_link_to "History", guide_editions_path(guide), wrap_tag: :li %>
   </ul>

--- a/app/views/editions/index.html.erb
+++ b/app/views/editions/index.html.erb
@@ -17,9 +17,7 @@
           <%= link_to "See edition", edition %>
         </td>
         <td>
-        <% if edition.previously_published_edition %>
           <%= link_to "See changes", edition_changes_path(old_edition_id: edition.previously_published_edition, new_edition_id: edition.id) %>
-        <% end %>
         </td>
         <td>
           <%= edition.user.name %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
 
   resources :slug_migrations
 
-  get '/edition_changes/:old_edition_id/:new_edition_id' => 'edition_changes#show', as: :edition_changes
+  get '/edition_changes(/:old_edition_id)/:new_edition_id' => 'edition_changes#show', as: :edition_changes
 
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -241,6 +241,19 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
         expect(page).to have_content("## Hi")
       end
     end
+
+    it "shows all fields as additions if there are no previous editions" do
+      guide = given_a_guide_exists(title: "First Edition", body: "Hello")
+      visit edition_changes_path(new_edition_id: guide.latest_edition.id)
+
+      within ".title ins" do
+        expect(page).to have_content("First Edition")
+      end
+
+      within ".body ins" do
+        expect(page).to have_content("Hello")
+      end
+    end
   end
 
 private


### PR DESCRIPTION
We used to disable the "Changes" link for guides that do not have any
previously published editions. User research shows this is confusing,
especially given the fact that initially all users are going to be new and
they will work on new content. This changes enables the changes tab for all
editions and compares the latest one with an empty edition if there is no
previously published ones, resulting in all fields being "green" additions.