### PR TITLE
Retain changes in the guide form on failure

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -78,6 +78,14 @@ class Edition < ActiveRecord::Base
     ).render(change_note)
   end
 
+  def draft_copy
+    dup.tap do |e|
+      e.change_note = nil
+      e.update_type = "minor"
+      e.state = "draft"
+    end
+  end
+
 private
 
   def published_cant_change

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -9,7 +9,7 @@
       </div>
     </fieldset>
 
-    <%= f.fields_for :editions, guide.latest_editable_edition do |editions_form| %>
+    <%= f.fields_for :latest_edition, guide.latest_editable_edition do |editions_form| %>
       <fieldset class='meta'>
         <legend>Meta</legend>
         <div class='form-group'>

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -166,4 +166,16 @@ RSpec.describe Edition, type: :model do
       expect(edition.change_note_html).to eq "<p><a href=\"http://example.org\">http://example.org</a></p>\n"
     end
   end
+
+  describe "#draft_copy" do
+    it "builds a new draft object with all fields but change notes" do
+      edition = Generators.valid_published_edition(title: "Original Title", change_note: "Changes")
+      draft = edition.draft_copy
+
+      expect(draft.title).to eq "Original Title"
+      expect(draft).to be_new_record
+      expect(draft).to be_a_draft
+      expect(draft.change_note).to be_blank
+    end
+  end
 end

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -1,6 +1,32 @@
 require 'rails_helper'
 
 RSpec.describe Guide do
+  describe "#ensure_draft_exists" do
+    let(:edition) { Generators.valid_published_edition }
+    let(:guide) do
+      Guide.create!(slug: "/service-manual/slug", latest_edition: edition)
+    end
+
+    it "does nothing if the latest edition is in a draft state" do
+      edition.update_attribute(:state, "draft")
+
+      guide.ensure_draft_exists
+
+      expect(guide.latest_edition).to eq edition
+      expect(guide.editions.count).to eq 1
+    end
+
+    it "builds an saves a draft copy of the latest edition if it's published" do
+      edition.update_attribute(:state, "published")
+
+      guide.ensure_draft_exists
+
+      expect(guide.latest_edition).to_not eq edition
+      expect(guide.editions.published.count).to eq 1
+      expect(guide.editions.draft.count).to eq 1
+    end
+  end
+
   describe "on create callbacks" do
     it "generates and sets content_id on create" do
       edition = Generators.valid_published_edition


### PR DESCRIPTION
I've noticed that after a validation error or an API error is triggered, the
form loads a wrong edition object and thus loses all the changes made by user.
This can make people really frustrated.

This change makes sure we always use the same latest_edition object in the form.
We tried this attempt before and reverted, because using a has_one association
would replace the published edition (published editions can not be modified).

To avoid this situation the code now ensures there is an editable draft edition
just before updating the existing latest_edition. In such a case it overwrites
the latest_edition id parameter that comes from the form to ensure the newly
created draft edition is updated.

A new side effect of this behaviour can be observed when an update to a
currently published version of guide fails. Then we persist a draft clone of
the latest published edition in the local database. Users should not experience
any difference in the UX compared to the previous behaviour.