### PR TITLE
Strike through deleted words in the changes view

### DIFF
--- a/app/assets/stylesheets/diffy.css.erb
+++ b/app/assets/stylesheets/diffy.css.erb
@@ -1,1 +1,4 @@
 <%= Diffy::CSS %>
+.diff del strong {
+  text-decoration: line-through;
+}


### PR DESCRIPTION
After testing a few alternatives with content designers and a designer we've
decided to strike-through parts of the sentence that got deleted. 

We've also decided to re-visit this decision once we start using this feature in production due to some edge-cases e.g.

<img width="779" alt="screenshot 2015-11-19 11 33 49" src="https://cloud.githubusercontent.com/assets/218239/11270239/281b2bca-8eb5-11e5-85c6-fbc45a9ce57e.png">


