### PR TITLE
Show an error summary on top of the form

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -43,9 +43,6 @@ class GuidesController < ApplicationController
         GuidePublisher.new(guide: @guide).put_draft
         redirect_to success_url(@guide), notice: "Guide has been updated"
       else
-        if @guide.errors.messages[:"editions.base"].present?
-          flash[:error] = "Edition #{@guide.errors.messages[:"editions.base"].join(', ')}"
-        end
         render action: :edit
       end
     end

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -1,5 +1,7 @@
 <div class='well'>
   <%= form_for guide do |f| %>
+    <%= render 'shared/form_error_summary', object: guide %>
+
     <fieldset class='guide'>
       <legend>Guide</legend>
       <div class='form-group'>

--- a/app/views/shared/_form_error_summary.html.erb
+++ b/app/views/shared/_form_error_summary.html.erb
@@ -1,0 +1,16 @@
+<% if object.errors.any? %>
+  <div class="panel panel-danger full-error-list">
+    <div class="panel-heading">
+      <h3 class="panel-title">
+        Some errors have prevented from saving your changes
+      </h3>
+    </div>
+      <ul class="list-group">
+        <% object.errors.full_messages.each do |err_message| %>
+          <li class="list-group-item">
+            <%= err_message %>
+          </li>
+        <% end %>
+      </ul>
+  </div>
+<% end %>

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -131,6 +131,17 @@ RSpec.describe "creating guides", type: :feature do
       expect(find('input.guide-slug')['disabled']).to be_present
     end
 
+    it "shows the summary of validation errors" do
+      guide = Guide.create!(slug: "/service-manual/something", latest_edition: Generators.valid_edition)
+      visit edit_guide_path(guide)
+      fill_in "Title", with: ""
+      click_button "Save Draft"
+
+      within(".full-error-list") do
+        expect(page).to have_content("title can't be blank")
+      end
+    end
+
     context "when publishing raises an exception" do
       let :api_error do
         GdsApi::HTTPClientError.new(422, "Error message stub", "error" => { "message" => "Error message stub" })


### PR DESCRIPTION
Errors that are not associated to any field visible in the form can occur e.g.
published editions can't change, a change not might be missing when it's hidden
by JS etc. In addition to that, the erroneous field might not be visible on the
screen as it's at the bottom of the form.

Show a summary of all errors on top of the form to make it clear to the user
a failure has occurred and changes were not saved.

<img width="1156" alt="screenshot 2015-11-20 12 36 46" src="https://cloud.githubusercontent.com/assets/218239/11300087/fcae70bc-8f83-11e5-95a6-5ef038038f92.png">
