### PR TITLE
Move comments to a Conversation tab

### DIFF
--- a/app/controllers/edition_changes_controller.rb
+++ b/app/controllers/edition_changes_controller.rb
@@ -7,6 +7,5 @@ class EditionChangesController < ApplicationController
     end
     @edition = Edition.find(params[:new_edition_id])
     @edition_diff = EditionDiff.new(old_edition: old_edition, new_edition: @edition)
-    @comments = @edition.comments.for_rendering
   end
 end

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -7,6 +7,11 @@ class EditionsController < ApplicationController
   def show
     @edition = Edition.find(params[:id])
     @guide = @edition.guide
+  end
+
+  def comments
+    @edition = Edition.find(params[:id])
+    @guide = @edition.guide
     @comments = @edition.comments.for_rendering
   end
 end

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -54,12 +54,10 @@ class GuidesController < ApplicationController
 
   def edit
     @guide = Guide.find(params[:id])
-    @comments = @guide.comments_for_rendering
   end
 
   def update
     @guide = Guide.find(params[:id])
-    @comments = @guide.comments_for_rendering
 
     @guide.ensure_draft_exists
 
@@ -84,12 +82,6 @@ private
     else
       back_or_default
     end
-  end
-
-  def comments_list(guide)
-    guide.latest_edition.comments
-      .order(created_at: :asc)
-      .includes(:user)
   end
 
   def guide_params(with = {})

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -11,7 +11,6 @@ class PublicationsController < ApplicationController
     flash[:error] = e.error_details["error"]["message"]
     @guide = @guide.reload
     @edition = @guide.latest_edition
-    @comments = @edition.comments.for_rendering
     render template: 'editions/show'
   end
 end

--- a/app/views/edition_changes/show.html.erb
+++ b/app/views/edition_changes/show.html.erb
@@ -32,7 +32,3 @@
 <div class="row">
   <%= render 'editions/publishing_controls', edition: @edition, guide: @edition.guide %>
 </div>
-
-<p class="row">
-  <%= render 'editions/comments', edition: @edition, comments: @comments %>
-</p>

--- a/app/views/editions/_header_with_navigation.html.erb
+++ b/app/views/editions/_header_with_navigation.html.erb
@@ -10,6 +10,16 @@
 <p>
   <ul class="nav nav-tabs">
     <%= active_link_to "View Govspeak", edition_path(edition), wrap_tag: :li %>
+
+    <%
+      conversation_title = "Conversation"
+      if guide.latest_edition.comments.any?
+        conversation_title = "#{conversation_title} (#{guide.latest_edition.comments.count})"
+      end
+    %>
+
+    <%= active_link_to conversation_title, edition_comments_path(guide.latest_edition), wrap_tag: :li %>
+
     <%= active_link_to "Edit guide", edit_guide_path(guide), wrap_tag: :li %>
     <%= active_link_to "Compare changes", edition_changes_path(old_edition_id: edition.previously_published_edition, new_edition_id: edition.id), wrap_tag: :li %>
     <%= active_link_to "Guide history", guide_editions_path(guide), wrap_tag: :li %>

--- a/app/views/editions/comments.html.erb
+++ b/app/views/editions/comments.html.erb
@@ -1,0 +1,6 @@
+<%= render 'editions/header_with_navigation', edition: @edition, guide: @guide %>
+<%= render 'editions/old_edition_alert', edition: @edition, guide: @guide %>
+
+<p class="row">
+  <%= render 'editions/comments', edition: @edition, comments: @comments %>
+</p>

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -73,7 +73,3 @@
 <div class="row">
   <%= render 'editions/publishing_controls', edition: @edition, guide: @guide %>
 </div>
-
-<p class="row">
-  <%= render 'editions/comments', edition: @edition, comments: @comments %>
-</p>

--- a/app/views/guides/edit.html.erb
+++ b/app/views/guides/edit.html.erb
@@ -5,10 +5,3 @@
 <div class="row">
   <%= render 'form', guide: @guide%>
 </div>
-
-<div class="row">
-  <%= render 'editions/comments', edition: @guide.latest_edition, comments: @comments %>
-</div>
-
-
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   resources :slug_migrations
 
   get '/edition_changes(/:old_edition_id)/:new_edition_id' => 'edition_changes#show', as: :edition_changes
+  get '/edition_comments/:id' => 'editions#comments', as: :edition_comments
 
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".

--- a/spec/features/comments_spec.rb
+++ b/spec/features/comments_spec.rb
@@ -10,29 +10,17 @@ RSpec.describe "Commenting", type: :feature do
     )
   end
 
-  it "allows discourse on edit page" do
-    visit edit_guide_path(guide)
+  it "allows discourse" do
+    visit root_path
+    click_link "Edit"
+    click_link "Conversation"
+
     within ".comments" do
       fill_in "Add new comment", with: "This is my comment"
       click_button "Save comment"
     end
 
-    expect(page.current_path).to eq edit_guide_path(guide)
-
-    within ".comments .comment" do
-      expect(page).to have_content "Stub User"
-      expect(page).to have_content "This is my comment"
-    end
-  end
-
-  it "allows discourse on show page" do
-    visit edition_path(guide.latest_edition)
-    within ".comments" do
-      fill_in "Add new comment", with: "This is my comment"
-      click_button "Save comment"
-    end
-
-    expect(page.current_path).to eq edition_path(guide.latest_edition)
+    expect(page.current_path).to eq edition_comments_path(guide.latest_edition)
 
     within ".comments .comment" do
       expect(page).to have_content "Stub User"


### PR DESCRIPTION
User testing found that the Comments section interfered with the UI too
much, and people didn't know what it was for.

Also, when saving a comment does the guide get saved or not? This is
confusing for the user.

![https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-27-11-2015-13-52-34-uichahwo.png](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-27-11-2015-13-52-34-uichahwo.png)