### PR TITLE
Edit form UI

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -14,7 +14,7 @@ class GuidesController < ApplicationController
 
   def new
     @guide = Guide.new(slug: "/service-manual/")
-    @guide.build_latest_edition
+    @guide.build_latest_edition(update_type: 'major')
   end
 
   def create

--- a/app/views/editions/_header_with_navigation.html.erb
+++ b/app/views/editions/_header_with_navigation.html.erb
@@ -9,9 +9,9 @@
 
 <p>
   <ul class="nav nav-tabs">
-    <%= active_link_to "Show", edition_path(edition), wrap_tag: :li %>
-    <%= active_link_to "Changes", edition_changes_path(old_edition_id: edition.previously_published_edition, new_edition_id: edition.id), wrap_tag: :li %>
-    <%= active_link_to "Edit", edit_guide_path(guide), wrap_tag: :li %>
-    <%= active_link_to "History", guide_editions_path(guide), wrap_tag: :li %>
+    <%= active_link_to "View Govspeak", edition_path(edition), wrap_tag: :li %>
+    <%= active_link_to "Edit guide", edit_guide_path(guide), wrap_tag: :li %>
+    <%= active_link_to "Compare changes", edition_changes_path(old_edition_id: edition.previously_published_edition, new_edition_id: edition.id), wrap_tag: :li %>
+    <%= active_link_to "Guide history", guide_editions_path(guide), wrap_tag: :li %>
   </ul>
 </p>

--- a/app/views/editions/_header_with_navigation.html.erb
+++ b/app/views/editions/_header_with_navigation.html.erb
@@ -1,15 +1,10 @@
 <header>
   <div class="page-title">
     <h1>
-      <span class="small">
-        <%= guide.slug %>
-      </span>
       <%= edition.title %>
+      <%= state_label(guide) %>
     </h1>
   </div>
-  <p class="subtitle">
-    <%= state_label(guide) %>
-  </p>
 </header>
 
 <p>

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -1,62 +1,40 @@
-<div class='well'>
+<div class='well col-md-8'>
   <%= form_for guide do |f| %>
     <%= render 'shared/form_error_summary', object: guide %>
 
-    <fieldset class='guide'>
-      <legend>Guide</legend>
+    <%= f.fields_for :latest_edition, guide.latest_editable_edition do |editions_form| %>
+      <div class="form-group">
+        <%= editions_form.label :title, "Guide title" %>
+        <%= editions_form.error_list :title %>
+        <%= editions_form.text_field :title, class: 'input-md-12 form-control' %>
+      </div>
+
       <div class='form-group'>
         <%= f.label :slug  %>
         <%= f.error_list :slug  %>
         <%= f.text_field :slug, class: 'input-md-12 form-control guide-slug', disabled: guide.persisted? %>
+        <span class="help-block">Must start with '/service-manual/' and contain only letters and dashes e.g. '/service-manual/stand-up-meetings'</span>
       </div>
-    </fieldset>
 
-    <%= f.fields_for :latest_edition, guide.latest_editable_edition do |editions_form| %>
-      <fieldset class='meta'>
-        <legend>Meta</legend>
-        <div class='form-group'>
-          <%= editions_form.label :related_discussion_title %>
-          <%= editions_form.error_list :related_discussion_title %>
-          <%= editions_form.text_field :related_discussion_title, class: 'input-md-12 form-control' %>
-        </div>
+      <div class='form-group'>
+        <%= editions_form.label :description, "Guide description" %>
+        <%= editions_form.error_list :description %>
+        <%= editions_form.text_area :description, rows: 4, class: 'input-md-12 form-control' %>
+        <span class="help-block">To be used for displaying search results, linking content etc.</span>
+      </div>
 
-        <div class='form-group'>
-          <%= editions_form.label :related_discussion_href, "Link to related discussion" %>
-          <%= editions_form.error_list :related_discussion_href %>
-          <%= editions_form.text_field :related_discussion_href, class: 'input-md-12 form-control' %>
-        </div>
+      <div class="form-group">
+        <%= editions_form.label :body %>
+        <%= editions_form.error_list :body %>
+        <%= editions_form.text_area :body, class: 'input-md-12 form-control', rows: 14 %>
+      </div>
 
-        <div class='form-group'>
-          <%= editions_form.label :content_owner_id, "Published by" %>
-          <%= editions_form.error_list :content_owner_id %>
-          <%= editions_form.select :content_owner_id, ContentOwner.all.pluck(:title, :id), {}, {class: 'select2 input-md-12 form-control'} %>
-        </div>
+      <div class='form-group'>
+        <%= editions_form.label :content_owner_id, "Published by" %>
+        <%= editions_form.error_list :content_owner_id %>
+        <%= editions_form.select :content_owner_id, ContentOwner.all.pluck(:title, :id), {}, {class: 'select2 input-md-12 form-control'} %>
+      </div>
 
-        <div class='form-group'>
-          <%= editions_form.label :description %>
-          <%= editions_form.error_list :description %>
-          <%= editions_form.text_area :description, rows: 4, class: 'input-md-12 form-control' %>
-        </div>
-
-      </fieldset>
-
-    <fieldset class='inputs'>
-      <legend>Content</legend>
-        <div class="form-group">
-          <%= editions_form.label :title %>
-          <%= editions_form.error_list :title %>
-          <%= editions_form.text_field :title, class: 'input-md-12 form-control' %>
-        </div>
-        <div class="form-group">
-          <%= editions_form.label :body %>
-          <%= editions_form.error_list :body %>
-          <%= editions_form.text_area :body, class: 'input-md-12 form-control', rows: 14 %>
-        </div>
-    </fieldset>
-
-
-    <fieldset class='update'>
-      <legend>Change summary</legend>
       <div class='form-group'>
         <label>Update type</label>
         <%= editions_form.error_list :update_type %>
@@ -74,18 +52,16 @@
         </div>
       </div>
       <div class="form-group change-note-form-group">
-        <%= editions_form.label :change_note %>
+        <%= editions_form.label :change_note, "Change to be made" %>
+        <span>(visible publicly)</span>
         <%= editions_form.text_area :change_note, class: 'input-md-12 form-control', rows: 5 %>
+        <span class="help-block">Explain the change, the reason for the change and provide some context.</span>
       </div>
-    </fieldset>
 
-      <fieldset class='publication'>
-        <legend>Publication</legend>
-        <div class='form-group'>
-          <%= f.submit "Save Draft", class: 'btn btn-success', name: :save_draft, data: disable_if_new_record(guide) %>
-          <%= f.submit "Save Draft and Preview", class: 'btn btn-default', name: :save_draft_and_preview, data: disable_if_new_record(guide) %>
-        </div>
-      </fieldset>
+      <div class='form-group'>
+        <%= f.submit "Save Draft", class: 'btn btn-success', name: :save_draft, data: disable_if_new_record(guide) %>
+        <%= f.submit "Save Draft and Preview", class: 'btn btn-default', name: :save_draft_and_preview, data: disable_if_new_record(guide) %>
+      </div>
     <% end %>
   <% end %>
 
@@ -94,4 +70,23 @@
       <%= f.submit "Send for review", class: 'btn btn-success' %>
     <% end %>
   <% end %>
+</div>
+
+<div class="col-md-4">
+  <div class="panel panel-default">
+    <div class="panel-heading">Help</div>
+
+    <ul class="nav nav-pills nav-stacked">
+      <li>
+        <a href="https://www.gov.uk/guidance/style-guide">Style guide</a>
+      </li>
+      <li>
+        <a href="https://www.gov.uk/guidance/content-design/writing-for-gov-uk">Writing for GOV.UK</a>
+      </li>
+      <li>
+        <a href="https://github.com/alphagov/govspeak/wiki/Using-govspeak-on-GOV.UK">Formatting text using Govspeak</a>
+      </li>
+    </ul>
+  </div>
+
 </div>

--- a/app/views/guides/edit.html.erb
+++ b/app/views/guides/edit.html.erb
@@ -1,8 +1,14 @@
-<%= render 'editions/header_with_navigation', edition: @guide.latest_edition, guide: @guide %>
+<div class="row">
+  <%= render 'editions/header_with_navigation', edition: @guide.latest_edition, guide: @guide %>
+</div>
 
-<%= render 'form', guide: @guide%>
+<div class="row">
+  <%= render 'form', guide: @guide%>
+</div>
 
-<%= render 'editions/comments', edition: @guide.latest_edition, comments: @comments %>
+<div class="row">
+  <%= render 'editions/comments', edition: @guide.latest_edition, comments: @comments %>
+</div>
 
 
 

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
 
       visit guides_path
       click_link "Current Draft Edition"
-      click_link "History"
+      click_link "Guide history"
       within("table tbody") do
         expect(page.find_all("tr").size).to eq 2
         page.find_all("tr a").last.click
@@ -225,7 +225,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       fill_in "Body", with: "## Hi"
       fill_in "Change to be made", with: "Better greeting"
       click_button "Save Draft"
-      click_link "Changes"
+      click_link "Compare changes"
 
       within ".title del" do
         expect(page).to have_content("First Edition")

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       visit guides_path
       click_link "Create new edition"
       the_form_should_be_prepopulated_with_title "Standups"
-      fill_in "Title", with: "Standup meetings"
-      fill_in "Change note", with: "Be more specific in the title"
+      fill_in "Guide title", with: "Standup meetings"
+      fill_in "Change to be made", with: "Be more specific in the title"
       click_button "Save Draft"
 
       guide.reload
@@ -31,7 +31,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       visit guides_path
 
       click_link "Create new edition"
-      expect(find_field("Change note").value).to be_blank
+      expect(find_field("Change to be made").value).to be_blank
 
       expect(find_field("Major update")).to be_checked
     end
@@ -44,7 +44,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
 
     guide.latest_edition.update_attributes(state: 'published') # someone else publishes it
 
-    fill_in "Title", with: "Agile"
+    fill_in "Guide title", with: "Agile"
 
     click_button "Save Draft"
 
@@ -65,8 +65,8 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       expect_any_instance_of(GuidePublisher).to receive(:put_draft).and_raise api_error
 
       visit edit_guide_path(guide)
-      fill_in "Title", with: "Updated Title"
-      fill_in "Change note", with: "Update Title"
+      fill_in "Guide title", with: "Updated Title"
+      fill_in "Change to be made", with: "Update Title"
       click_button "Save Draft"
 
       the_form_should_be_prepopulated_with_title "Updated Title"
@@ -83,7 +83,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
 
       visit guides_path
       click_link "Create new edition"
-      fill_in "Change note", with: "Fix a typo"
+      fill_in "Change to be made", with: "Fix a typo"
       click_button "Save Draft"
 
       within ".alert" do
@@ -113,7 +113,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     guide = given_a_guide_exists state: 'draft', title: "Agile methodologies"
     visit guides_path
     click_link "Continue editing"
-    fill_in "Title", with: "Agile"
+    fill_in "Guide title", with: "Agile"
     click_button "Save Draft"
     expect(current_path).to eq edit_guide_path guide
 
@@ -125,7 +125,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     stub_user.update_attribute :name, "John Smith"
     guide = given_a_guide_exists state: 'draft'
     visit edit_guide_path(guide)
-    fill_in "Title", with: "An amended title"
+    fill_in "Guide title", with: "An amended title"
     click_button "Save Draft"
     visit guides_path
     within ".last-edited-by" do
@@ -136,7 +136,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
   it "should save a draft locally, sent it to Publishing API, then redirect to the front end when previewing" do
     guide = given_a_guide_exists state: 'draft', title: 'Test guide', slug: '/service-manual/preview-test'
     visit edit_guide_path(guide)
-    fill_in "Title", with: "Changed Title"
+    fill_in "Guide title", with: "Changed Title"
 
     expect_any_instance_of(GuidePublisher).to receive(:put_draft)
 
@@ -221,9 +221,9 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     it "shows exact changes in any fields" do
       guide = given_a_published_guide_exists(title: "First Edition", body: "### Hello")
       visit edit_guide_path(guide)
-      fill_in "Title", with: "Second Edition"
+      fill_in "Guide title", with: "Second Edition"
       fill_in "Body", with: "## Hi"
-      fill_in "Change note", with: "Better greeting"
+      fill_in "Change to be made", with: "Better greeting"
       click_button "Save Draft"
       click_link "Changes"
 
@@ -273,7 +273,7 @@ private
   end
 
   def the_form_should_be_prepopulated_with_title(title)
-    expect(find_field('Title').value).to eq title
+    expect(find_field('Guide title').value).to eq title
   end
 
   def expect_external_redirect_to(external_url)

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -36,8 +36,6 @@ RSpec.describe "creating guides", type: :feature do
     edition = guide.latest_edition
     content_id = guide.content_id
     expect(content_id).to be_present
-    expect(edition.related_discussion_title).to eq "Discussion on HackPad"
-    expect(edition.related_discussion_href).to eq "https://designpatterns.hackpad.com/"
     expect(edition.content_owner.title).to eq "Design Community"
     expect(edition.content_owner.href).to eq "http://sm-11.herokuapp.com/designing-services/design-community/"
     expect(edition.title).to eq "First Edition Title"
@@ -48,7 +46,7 @@ RSpec.describe "creating guides", type: :feature do
     expect(edition.published?).to eq false
 
     visit edit_guide_path(guide)
-    fill_in "Title", with: "Second Edition Title"
+    fill_in "Guide title", with: "Second Edition Title"
     click_button "Save Draft"
 
     within ".alert" do
@@ -134,7 +132,7 @@ RSpec.describe "creating guides", type: :feature do
     it "shows the summary of validation errors" do
       guide = Guide.create!(slug: "/service-manual/something", latest_edition: Generators.valid_edition)
       visit edit_guide_path(guide)
-      fill_in "Title", with: ""
+      fill_in "Guide title", with: ""
       click_button "Save Draft"
 
       within(".full-error-list") do
@@ -168,7 +166,7 @@ RSpec.describe "creating guides", type: :feature do
         expect_any_instance_of(GuidePublisher).to receive(:put_draft).once.and_raise(api_error)
 
         visit edit_guide_path(guide)
-        fill_in "Title", with: "Changed Title"
+        fill_in "Guide title", with: "Changed Title"
         click_button "Save Draft"
 
         expect(Guide.count).to eq 1
@@ -182,15 +180,13 @@ private
 
   def fill_in_guide_form
     fill_in "Slug", with: "/service-manual/the/path"
-    fill_in "Related discussion title", with: "Discussion on HackPad"
-    fill_in "Link to related discussion", with: "https://designpatterns.hackpad.com/"
     select "Design Community", from: "Published by"
-    fill_in "Description", with: "This guide acts as a test case"
+    fill_in "Guide description", with: "This guide acts as a test case"
 
-    fill_in "Title", with: "First Edition Title"
+    fill_in "Guide title", with: "First Edition Title"
     fill_in "Body", with: "## First Edition Title"
 
     choose "Major update"
-    fill_in "Change note", with: "Change Note"
+    fill_in "Change to be made", with: "Change Note"
   end
 end


### PR DESCRIPTION
Suggestion from our designer:

![screen_shot_2015-11-23_at_12 14 10](https://cloud.githubusercontent.com/assets/218239/11372696/c9539f26-92c6-11e5-869f-2f9b086d63aa.png)

Current state:
![screen shot 2015-11-24 at 16 17 25](https://cloud.githubusercontent.com/assets/218239/11372715/e5987828-92c6-11e5-9fc3-cd9a4c9ba663.png)

## Summary

- The form view is now consistent with other views and uses 8-4 column layout
- The side panel has links to content guidance and formatting help
- Related discussion fields have been removed from the form (TODO: remove
  them completely)
- Fields have been re-arranged, labels and help text added.
