### PR TITLE
Action buttons. Action buttons everywhere

### DIFF
--- a/app/views/edition_changes/show.html.erb
+++ b/app/views/edition_changes/show.html.erb
@@ -33,4 +33,10 @@
       </div>
     <% end %>
   </div>
+
+  <div class="col-md-12">
+    <%= form_for @edition.guide do |f| %>
+      <%= render 'editions/actions', publish_controls_only: true, form: f, guide: @edition.guide, edition: @edition %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/editions/_actions.html.erb
+++ b/app/views/editions/_actions.html.erb
@@ -28,12 +28,12 @@
           <%= form.submit "Send for review", name: :send_for_review, class: 'btn btn-success', disabled: true %>
         <% end %>
 
-        <% if edition.approval %>
-          <p class="text-info">
-            <strong>Changes approved by <%= edition.approval.user.name %>.</strong>
-          </p>
-        <% end %>
       </div>
     </div>
+    <% if edition.approval %>
+      <p class="text-info">
+        <strong>Changes approved by <%= edition.approval.user.name %>.</strong>
+      </p>
+    <% end %>
   </div>
 </div>

--- a/app/views/editions/comments.html.erb
+++ b/app/views/editions/comments.html.erb
@@ -4,6 +4,7 @@
 <%= form_for @guide do |f| %>
   <%= render 'editions/actions', publish_controls_only: true, form: f, guide: @guide, edition: @edition %>
 <% end %>
+
 <% @editions.each do |edition| %>
   <div class="panel panel-default">
     <div class="panel-heading">
@@ -20,4 +21,8 @@
       <%= render 'editions/comments', edition: edition, comments: edition.comments.for_rendering %>
     </div>
   </div>
+<% end %>
+
+<%= form_for @guide do |f| %>
+  <%= render 'editions/actions', publish_controls_only: true, form: f, guide: @guide, edition: @edition %>
 <% end %>

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -71,7 +71,11 @@
         </div>
       <% end %>
     </div>
+  </div>
 
-
+  <div class="col-md-12">
+    <%= form_for @guide do |f| %>
+      <%= render 'editions/actions', publish_controls_only: true, form: f, guide: @guide, edition: @edition %>
+    <% end %>
   </div>
 </div>

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -85,4 +85,8 @@
     </div>
   </div>
 
+  <div class="col-md-12">
+    <%= render 'editions/actions', publish_controls_only: false, form: f, guide: @guide, edition: @guide.latest_edition %>
+  </div>
+
 <% end %>

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       the_form_should_be_prepopulated_with_title "Standups"
       fill_in "Guide title", with: "Standup meetings"
       fill_in "Change to be made", with: "Be more specific in the title"
-      click_button "Save"
+      click_first_button 'Save'
 
       guide.reload
       expect(guide.editions.published.size).to eq 1
@@ -46,7 +46,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
 
     fill_in "Guide title", with: "Agile"
 
-    click_button "Save"
+    click_first_button 'Save'
 
     expect(guide.editions.published.map(&:title)).to match_array ["Agile development"]
     expect(guide.editions.draft.map(&:title)).to match_array ["Agile"]
@@ -67,7 +67,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       visit edit_guide_path(guide)
       fill_in "Guide title", with: "Updated Title"
       fill_in "Change to be made", with: "Update Title"
-      click_button "Save"
+      click_first_button 'Save'
 
       the_form_should_be_prepopulated_with_title "Updated Title"
 
@@ -84,7 +84,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       visit guides_path
       click_link "Edit"
       fill_in "Change to be made", with: "Fix a typo"
-      click_button "Save"
+      click_first_button 'Save'
 
       within ".alert" do
         expect(page).to have_content('Error message stub')
@@ -97,7 +97,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       visit edition_path(guide.latest_edition)
       expect_any_instance_of(GuidePublisher).to receive(:publish).and_raise api_error
 
-      click_button "Publish"
+      click_first_button "Publish"
 
       within ".alert" do
         expect(page).to have_content('Error message stub')
@@ -114,7 +114,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     visit guides_path
     click_link "Edit"
     fill_in "Guide title", with: "Agile"
-    click_button "Save"
+    click_first_button 'Save'
     expect(current_path).to eq edit_guide_path guide
 
     expect(guide.editions.draft.size).to eq 1
@@ -126,7 +126,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     guide = given_a_guide_exists state: 'draft'
     visit edit_guide_path(guide)
     fill_in "Guide title", with: "An amended title"
-    click_button "Save"
+    click_first_button 'Save'
     visit guides_path
     within ".last-edited-by" do
       expect(page).to have_content "John Smith"
@@ -141,7 +141,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     expect_any_instance_of(GuidePublisher).to receive(:put_draft)
 
     expect_external_redirect_to "http://draft-origin.dev.gov.uk/service-manual/preview-test" do
-      click_button "Save and preview"
+      click_first_button "Save and preview"
     end
 
     expect(guide.editions.map(&:title)).to match_array ["Changed Title"]
@@ -153,7 +153,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       guide = Guide.create!(latest_edition: edition, slug: "/service-manual/something")
 
       visit edit_guide_path(guide)
-      click_button "Send for review"
+      click_first_button "Send for review"
       expect(page).to have_content "Review Requested"
     end
 
@@ -166,7 +166,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
         login_as reviewer
         visit guides_path
         click_link "Standups"
-        click_button "Approve for publication"
+        click_first_button "Approve for publication"
 
         expect(current_path).to eq edition_path(edition)
         expect(page).to have_content "Thanks for approving this guide"
@@ -223,7 +223,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       fill_in "Guide title", with: "Second Edition"
       fill_in "Body", with: "## Hi"
       fill_in "Change to be made", with: "Better greeting"
-      click_button "Save"
+      click_first_button 'Save'
       click_link "Compare changes"
 
       within ".title del" do

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "creating guides", type: :feature do
                             .twice
                             .with(an_instance_of(String), be_valid_against_schema('service_manual_guide'))
 
-    click_button "Save"
+    click_first_button "Save"
 
     within ".alert" do
       expect(page).to have_content('created')
@@ -47,7 +47,7 @@ RSpec.describe "creating guides", type: :feature do
 
     visit edit_guide_path(guide)
     fill_in "Guide title", with: "Second Edition Title"
-    click_button "Save"
+    click_first_button "Save"
 
     within ".alert" do
       expect(page).to have_content('updated')
@@ -72,18 +72,18 @@ RSpec.describe "creating guides", type: :feature do
                             .once
                             .with(an_instance_of(String), 'major')
 
-    click_button "Save"
+    click_first_button "Save"
     guide = Guide.first
     visit edit_guide_path(guide)
-    click_button "Send for review"
+    click_first_button "Send for review"
 
     login_as(User.new(name: "Reviewer")) do
       visit edition_path(guide.latest_edition)
-      click_button "Approve for publication"
+      click_first_button "Approve for publication"
     end
 
     visit edition_path(guide.latest_edition)
-    click_button "Publish"
+    click_first_button "Publish"
 
     within ".alert-success" do
       expect(page).to have_content('published')
@@ -105,7 +105,7 @@ RSpec.describe "creating guides", type: :feature do
 
       it "shows api errors" do
         fill_in_guide_form
-        click_button "Save"
+        click_first_button "Save"
 
         within ".alert" do
           expect(page).to have_content('Error message stub')
@@ -114,7 +114,7 @@ RSpec.describe "creating guides", type: :feature do
 
       it "does not store a guide" do
         fill_in_guide_form
-        click_button "Save"
+        click_first_button "Save"
 
         expect(Guide.count).to eq 0
         expect(Edition.count).to eq 0
@@ -133,7 +133,7 @@ RSpec.describe "creating guides", type: :feature do
       guide = Guide.create!(slug: "/service-manual/something", latest_edition: Generators.valid_edition)
       visit edit_guide_path(guide)
       fill_in "Guide title", with: ""
-      click_button "Save"
+      click_first_button "Save"
 
       within(".full-error-list") do
         expect(page).to have_content("title can't be blank")
@@ -152,7 +152,7 @@ RSpec.describe "creating guides", type: :feature do
         expect_any_instance_of(GuidePublisher).to receive(:put_draft).once.and_raise(api_error)
 
         visit edit_guide_path(guide)
-        click_button "Save"
+        click_first_button "Save"
 
         within ".alert" do
           expect(page).to have_content('Error message stub')
@@ -167,7 +167,7 @@ RSpec.describe "creating guides", type: :feature do
 
         visit edit_guide_path(guide)
         fill_in "Guide title", with: "Changed Title"
-        click_button "Save"
+        click_first_button "Save"
 
         expect(Guide.count).to eq 1
         expect(Guide.first.latest_edition.title).to_not eq "Changed Title"

--- a/spec/support/capybara_helpers.rb
+++ b/spec/support/capybara_helpers.rb
@@ -1,0 +1,10 @@
+module CapybaraHelpers
+  def click_first_button(value)
+    first(:css, "input[value='#{value}']").click
+  end
+end
+
+
+RSpec.configure do |config|
+  config.include CapybaraHelpers, type: :feature
+end


### PR DESCRIPTION
Duplicate all guide action buttons at the bottom of the page.


As per design suggestions - this should make it easier for the users to find
action buttons regardless of where they are on the page.

![](http://i.imgur.com/jrI1nhE.jpg)

Many tests broke because button matchers became ambiguous with two of each
button visible on the page. I've written a helper that allows to click the
first visible button.
