### PR TITLE
[do-not-merge] Add guide actions and explanation of state to top of page

### DIFF
--- a/app/helpers/guide_helper.rb
+++ b/app/helpers/guide_helper.rb
@@ -7,8 +7,7 @@ module GuideHelper
     "published"        => "info",
   }
 
-  def state_label(guide)
-    state     = guide.latest_edition.try(:state) || "new"
+  def state_label(state)
     title     = state.titleize
     css_class = STATE_CSS_CLASSES[state]
     content_tag :span, title, title: 'State', class: "label label-#{css_class}"

--- a/app/views/editions/_header_with_navigation.html.erb
+++ b/app/views/editions/_header_with_navigation.html.erb
@@ -2,40 +2,49 @@
   <div class="page-title">
     <h1>
       <%= edition.title %>
-      <%# <%= state_label(guide.latest_edition.state || "new") %1> %>
     </h1>
-    <div class="callout callout-info">
-      <div class="callout-body">
-        This guide is marked as <%= state_label(guide.latest_edition.state || "new") %>.
-        <%=
-          case guide.latest_edition.state
-          when "draft"
-            "When you are done editing it, send it for review."
-          when "review_requested"
-            "Once someone reviews it, it will become #{state_label("approved")}. At this point, it can be published by you."
-          when "approved"
-            "You may now publish it."
-          when "published"
-            "You may edit it to create a new draft version."
-          end.html_safe
-        %>
+    <% if edition == guide.latest_edition %>
+      <div class="callout callout-info">
+        <div class="callout-body">
+          This guide is marked as <%= state_label(edition.state || "new") %>
+          <% if edition.can_request_review? %>
+            <%= form_for :review_request, url: edition_review_requests_path(edition_id: edition.id), html: {class: "form-inline"} do |f| %>
+              When you are done editing it <%= f.submit "Send it for review", class: 'btn btn-success' %>
+            <% end %>
+          <% elsif edition.can_be_approved? %>
+              <%= form_for Approval.new do |f| %>
+                <%= f.hidden_field :edition_id, value: edition.id %>
+                If you have reviewed it, you can
+                <%= f.submit "Mark it as approved", class: 'btn btn-success' %>
+              <% end %>
+          <% elsif edition.can_be_published? %>
+            <% if edition.approval.present? %>
+              It was approved by <strong><%= edition.approval.user.name %></strong>
+            <% end %>
+            <%= form_for :publication, url: guide_publications_path(guide_id: guide.id) do |f| %>
+              You can now
+              <%= f.submit "Publish it", class: 'btn btn-success', name: :publish %>
+            <% end %>
+          <% elsif edition.published? %>
+            You can <%= link_to "edit it", edit_guide_path(guide), class: "btn btn-default" %> to create a new draft version
+          <% end %>
+        </div>
       </div>
-    </div>
+    <% end %>
   </div>
 </header>
 
 <p>
   <ul class="nav nav-tabs">
     <%= active_link_to "View Govspeak", edition_path(edition), wrap_tag: :li %>
-
     <%
       conversation_title = "Conversation"
-      if guide.latest_edition.comments.any?
-        conversation_title = "#{conversation_title} (#{guide.latest_edition.comments.count})"
+      if edition.comments.any?
+        conversation_title = "#{conversation_title} (#{edition.comments.count})"
       end
     %>
 
-    <%= active_link_to conversation_title, edition_comments_path(guide.latest_edition), wrap_tag: :li %>
+    <%= active_link_to conversation_title, edition_comments_path(edition), wrap_tag: :li %>
 
     <%= active_link_to "Edit guide", edit_guide_path(guide), wrap_tag: :li %>
     <%= active_link_to "Compare changes", edition_changes_path(old_edition_id: edition.previously_published_edition, new_edition_id: edition.id), wrap_tag: :li %>

--- a/app/views/editions/_header_with_navigation.html.erb
+++ b/app/views/editions/_header_with_navigation.html.erb
@@ -2,8 +2,25 @@
   <div class="page-title">
     <h1>
       <%= edition.title %>
-      <%= state_label(guide) %>
+      <%# <%= state_label(guide.latest_edition.state || "new") %1> %>
     </h1>
+    <div class="callout callout-info">
+      <div class="callout-body">
+        This guide is marked as <%= state_label(guide.latest_edition.state || "new") %>.
+        <%=
+          case guide.latest_edition.state
+          when "draft"
+            "When you are done editing it, send it for review."
+          when "review_requested"
+            "Once someone reviews it, it will become #{state_label("approved")}. At this point, it can be published by you."
+          when "approved"
+            "You may now publish it."
+          when "published"
+            "You may edit it to create a new draft version."
+          end.html_safe
+        %>
+      </div>
+    </div>
   </div>
 </header>
 

--- a/app/views/editions/_publishing_controls.html.erb
+++ b/app/views/editions/_publishing_controls.html.erb
@@ -2,32 +2,4 @@
   <p>
     <%= link_to "Preview", guide_preview_url(guide), class: 'btn btn-default' %>
   </p>
-
-  <% if edition.can_be_published? %>
-    <%= form_for :publication, url: guide_publications_path(guide_id: guide.id) do |f| %>
-      <%= f.submit "Publish Guide", class: 'btn btn-success', name: :publish %>
-    <% end %>
-    <% if @edition.approval %>
-      <p class="text-info">
-        <strong>Changes approved by <%= @edition.approval.user.name %>.</strong>
-      </p>
-    <% end %>
-  <% end %>
-
-
-  <% if edition.can_request_review? %>
-    <%= form_for :review_request, url: edition_review_requests_path(edition_id: edition.id) do |f| %>
-      <%= f.submit "Send for review", class: 'btn btn-success' %>
-    <% end %>
-  <% end %>
-
-  <% if edition.can_be_approved? %>
-    <%= form_for Approval.new do |f| %>
-      <fieldset class='meta'>
-        <legend>Approve</legend>
-        <%= f.hidden_field :edition_id, value: edition.id %>
-        <%= f.submit "Mark as Approved", class: 'btn btn-success' %>
-      </fieldset>
-    <% end %>
-  <% end %>
 </div>

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -64,12 +64,6 @@
       </div>
     <% end %>
   <% end %>
-
-  <% if guide.latest_edition.can_request_review? %>
-    <%= form_for :review_request, url: edition_review_requests_path(edition_id: guide.latest_edition.id) do |f| %>
-      <%= f.submit "Send for review", class: 'btn btn-success' %>
-    <% end %>
-  <% end %>
 </div>
 
 <div class="col-md-4">

--- a/app/views/guides/index.html.erb
+++ b/app/views/guides/index.html.erb
@@ -51,7 +51,7 @@
               <%= guide.latest_edition.updated_at.strftime("%d %b %Y") %>
             </td>
             <td>
-              <%= state_label(guide) %>
+              <%= state_label(guide.latest_edition.state) %>
             </td>
             <td class='content-controls'>
               <% action_title = @state_titles.fetch(guide.latest_edition.state.to_sym) %>

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       guide = Guide.create!(latest_edition: edition, slug: "/service-manual/something")
 
       visit edit_guide_path(guide)
-      click_button "Send for review"
+      click_button "Send it for review"
       visit guides_path
       expect(page).to have_content "Review Requested"
     end
@@ -167,12 +167,12 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
         login_as reviewer
         visit guides_path
         click_link "Standups"
-        click_button "Mark as Approved"
+        click_button "Mark it as approved"
 
         expect(current_path).to eq edition_path(edition)
 
         expect(page).to have_content "Thanks for approving this guide"
-        expect(page).to have_content "Changes approved by Keanu Reviews"
+        expect(page).to have_content "It was approved by Keanu Reviews"
         within ".label" do
           expect(page).to have_content "Approved"
         end
@@ -212,8 +212,8 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       within ".alert-info" do
         expect(page).to have_content "You're looking at a past edition of this guide"
       end
-      expect(page).to_not have_button "Publish Guide"
-      expect(page).to_not have_button "Send for review"
+      expect(page).to_not have_button "Publish it"
+      expect(page).to_not have_button "Send it for review"
     end
   end
 

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -75,11 +75,11 @@ RSpec.describe "creating guides", type: :feature do
     click_button "Save Draft"
     guide = Guide.first
     visit edit_guide_path(guide)
-    click_button "Send for review"
+    click_button "Send it for review"
 
     login_as(User.new(name: "Reviewer")) do
       visit edition_path(guide.latest_edition)
-      click_button "Mark as Approved"
+      click_button "Mark it as approved"
     end
 
     visit edition_path(guide.latest_edition)


### PR DESCRIPTION
This shows the user what state the guide is in, and allows them to easily
review/publish it.

![image](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-30-11-2015-15-34-03-phohsala.png)
![image](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-30-11-2015-15-34-58-xeikaesu.png)
![image](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-30-11-2015-15-35-17-aibeechu.png)
![image](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-30-11-2015-15-35-30-uixushoh.png)