### PR TITLE
Normalise newlines in seed.rb

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -72,7 +72,7 @@ if Rails.env.development? || ENV["GOVUK_APP_DOMAIN"] == "preview.alphagov.co.uk"
       phase:           "beta",
       description:     "Description",
       update_type:     "minor",
-      body:            object[:body],
+      body:            object[:body].gsub(/\n/, "\r\n"),
       content_owner:   ContentOwner.first,
       user:            author,
     )


### PR DESCRIPTION
When importing data from the old service manual guides the newline symbols are
"\n", but when saved again via the application they change to "\r\n". This
causes "compare changes" view to highlight the whole document first time it's
saved. Importing data with "\r\n" as newlines solves this problem.