### PR TITLE
Delete all SlugMigration rows before every test

### DIFF
--- a/db/migrate/20151116113920_insert_slug_migrations.rb
+++ b/db/migrate/20151116113920_insert_slug_migrations.rb
@@ -1,5 +1,7 @@
 class InsertSlugMigrations < ActiveRecord::Migration
   def change
+    return say("Skipping slug creation in test environment") if Rails.env.test?
+
     OLD_SLUGS.each do |s|
       execute "INSERT INTO slug_migrations (slug, created_at, updated_at, content_id) VALUES ('#{s}', now(), now(), '#{SecureRandom.uuid}')"
     end


### PR DESCRIPTION
Slug migrations are populated in migrations, so if we recreate and
migrate the database, all tests would fail. This doesn't work very well
in CI.