### PR TITLE
Revamp change notes UI

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -131,6 +131,7 @@ private
         :related_discussion_title,
         :update_type,
         :change_note,
+        :change_summary,
       ]).deep_merge(with)
   end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -15,6 +15,7 @@ class Edition < ActiveRecord::Base
   validates_presence_of [:state, :phase, :description, :title, :update_type, :body, :content_owner, :user]
   validates_inclusion_of :state, in: %w(draft published review_requested approved)
   validates :change_note, presence: true, if: :major?
+  validates :change_summary, presence: true, if: :major?
   validate :published_cant_change
 
   %w{minor major}.each do |s|

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -5,10 +5,52 @@
   </div>
 
   <div class="col-md-8">
-    <div class="well">
-      <%= render 'shared/form_error_summary', object: guide %>
+    <%= render 'shared/form_error_summary', object: guide %>
+    <%= f.fields_for :latest_edition, guide.latest_editable_edition do |editions_form| %>
 
-      <%= f.fields_for :latest_edition, guide.latest_editable_edition do |editions_form| %>
+      <div class="well">
+        <h2>About this update</h2>
+
+        <div class='form-group'>
+          <label>Impact of the update</label>
+          <%= editions_form.error_list :update_type %>
+          <div class="radio">
+            <%= label_tag do %>
+              <%= editions_form.radio_button :update_type, "minor", { class: 'update-type-select'} %>
+              Minor update
+              <span class='text-muted'>e.g. spelling or typographic corrections.</span>
+            <% end %>
+          </div>
+          <div class="radio">
+            <%= label_tag do %>
+              <%= editions_form.radio_button :update_type, "major", { class: 'update-type-select'} %>
+              Major update
+              <span class='text-muted'>e.g. updates that change the meaning of the guidance.</span>
+            <% end %>
+          </div>
+        </div>
+
+        <div class="form-group change-note-form-group">
+          <%= editions_form.label :change_summary, "Summary of change" %>
+          <div class="help-block">What is being changed in this update</div>
+          <%= editions_form.text_field :change_summary, class: 'input-md-12 form-control', rows: 5 %>
+        </div>
+
+        <div class="form-group change-note-form-group">
+          <%= editions_form.label :change_note, "Why the change is being made" %>
+          <div class="help-block">Include any evidence from research and links to any related discussions</div>
+          <%= editions_form.text_area :change_note, class: 'input-md-12 form-control', rows: 5 %>
+        </div>
+
+        <p class="text-strong change-note-form-group">
+          <span class="glyphicon glyphicon-warning-sign text-warning" aria-hidden="true"></span>
+          <strong>These notes will be made visible to the public and subscribed users will receive an email update when this guide is published.</strong>
+        </p>
+      </div>
+
+      <div class="well">
+        <h2>Guide content</h2>
+
         <div class="form-group">
           <%= editions_form.label :title, "Guide title" %>
           <%= editions_form.error_list :title %>
@@ -40,31 +82,8 @@
           <%= editions_form.error_list :content_owner_id %>
           <%= editions_form.select :content_owner_id, ContentOwner.all.pluck(:title, :id), {}, {class: 'select2 input-md-12 form-control'} %>
         </div>
-
-        <div class='form-group'>
-          <label>Update type</label>
-          <%= editions_form.error_list :update_type %>
-          <div class="radio">
-            <%= label_tag do %>
-              <%= editions_form.radio_button :update_type, "minor", { class: 'update-type-select'} %>
-              Minor update
-            <% end %>
-          </div>
-          <div class="radio">
-            <%= label_tag do %>
-              <%= editions_form.radio_button :update_type, "major", { class: 'update-type-select'} %>
-              Major update
-            <% end %>
-          </div>
-        </div>
-        <div class="form-group change-note-form-group">
-          <%= editions_form.label :change_note, "Change to be made" %>
-          <span>(visible publicly)</span>
-          <%= editions_form.text_area :change_note, class: 'input-md-12 form-control', rows: 5 %>
-          <span class="help-block">Explain the change, the reason for the change and provide some context.</span>
-        </div>
-      <% end %>
-    </div>
+      </div>
+    <% end %>
   </div>
 
   <div class="col-md-4">

--- a/db/migrate/20151211164627_add_change_summary_to_editions.rb
+++ b/db/migrate/20151211164627_add_change_summary_to_editions.rb
@@ -1,0 +1,5 @@
+class AddChangeSummaryToEditions < ActiveRecord::Migration
+  def change
+    add_column :editions, :change_summary, :text
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -161,7 +161,8 @@ CREATE TABLE editions (
     updated_at timestamp without time zone NOT NULL,
     state text,
     change_note text,
-    content_owner_id integer NOT NULL
+    content_owner_id integer NOT NULL,
+    change_summary text
 );
 
 
@@ -512,4 +513,6 @@ INSERT INTO schema_migrations (version) VALUES ('20151112133846');
 INSERT INTO schema_migrations (version) VALUES ('20151116113920');
 
 INSERT INTO schema_migrations (version) VALUES ('20151119131239');
+
+INSERT INTO schema_migrations (version) VALUES ('20151211164627');
 

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       click_link "Edit"
       the_form_should_be_prepopulated_with_title "Standups"
       fill_in "Guide title", with: "Standup meetings"
-      fill_in "Change to be made", with: "Be more specific in the title"
+      fill_in "Why the change is being made", with: "Be more specific in the title"
       click_first_button 'Save'
 
       guide.reload
@@ -31,7 +31,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       visit guides_path
 
       click_link "Edit"
-      expect(find_field("Change to be made").value).to be_blank
+      expect(find_field("Why the change is being made").value).to be_blank
 
       expect(find_field("Major update")).to be_checked
     end
@@ -66,7 +66,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
 
       visit edit_guide_path(guide)
       fill_in "Guide title", with: "Updated Title"
-      fill_in "Change to be made", with: "Update Title"
+      fill_in "Why the change is being made", with: "Update Title"
       click_first_button 'Save'
 
       the_form_should_be_prepopulated_with_title "Updated Title"
@@ -83,7 +83,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
 
       visit guides_path
       click_link "Edit"
-      fill_in "Change to be made", with: "Fix a typo"
+      fill_in "Why the change is being made", with: "Fix a typo"
       click_first_button 'Save'
 
       within ".alert" do
@@ -222,7 +222,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       visit edit_guide_path(guide)
       fill_in "Guide title", with: "Second Edition"
       fill_in "Body", with: "## Hi"
-      fill_in "Change to be made", with: "Better greeting"
+      fill_in "Why the change is being made", with: "Better greeting"
       click_first_button 'Save'
       click_link "Compare changes"
 

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -245,6 +245,7 @@ private
     fill_in "Body", with: "## First Edition Title"
 
     choose "Major update"
-    fill_in "Change to be made", with: "Change Note"
+    fill_in "Summary of change", with: "Factual change"
+    fill_in "Why the change is being made", with: "Change Note"
   end
 end

--- a/spec/support/generators.rb
+++ b/spec/support/generators.rb
@@ -3,15 +3,16 @@ class Generators
     content_owner = ContentOwner.first || ContentOwner.create(title: "content owner title", href: "content_owner_href")
 
     attributes = {
-      title:         "The Title",
-      state:         "draft",
-      phase:         "beta",
-      description:   "Description",
-      update_type:   "major",
-      change_note:   "change note",
-      body:          "# Heading",
-      content_owner: content_owner,
-      user:          User.new(name: "Generated User")
+      title:          "The Title",
+      state:          "draft",
+      phase:          "beta",
+      description:    "Description",
+      update_type:    "major",
+      change_note:    "change note",
+      change_summary: "change summary",
+      body:           "# Heading",
+      content_owner:  content_owner,
+      user:           User.new(name: "Generated User")
     }.merge(attributes)
 
     Edition.new(attributes)


### PR DESCRIPTION
After user testing it has became clear that users do not understand the two
modes of update types. Make it clear what each mode means in the UI.

Also, move the whole thing to the top of the form and visually separate it from
the content section (I've put in in a separate 'well' container). This implies
that users should write the change note before making any content editions.

Add a 'change summary' field alongside the 'change note' field. This should
make users think about how they write change notes and suggest git/github
change note style.

![](https://dl.dropbox.com/u/1197930/screenshots/ETOURECU-2015.12.14-11-10-09.png)