### PR TITLE
Index guides in rummager

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'active_link_to', '~> 1.0.3'
 gem 'select2-rails', '~> 4.0.0'
 gem 'diffy', '~> 3.0', '>= 3.0.7'
 gem 'redcarpet', '~> 3.3.3'
+gem 'rummageable', '1.2.0'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,10 @@ GEM
       rspec-mocks (~> 3.3.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
+    rummageable (1.2.0)
+      multi_json
+      null_logger
+      rest-client
     sanitize (2.1.0)
       nokogiri (>= 1.4.4)
     sass (3.4.19)
@@ -304,6 +308,7 @@ DEPENDENCIES
   rails (= 4.2.4)
   redcarpet (~> 3.3.3)
   rspec-rails (~> 3.3)
+  rummageable (= 1.2.0)
   sass-rails (~> 5.0)
   select2-rails (~> 4.0.0)
   simplecov (= 0.10.0)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The application runs on port `3111` by default. If you're using the GDS VM it's 
 Currently [government-frontend](alphagov/government-frontend) has a feature flag to enable rendering service manual content.
 
 ```
-FLAG_ENABLE_SERVICE_MANUAL=1 bowl service-manual-publisher government-frontend frontend www
+FLAG_ENABLE_SERVICE_MANUAL=1 bowl service-manual-publisher government-frontend www rummager designprinciples draft-content-store router
 ```
 
 The application has a style guide that can be accessed on `/style-guide`.

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -97,6 +97,7 @@ private
     ActiveRecord::Base.transaction do
       @guide.latest_edition.update_attributes!(state: 'published')
       GuidePublisher.new(guide: @guide).publish
+      SearchIndexer.new(@guide).index
       redirect_to back_or_default, notice: "Guide has been published"
     end
   rescue GdsApi::HTTPErrorResponse => e

--- a/app/models/search_indexer.rb
+++ b/app/models/search_indexer.rb
@@ -1,0 +1,21 @@
+class SearchIndexer
+  def initialize(guide)
+    @guide = guide
+    @edition = guide.latest_edition
+  end
+
+  def index
+    index = Rummageable::Index.new(
+      Plek.current.find('rummager'), '/service-manual'
+    )
+    index.add_batch([{
+      "_type":             "manual_section",
+      "description":       @edition.description,
+      "indexable_content": @edition.body,
+      "title":             @edition.title,
+      "link":              @guide.slug,
+      "manual":            "/service-manual",
+      "organisations":     ["government-digital-service"],
+    }])
+  end
+end

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -1,0 +1,39 @@
+namespace :rummager do
+  desc "index all published documents in rummager"
+  task index: :environment do
+    require 'plek'
+    require 'rummageable'
+
+    root_document = {
+      format: "manual",
+      title: "Government Service Design Manual",
+      description: "All new digital services from the government must meet the Digital by Default Service Standard",
+      link: "/service-manual",
+      organisations: "government-digital-service",
+    }
+    index_document root_document
+
+    Guide.all.each do |guide|
+      edition = guide.latest_edition
+      if edition.published?
+        puts "Indexing #{edition.title}..."
+        index_document({
+          "_type": "manual_section",
+          "description": edition.description,
+          "indexable_content": edition.body,
+          "title": edition.title,
+          "link": guide.slug,
+          "manual": "/service-manual",
+          "organisations": [ "government-digital-service" ],
+        })
+      end
+    end
+  end
+
+  def index_document document
+    @rummageable_index ||= Rummageable::Index.new(
+      Plek.current.find('rummager'), '/service-manual'
+    )
+    @rummageable_index.add_batch([document])
+  end
+end

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -4,6 +4,8 @@ require 'capybara/rails'
 RSpec.describe "Taking a guide through the publishing process", type: :feature do
   before do
     allow_any_instance_of(GuidePublisher).to receive(:put_draft)
+    allow_any_instance_of(GuidePublisher).to receive(:publish)
+    allow_any_instance_of(SearchIndexer).to receive(:index)
   end
 
   context "latest edition is published" do
@@ -34,6 +36,18 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       expect(find_field("Change to be made").value).to be_blank
 
       expect(find_field("Major update")).to be_checked
+    end
+
+    it "indexes documents for search" do
+      given_a_guide_exists
+      indexer = double(:indexer)
+      expect(SearchIndexer).to receive(:new).with(Guide.first).and_return(indexer)
+      expect(indexer).to receive(:index)
+      visit guides_path
+      click_link "Edit"
+      click_button "Send for review"
+      click_button "Approve for publication"
+      click_button "Publish"
     end
   end
 

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe "creating guides", type: :feature do
     ).save!
     visit root_path
     click_link "Create a Guide"
+
+    allow_any_instance_of(SearchIndexer).to receive(:index)
   end
 
   it "has a prepopulated slug field" do

--- a/spec/models/search_indexer_spec.rb
+++ b/spec/models/search_indexer_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe SearchIndexer do
+  it "indexes documents in rummager" do
+    index = double(:rummageable_index)
+    plek = Plek.current.find('rummager')
+    expect(Rummageable::Index).to receive(:new).with(plek, "/service-manual").and_return index
+    guide = Guide.create!(slug: "/service-manual/some-slug", latest_edition: Generators.valid_edition)
+    expect(index).to receive(:add_batch).with([{
+      _type:             "manual_section",
+      description:       guide.latest_edition.description,
+      indexable_content: guide.latest_edition.body,
+      title:             guide.latest_edition.title,
+      link:              guide.slug,
+      manual:            "/service-manual",
+      organisations:     ["government-digital-service"]
+    }])
+    SearchIndexer.new(guide).index
+  end
+end


### PR DESCRIPTION
We will use the `design-principles` frontend to render search results for
now. `design-principles` uses a filter for search results called
`filter_manual`, which works with the old guide service manual.

![image](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-01-12-2015-15-14-33-eemaevef.png)
![image](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-01-12-2015-15-15-00-sihoutoh.png)
![image](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-01-12-2015-15-15-15-ieweitha.png)