### PR TITLE
Default to major update types for new drafts

### DIFF
--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -49,7 +49,9 @@ class Guide < ActiveRecord::Base
     return Edition.new unless latest_edition
 
     if latest_edition.published?
-      latest_edition.draft_copy
+      latest_edition.draft_copy.tap do |e|
+        e.update_type = "major"
+      end
     else
       latest_edition
     end

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -2,25 +2,22 @@ require 'rails_helper'
 require 'capybara/rails'
 
 RSpec.describe "Taking a guide through the publishing process", type: :feature do
-
   before do
     allow_any_instance_of(GuidePublisher).to receive(:put_draft)
   end
 
   context "latest edition is published" do
-    let(:guide){ given_a_published_guide_exists title: "Standups" }
-
-    before do
+    it "should create a new draft edition when saving changes" do
+      guide = given_a_published_guide_exists title: "Standups"
       publisher_double = double(:publisher)
       expect(GuidePublisher).to receive(:new).with(guide: guide).and_return(publisher_double)
       expect(publisher_double).to receive(:put_draft).once
-    end
 
-    it "should create a new draft edition when saving changes" do
       visit guides_path
       click_link "Create new edition"
       the_form_should_be_prepopulated_with_title "Standups"
       fill_in "Title", with: "Standup meetings"
+      fill_in "Change note", with: "Be more specific in the title"
       click_button "Save Draft"
 
       guide.reload
@@ -29,14 +26,13 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       expect(guide.latest_edition.title).to eq "Standup meetings"
     end
 
-    it "has a new default empty change note" do
+    it "defaults to a major update and the new change note is empty" do
+      given_a_published_guide_exists title: "Standups"
       visit guides_path
 
       click_link "Create new edition"
-      expect(find_field('Change note').value).to be_blank
-      expect(page).to have_select("Update type", selected: "Minor")
-
-      click_button "Save Draft"
+      expect(find_field("Change note").value).to be_blank
+      expect(page).to have_select("Update type", selected: "Major")
     end
   end
 
@@ -69,6 +65,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
 
       visit edit_guide_path(guide)
       fill_in "Title", with: "Updated Title"
+      fill_in "Change note", with: "Update Title"
       click_button "Save Draft"
 
       the_form_should_be_prepopulated_with_title "Updated Title"
@@ -85,6 +82,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
 
       visit guides_path
       click_link "Create new edition"
+      fill_in "Change note", with: "Fix a typo"
       click_button "Save Draft"
 
       within ".alert" do
@@ -224,6 +222,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       visit edit_guide_path(guide)
       fill_in "Title", with: "Second Edition"
       fill_in "Body", with: "## Hi"
+      fill_in "Change note", with: "Better greeting"
       click_button "Save Draft"
       click_link "Changes"
 

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -46,15 +46,27 @@ RSpec.describe Guide do
 
   describe "#latest_editable_edition" do
     it "returns the latest edition if it's not published" do
-      guide = Guide.create(slug: "/service-manual/ediatble", editions: [Generators.valid_edition])
+      guide = Guide.create(slug: "/service-manual/editable", editions: [Generators.valid_edition])
       expect(guide.latest_editable_edition).to eq guide.reload.latest_edition
     end
 
     it "returns an unsaved copy of the latest edition if the latter is published" do
-      guide = Guide.create(slug: "/service-manual/ediatble", editions: [Generators.valid_published_edition(title: "Agile Methodologies")])
+      guide = Guide.create(
+                slug: "/service-manual/editable",
+                editions: [Generators.valid_published_edition(title: "Agile Methodologies")]
+              )
 
       expect(guide.latest_editable_edition).to be_a_new_record
       expect(guide.latest_editable_edition.title).to eq "Agile Methodologies"
+    end
+
+    it "defaults to a 'major' update for a new drafts" do
+      guide = Guide.create(
+                slug: "/service-manual/editable",
+                editions: [Generators.valid_published_edition(update_type: "minor")]
+              )
+
+      expect(guide.latest_editable_edition.update_type).to eq "major"
     end
 
     it "returns a new edition for a guide with no latest edition" do


### PR DESCRIPTION
When a new draft of a published edition is created, default to update_type
'major', then after saving respect what the user has chosen when first saving
the draft.

We want to encourage users to provide change notes for each change.

Some feature specs broke due to the new default, because major updates require
a change note to be present.