### PR TITLE
[do-not-merge] Show a progress bar for edition state

### DIFF
--- a/app/helpers/guide_helper.rb
+++ b/app/helpers/guide_helper.rb
@@ -7,6 +7,25 @@ module GuideHelper
     "published"        => "info",
   }
 
+  def state_progress_bar(guide)
+    state = guide.latest_edition.state
+    return "" if state.nil?
+
+    states = %w(draft review_requested approved published)
+
+    html = '<div class="progress">'
+    states.each do |s|
+      html << <<-HTML
+                  <div class="progress-bar progress-bar-#{STATE_CSS_CLASSES.fetch(s)}" style="width: 25%">
+                    <span>#{s.humanize}</span>
+                  </div>
+      HTML
+      break if s == state
+    end
+    html << "</div>"
+    html.html_safe
+  end
+
   def state_label(guide)
     state     = guide.latest_edition.try(:state) || "new"
     title     = state.titleize

--- a/app/views/editions/_header_with_navigation.html.erb
+++ b/app/views/editions/_header_with_navigation.html.erb
@@ -1,27 +1,30 @@
 <header>
   <div class="page-title">
     <h1>
-      <%= edition.title %>
+      <%= edition.title || "New Guide" %>
       <%= state_label(guide) %>
     </h1>
   </div>
+  <%= state_progress_bar(guide) %>
 </header>
 
 <p>
   <ul class="nav nav-tabs">
-    <%= active_link_to "View Govspeak", edition_path(edition), wrap_tag: :li %>
+    <% if edition.persisted? %>
+      <%= active_link_to "View Govspeak", edition_path(edition), wrap_tag: :li %>
 
-    <%
-      conversation_title = "Conversation"
-      if guide.latest_edition.comments.any?
-        conversation_title = "#{conversation_title} (#{guide.latest_edition.comments.count})"
-      end
-    %>
+      <%
+        conversation_title = "Conversation"
+        if guide.latest_edition.comments.any?
+          conversation_title = "#{conversation_title} (#{guide.latest_edition.comments.count})"
+        end
+      %>
 
-    <%= active_link_to conversation_title, edition_comments_path(guide.latest_edition), wrap_tag: :li %>
+      <%= active_link_to conversation_title, edition_comments_path(guide.latest_edition), wrap_tag: :li %>
 
-    <%= active_link_to "Edit guide", edit_guide_path(guide), wrap_tag: :li %>
-    <%= active_link_to "Compare changes", edition_changes_path(old_edition_id: edition.previously_published_edition, new_edition_id: edition.id), wrap_tag: :li %>
-    <%= active_link_to "Guide history", guide_editions_path(guide), wrap_tag: :li %>
+      <%= active_link_to "Edit guide", edit_guide_path(guide), wrap_tag: :li %>
+      <%= active_link_to "Compare changes", edition_changes_path(old_edition_id: edition.previously_published_edition, new_edition_id: edition.id), wrap_tag: :li %>
+      <%= active_link_to "Guide history", guide_editions_path(guide), wrap_tag: :li %>
+    <% end %>
   </ul>
 </p>

--- a/app/views/guides/new.html.erb
+++ b/app/views/guides/new.html.erb
@@ -1,1 +1,8 @@
-<%= render 'form', guide: @guide, edition: @edition%>
+<div class="row">
+  <%= render 'editions/header_with_navigation', edition: @guide.latest_edition, guide: @guide %>
+</div>
+
+<div class="row">
+  <%= render 'form', guide: @guide%>
+</div>
+


### PR DESCRIPTION
Awaiting feedback on this. Perhaps some copy would be nice.

In user testing, some users didn't quite realise there was a pipeline for publishing state. This is an attempt to fix this.

![https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-27-11-2015-16-02-50-ewooteih.png](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-27-11-2015-16-02-50-ewooteih.png)

![https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-27-11-2015-16-00-57-eedailae.png](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-27-11-2015-16-00-57-eedailae.png)