### PR TITLE
Change titles of edition action buttons

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -59,8 +59,8 @@ class GuidesController < ApplicationController
       return send_for_review
     elsif params[:publish].present?
       return publish
-    elsif params[:approve].present?
-      return approve
+    elsif params[:approve_for_publication].present?
+      return approve_for_publication
     end
 
     @guide.ensure_draft_exists
@@ -86,7 +86,7 @@ private
     redirect_to back_or_default, notice: "A review has been requested"
   end
 
-  def approve
+  def approve_for_publication
     @guide.latest_edition.build_approval(user: current_user)
     @guide.latest_edition.state = "approved"
     @guide.latest_edition.save!
@@ -107,7 +107,7 @@ private
   end
 
   def success_url(guide)
-    if params[:save_draft_and_preview]
+    if params[:save_and_preview]
       guide_preview_url(guide)
     else
       back_or_default

--- a/app/views/editions/_actions.html.erb
+++ b/app/views/editions/_actions.html.erb
@@ -4,8 +4,11 @@
       <% if edition.persisted? %>
         <%= link_to "Preview", guide_preview_url(guide), class: 'btn btn-default' %>
       <% end %>
-      <%= form.submit "Save Draft", class: 'btn btn-default', name: :save_draft, data: disable_if_new_record(guide) %>
-      <%= form.submit "Save Draft and Preview", class: 'btn btn-default', name: :save_draft_and_preview, data: disable_if_new_record(guide) %>
+        <%= form.submit "Save", class: 'btn btn-default', name: :save, data: disable_if_new_record(guide) %>
+      <%= form.submit "Save and preview", class: 'btn btn-default', name: :save_and_preview, data: disable_if_new_record(guide) %>
+      <% if !edition.persisted? %>
+        <%= link_to "Discard new guide", guides_path, class: "btn btn-danger" %>
+      <% end %>
     <% end %>
 
     <% if edition.persisted? %>
@@ -13,15 +16,16 @@
         <%= form.submit "Send for review", name: :send_for_review, class: 'btn btn-success' %>
       <% end %>
       <% if edition.can_be_approved? %>
-        <%= form.submit "Mark as Approved", name: :approve, class: 'btn btn-success' %>
+        <%= form.submit "Approve for publication", name: :approve_for_publication, class: 'btn btn-success' %>
       <% end %>
 
       <% if edition.can_be_published? %>
-        <%= form.submit "Publish Guide", class: 'btn btn-success', name: :publish %>
+        <%= form.submit "Publish", class: 'btn btn-success', name: :publish %>
       <% end %>
     <% else %>
       <%= form.submit "Send for review", name: :send_for_review, class: 'btn btn-success', disabled: true %>
     <% end %>
+
     <% if edition.approval %>
       <p class="text-info">
         <strong>Changes approved by <%= edition.approval.user.name %>.</strong>

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       the_form_should_be_prepopulated_with_title "Standups"
       fill_in "Guide title", with: "Standup meetings"
       fill_in "Change to be made", with: "Be more specific in the title"
-      click_button "Save Draft"
+      click_button "Save"
 
       guide.reload
       expect(guide.editions.published.size).to eq 1
@@ -46,7 +46,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
 
     fill_in "Guide title", with: "Agile"
 
-    click_button "Save Draft"
+    click_button "Save"
 
     expect(guide.editions.published.map(&:title)).to match_array ["Agile development"]
     expect(guide.editions.draft.map(&:title)).to match_array ["Agile"]
@@ -67,7 +67,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       visit edit_guide_path(guide)
       fill_in "Guide title", with: "Updated Title"
       fill_in "Change to be made", with: "Update Title"
-      click_button "Save Draft"
+      click_button "Save"
 
       the_form_should_be_prepopulated_with_title "Updated Title"
 
@@ -84,7 +84,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       visit guides_path
       click_link "Edit"
       fill_in "Change to be made", with: "Fix a typo"
-      click_button "Save Draft"
+      click_button "Save"
 
       within ".alert" do
         expect(page).to have_content('Error message stub')
@@ -114,7 +114,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     visit guides_path
     click_link "Edit"
     fill_in "Guide title", with: "Agile"
-    click_button "Save Draft"
+    click_button "Save"
     expect(current_path).to eq edit_guide_path guide
 
     expect(guide.editions.draft.size).to eq 1
@@ -126,7 +126,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     guide = given_a_guide_exists state: 'draft'
     visit edit_guide_path(guide)
     fill_in "Guide title", with: "An amended title"
-    click_button "Save Draft"
+    click_button "Save"
     visit guides_path
     within ".last-edited-by" do
       expect(page).to have_content "John Smith"
@@ -141,7 +141,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     expect_any_instance_of(GuidePublisher).to receive(:put_draft)
 
     expect_external_redirect_to "http://draft-origin.dev.gov.uk/service-manual/preview-test" do
-      click_button "Save Draft and Preview"
+      click_button "Save and preview"
     end
 
     expect(guide.editions.map(&:title)).to match_array ["Changed Title"]
@@ -166,7 +166,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
         login_as reviewer
         visit guides_path
         click_link "Standups"
-        click_button "Mark as Approved"
+        click_button "Approve for publication"
 
         expect(current_path).to eq edition_path(edition)
         expect(page).to have_content "Thanks for approving this guide"
@@ -224,7 +224,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       fill_in "Guide title", with: "Second Edition"
       fill_in "Body", with: "## Hi"
       fill_in "Change to be made", with: "Better greeting"
-      click_button "Save Draft"
+      click_button "Save"
       click_link "Compare changes"
 
       within ".title del" do

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "creating guides", type: :feature do
                             .twice
                             .with(an_instance_of(String), be_valid_against_schema('service_manual_guide'))
 
-    click_button "Save Draft"
+    click_button "Save"
 
     within ".alert" do
       expect(page).to have_content('created')
@@ -47,7 +47,7 @@ RSpec.describe "creating guides", type: :feature do
 
     visit edit_guide_path(guide)
     fill_in "Guide title", with: "Second Edition Title"
-    click_button "Save Draft"
+    click_button "Save"
 
     within ".alert" do
       expect(page).to have_content('updated')
@@ -72,14 +72,14 @@ RSpec.describe "creating guides", type: :feature do
                             .once
                             .with(an_instance_of(String), 'major')
 
-    click_button "Save Draft"
+    click_button "Save"
     guide = Guide.first
     visit edit_guide_path(guide)
     click_button "Send for review"
 
     login_as(User.new(name: "Reviewer")) do
       visit edition_path(guide.latest_edition)
-      click_button "Mark as Approved"
+      click_button "Approve for publication"
     end
 
     visit edition_path(guide.latest_edition)
@@ -105,7 +105,7 @@ RSpec.describe "creating guides", type: :feature do
 
       it "shows api errors" do
         fill_in_guide_form
-        click_button "Save Draft"
+        click_button "Save"
 
         within ".alert" do
           expect(page).to have_content('Error message stub')
@@ -114,7 +114,7 @@ RSpec.describe "creating guides", type: :feature do
 
       it "does not store a guide" do
         fill_in_guide_form
-        click_button "Save Draft"
+        click_button "Save"
 
         expect(Guide.count).to eq 0
         expect(Edition.count).to eq 0
@@ -133,7 +133,7 @@ RSpec.describe "creating guides", type: :feature do
       guide = Guide.create!(slug: "/service-manual/something", latest_edition: Generators.valid_edition)
       visit edit_guide_path(guide)
       fill_in "Guide title", with: ""
-      click_button "Save Draft"
+      click_button "Save"
 
       within(".full-error-list") do
         expect(page).to have_content("title can't be blank")
@@ -152,7 +152,7 @@ RSpec.describe "creating guides", type: :feature do
         expect_any_instance_of(GuidePublisher).to receive(:put_draft).once.and_raise(api_error)
 
         visit edit_guide_path(guide)
-        click_button "Save Draft"
+        click_button "Save"
 
         within ".alert" do
           expect(page).to have_content('Error message stub')
@@ -167,7 +167,7 @@ RSpec.describe "creating guides", type: :feature do
 
         visit edit_guide_path(guide)
         fill_in "Guide title", with: "Changed Title"
-        click_button "Save Draft"
+        click_button "Save"
 
         expect(Guide.count).to eq 1
         expect(Guide.first.latest_edition.title).to_not eq "Changed Title"
@@ -178,9 +178,9 @@ RSpec.describe "creating guides", type: :feature do
 
   describe "action buttons" do
     {
-      review_requested: "Send for review",
-      mark_as_approved: "Mark as Approved",
-      publish:          "Publish Guide",
+      send_for_review: "Send for review",
+      approve_for_publication: "Approve for publication",
+      publish:          "Publish",
     }.each do |name, title|
       define_method :"expect_#{name}_to_be" do |state|
         if state == :visible
@@ -199,8 +199,8 @@ RSpec.describe "creating guides", type: :feature do
       end
 
       it "only allows requesting of reviews" do
-        expect_review_requested_to_be :visible
-        expect_mark_as_approved_to_be :hidden
+        expect_send_for_review_to_be :visible
+        expect_approve_for_publication_to_be :hidden
         expect_publish_to_be :hidden
       end
     end
@@ -213,8 +213,8 @@ RSpec.describe "creating guides", type: :feature do
       end
 
       it "only allows being marked at approved" do
-        expect_review_requested_to_be :hidden
-        expect_mark_as_approved_to_be :visible
+        expect_send_for_review_to_be :hidden
+        expect_approve_for_publication_to_be :visible
         expect_publish_to_be :hidden
       end
     end
@@ -227,8 +227,8 @@ RSpec.describe "creating guides", type: :feature do
       end
 
       it "only allows publishing" do
-        expect_review_requested_to_be :hidden
-        expect_mark_as_approved_to_be :hidden
+        expect_send_for_review_to_be :hidden
+        expect_approve_for_publication_to_be :hidden
         expect_publish_to_be :visible
       end
     end


### PR DESCRIPTION
- Don't add "Back to all guides" button, because this essentially
replicates the behaviour of the browser back button.
- Don't have different save buttons for persisted and not persisted
  guides, because it's inconsistent.

https://trello.com/c/YoTKvG78/87-renaming-and-restructuring-calls-to-action