### PR TITLE
Fix a test that started failing due to a merge conflict

### DIFF
--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -45,9 +45,9 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       expect(indexer).to receive(:index)
       visit guides_path
       click_link "Edit"
-      click_button "Send for review"
-      click_button "Approve for publication"
-      click_button "Publish"
+      click_first_button "Send for review"
+      click_first_button "Approve for publication"
+      click_first_button "Publish"
     end
   end
 


### PR DESCRIPTION
The issue was introduced by combining changes from the search branch and the
branch that added extra row of action buttons.

@AndrewVos 