### PR TITLE
Show a disabled "send for review" button when not persisted

### DIFF
--- a/app/views/editions/_actions.html.erb
+++ b/app/views/editions/_actions.html.erb
@@ -7,10 +7,18 @@
     <% end %>
 
     <% if edition.persisted? %>
-      <%= form.submit "Send for review", name: :send_for_review, class: 'btn btn-success', disabled: !edition.can_request_review? %>
-      <%= form.submit "Mark as Approved", name: :approve, class: 'btn btn-success', disabled: !edition.can_be_approved? %>
+      <% if edition.can_request_review? %>
+        <%= form.submit "Send for review", name: :send_for_review, class: 'btn btn-success' %>
+      <% end %>
+      <% if edition.can_be_approved? %>
+        <%= form.submit "Mark as Approved", name: :approve, class: 'btn btn-success' %>
+      <% end %>
 
-      <%= form.submit "Publish Guide", class: 'btn btn-success', name: :publish, disabled: !edition.can_be_published? %>
+      <% if edition.can_be_published? %>
+        <%= form.submit "Publish Guide", class: 'btn btn-success', name: :publish %>
+      <% end %>
+    <% else %>
+      <%= form.submit "Send for review", name: :send_for_review, class: 'btn btn-success', disabled: true %>
     <% end %>
     <% if edition.approval %>
       <p class="text-info">

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -176,6 +176,64 @@ RSpec.describe "creating guides", type: :feature do
     end
   end
 
+  describe "action buttons" do
+    {
+      review_requested: "Send for review",
+      mark_as_approved: "Mark as Approved",
+      publish:          "Publish Guide",
+    }.each do |name, title|
+      define_method :"expect_#{name}_to_be" do |state|
+        if state == :visible
+          expect(page).to have_button title
+        else
+          expect(page).to_not have_button title
+        end
+      end
+    end
+
+    context "when a review can be requested" do
+      before do
+        edition = Generators.valid_edition
+        Guide.create!(slug: "/service-manual/something", latest_edition: edition)
+        visit edition_path(edition)
+      end
+
+      it "only allows requesting of reviews" do
+        expect_review_requested_to_be :visible
+        expect_mark_as_approved_to_be :hidden
+        expect_publish_to_be :hidden
+      end
+    end
+
+    context "when it can be marked as approved" do
+      before do
+        edition = Generators.valid_edition(state: "review_requested")
+        Guide.create!(slug: "/service-manual/something", latest_edition: edition)
+        visit edition_path(edition)
+      end
+
+      it "only allows being marked at approved" do
+        expect_review_requested_to_be :hidden
+        expect_mark_as_approved_to_be :visible
+        expect_publish_to_be :hidden
+      end
+    end
+
+    context "when it can be published" do
+      before do
+        edition = Generators.valid_edition(state: "approved")
+        Guide.create!(slug: "/service-manual/something", latest_edition: edition)
+        visit edition_path(edition)
+      end
+
+      it "only allows publishing" do
+        expect_review_requested_to_be :hidden
+        expect_mark_as_approved_to_be :hidden
+        expect_publish_to_be :visible
+      end
+    end
+  end
+
 private
 
   def fill_in_guide_form


### PR DESCRIPTION
The "Send for review" button is now displayed when creating a new guide,
because
https://trello.com/c/QAu4Eggt/96-fix-create-a-new-guide-edition-workflow

Also, hide other guide action buttons instead of disabling them.