### PR TITLE
Use radio buttons for update type selection

### DIFF
--- a/app/assets/javascripts/guide.js
+++ b/app/assets/javascripts/guide.js
@@ -4,7 +4,7 @@ $(function() {
 });
 
 function toggleChangeNote() {
-  var value = $(".update-type-select").val();
+  var value = $(".update-type-select:checked").val();
   var changeNote = $(".change-note-form-group");
 
   if (value == "major") {

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -56,11 +56,22 @@
 
 
     <fieldset class='update'>
-      <legend>Content</legend>
+      <legend>Change summary</legend>
       <div class='form-group'>
-        <%= editions_form.label :update_type %>
+        <label>Update type</label>
         <%= editions_form.error_list :update_type %>
-        <%= editions_form.select :update_type, [["Major", "major"], ["Minor", "minor"]], {}, {class: 'update-type-select input-md-12 form-control'} %>
+        <div class="radio">
+          <%= label_tag do %>
+            <%= editions_form.radio_button :update_type, "minor", { class: 'update-type-select'} %>
+            Minor update
+          <% end %>
+        </div>
+        <div class="radio">
+          <%= label_tag do %>
+            <%= editions_form.radio_button :update_type, "major", { class: 'update-type-select'} %>
+            Major update
+          <% end %>
+        </div>
       </div>
       <div class="form-group change-note-form-group">
         <%= editions_form.label :change_note %>

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
 
       click_link "Create new edition"
       expect(find_field("Change note").value).to be_blank
-      expect(page).to have_select("Update type", selected: "Major")
+
+      expect(find_field("Major update")).to be_checked
     end
   end
 

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -190,7 +190,7 @@ private
     fill_in "Title", with: "First Edition Title"
     fill_in "Body", with: "## First Edition Title"
 
-    select "Major", from: "Update type"
+    choose "Major update"
     fill_in "Change note", with: "Change Note"
   end
 end


### PR DESCRIPTION
There are only two options so radio buttons provide a better UX for selecting
an update type.

![screen shot 2015-11-23 at 15 52 25](https://cloud.githubusercontent.com/assets/218239/11341399/3c32b11c-91fa-11e5-9839-1f933e7e5d5b.png)
