### PR TITLE
Fix broke guide ordering on index

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -26,6 +26,8 @@ class GuidesController < ApplicationController
 
     if params[:q].present?
       @guides = @guides.search(params[:q])
+    else
+      @guides = @guides.order(updated_at: :desc)
     end
 
     @guides = @guides.page(params[:page])


### PR DESCRIPTION
If we're not searching for a guide, then sort by updated_at