### PR TITLE
Redirect back to guide index after state change

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -1,11 +1,5 @@
 class GuidesController < ApplicationController
   def index
-    @state_titles = {
-      draft: "Edit",
-      review_requested: "Review guide",
-      approved: "Publish",
-      published: "Edit",
-    }
     @user_options = User.all.collect{ |u| [u.name, u.id] }
     @state_options = %w(draft published review_requested approved).map {|s| [s.titleize, s]}
     @content_owner_options = ContentOwner.pluck(:title, :id)

--- a/app/helpers/guide_helper.rb
+++ b/app/helpers/guide_helper.rb
@@ -14,6 +14,21 @@ module GuideHelper
     content_tag :span, title, title: 'State', class: "label label-#{css_class}"
   end
 
+  def guide_action_button(guide)
+    state = guide.latest_edition.state
+    if state == "draft" || state == "published"
+      title = "Edit"
+      path =  edit_guide_path(guide)
+    elsif state == "review_requested"
+      title = "Review guide"
+      path = edition_path(guide.latest_edition)
+    elsif state == "approved"
+      title = "Publish"
+      path = edition_path(guide.latest_edition)
+    end
+    link_to title, path, class: "btn btn-block btn-default btn-xs"
+  end
+
   def latest_editor_name(guide)
     guide.latest_edition.user.try(:name).to_s
   end

--- a/app/views/guides/index.html.erb
+++ b/app/views/guides/index.html.erb
@@ -54,8 +54,7 @@
               <%= state_label(guide) %>
             </td>
             <td class='content-controls'>
-              <% action_title = @state_titles.fetch(guide.latest_edition.state.to_sym) %>
-              <%= link_to action_title, edit_guide_path(guide), class: "btn btn-block btn-default btn-xs" %>
+              <%= guide_action_button(guide) %>
             </td>
           </tr>
         <% end %>

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -154,7 +154,6 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
 
       visit edit_guide_path(guide)
       click_button "Send for review"
-      visit guides_path
       expect(page).to have_content "Review Requested"
     end
 
@@ -170,9 +169,10 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
         click_button "Mark as Approved"
 
         expect(current_path).to eq edition_path(edition)
-
         expect(page).to have_content "Thanks for approving this guide"
         expect(page).to have_content "Changes approved by Keanu Reviews"
+
+        visit root_path
         within ".label" do
           expect(page).to have_content "Approved"
         end


### PR DESCRIPTION
When a user changes state to approved/review_requests they probably
wouldn't edit the edition anymore, because they are awaiting a response
from a different actor.

Also, fix Action links in the guide index page.. Publish and Review were
pointing at the edit path, when they should have been pointing at the
show path.