### PR TITLE
Handle a wider range of GDS API exceptions

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -28,7 +28,7 @@ class GuidesController < ApplicationController
         render action: :new
       end
     end
-  rescue GdsApi::HTTPClientError => e
+  rescue GdsApi::HTTPErrorResponse => e
     flash[:error] = e.error_details["error"]["message"]
     render template: 'guides/new'
   end
@@ -52,7 +52,7 @@ class GuidesController < ApplicationController
         render action: :edit
       end
     end
-  rescue GdsApi::HTTPClientError => e
+  rescue GdsApi::HTTPErrorResponse => e
     flash[:error] = e.error_details["error"]["message"]
     render template: 'guides/edit'
   end

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -7,7 +7,7 @@ class PublicationsController < ApplicationController
       redirect_to @guide.latest_edition, notice: "Guide has been published"
     end
 
-  rescue GdsApi::HTTPClientError => e
+  rescue GdsApi::HTTPErrorResponse => e
     flash[:error] = e.error_details["error"]["message"]
     @guide = @guide.reload
     @edition = @guide.latest_edition

--- a/app/controllers/slug_migrations_controller.rb
+++ b/app/controllers/slug_migrations_controller.rb
@@ -38,7 +38,7 @@ class SlugMigrationsController < ApplicationController
         render action: :edit
       end
     end
-  rescue GdsApi::HTTPClientError => e
+  rescue GdsApi::HTTPErrorResponse => e
     flash[:error] = e.error_details["error"]["message"]
     render action: :edit
   end


### PR DESCRIPTION
We've had a few reports in errbit about unhandled HTTPClientErrors. Looking at
GDS API adapters it looks like the right error class to rescue is
HTTPErrorResponse. It has the structure our current code expects in order to
show a flash message and handles both client and server exceptions.

Error class hierarchy: https://github.com/alphagov/gds-api-adapters/blob/7fdcd84b4766bd3c6b3a5bacd83459ccf5ce8564/lib/gds_api/exceptions.rb#L14-L28