### PR TITLE
Redirect back to the previous page after posting a comment

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,4 +10,12 @@ class ApplicationController < ActionController::Base
     [Plek.find('draft-origin'), guide.slug].join('')
   end
   helper_method :guide_preview_url
+
+  def back_or_default(fallback_uri = root_url)
+    if request.referrer.present? && request.referrer != request.url
+      request.referrer
+    else
+      fallback_uri
+    end
+  end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -6,6 +6,6 @@ class CommentsController < ApplicationController
       comment: params[:comment][:comment],
     )
 
-    redirect_to root_path, notice: "Comment has been created"
+    redirect_to back_or_default(edition_path(edition)), notice: "Comment has been created"
   end
 end

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -62,10 +62,8 @@ private
   def success_url(guide)
     if params[:save_draft_and_preview]
       guide_preview_url(guide)
-    elsif request.referrer.present? && request.referrer != request.url
-      request.referrer
     else
-      root_url
+      back_or_default
     end
   end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -13,4 +13,27 @@ RSpec.describe ApplicationController do
       get :index
     end
   end
+
+  describe "back_or_default" do
+    it "returns referer if there's one" do
+      request.env['HTTP_REFERER'] = 'referer_url'
+      expect(controller.back_or_default('default')).to eq 'referer_url'
+    end
+
+    it "returns root_url if there's no referer nor fallback path" do
+      request.env['HTTP_REFERER'] = nil
+      expect(controller.back_or_default).to eq root_url
+    end
+
+    it "returns fallback uri if there's no referer" do
+      request.env['HTTP_REFERER'] = nil
+      expect(controller.back_or_default('fallback_url')).to eq 'fallback_url'
+    end
+
+    it "returns fallback uri if referer is the same as current url to avoid infinite loops" do
+      request.env['HTTP_REFERER'] = 'infinite_loop_url'
+      allow(request).to receive(:url).and_return('infinite_loop_url')
+      expect(controller.back_or_default('fallback_url')).to eq 'fallback_url'
+    end
+  end
 end

--- a/spec/features/comments_spec.rb
+++ b/spec/features/comments_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+require 'capybara/rails'
+
+RSpec.describe "Commenting", type: :feature do
+  it "allows discourse" do
+    edition = Generators.valid_edition
+    guide = Guide.create!(
+      latest_edition: edition,
+      slug: "/service-manual/test/slug_published"
+    )
+
+    visit edit_guide_path(guide)
+    within ".comments" do
+      fill_in "Comment", with: "This is my comment"
+      click_button "Comment"
+    end
+
+    visit edit_guide_path(guide)
+    within ".comments .comment" do
+      expect(page).to have_content "Stub User"
+      expect(page).to have_content "This is my comment"
+    end
+  end
+end

--- a/spec/features/comments_spec.rb
+++ b/spec/features/comments_spec.rb
@@ -2,20 +2,38 @@ require 'rails_helper'
 require 'capybara/rails'
 
 RSpec.describe "Commenting", type: :feature do
-  it "allows discourse" do
+  let!(:guide) do
     edition = Generators.valid_edition
-    guide = Guide.create!(
+    Guide.create!(
       latest_edition: edition,
-      slug: "/service-manual/test/slug_published"
+      slug: "/service-manual/test/comment"
     )
+  end
 
+  it "allows discourse on edit page" do
     visit edit_guide_path(guide)
     within ".comments" do
       fill_in "Comment", with: "This is my comment"
       click_button "Comment"
     end
 
-    visit edit_guide_path(guide)
+    expect(page.current_path).to eq edit_guide_path(guide)
+
+    within ".comments .comment" do
+      expect(page).to have_content "Stub User"
+      expect(page).to have_content "This is my comment"
+    end
+  end
+
+  it "allows discourse on show page" do
+    visit edition_path(guide.latest_edition)
+    within ".comments" do
+      fill_in "Comment", with: "This is my comment"
+      click_button "Comment"
+    end
+
+    expect(page.current_path).to eq edition_path(guide.latest_edition)
+
     within ".comments .comment" do
       expect(page).to have_content "Stub User"
       expect(page).to have_content "This is my comment"

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -167,26 +167,6 @@ RSpec.describe "creating guides", type: :feature do
     end
   end
 
-  it "allows discourse" do
-    edition = Generators.valid_edition
-    guide = Guide.create!(
-      latest_edition: edition,
-      slug: "/service-manual/test/slug_published"
-    )
-
-    visit edit_guide_path(guide)
-    within ".comments" do
-      fill_in "Comment", with: "This is my comment"
-      click_button "Comment"
-    end
-
-    visit edit_guide_path(guide)
-    within ".comments .comment" do
-      expect(page).to have_content "Stub User"
-      expect(page).to have_content "This is my comment"
-    end
-  end
-
 private
 
   def fill_in_guide_form


### PR DESCRIPTION
To make UX less confusing redirect users to the previous page after posting a comment, so they can see their saved comment on the screen.