### PR TITLE
Disable publishing based on an ENV variable

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -94,6 +94,12 @@ private
   end
 
   def publish
+    if ENV['DISABLE_PUBLISHING']
+      @edition = @guide.latest_edition
+      flash[:error] = "Publishing is currently disabled. The guide has not been published."
+      return render template: 'editions/show'
+    end
+
     ActiveRecord::Base.transaction do
       @guide.latest_edition.update_attributes!(state: 'published')
       GuidePublisher.new(guide: @guide).publish

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -8,6 +8,22 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     allow_any_instance_of(SearchIndexer).to receive(:index)
   end
 
+  context "trying to publish while it's disabled" do
+    it "should prevent it from happening" do
+      ENV['DISABLE_PUBLISHING'] = '1'
+      expect_any_instance_of(GuidePublisher).to_not receive(:publish)
+      guide = given_a_guide_exists title: "Standups", state: 'approved'
+      visit edit_guide_path(guide)
+      click_first_button "Publish"
+
+      within ".alert" do
+        expect(page).to have_content("Publishing is currently disabled")
+      end
+    end
+
+    after { ENV.delete('DISABLE_PUBLISHING') }
+  end
+
   context "latest edition is published" do
     it "should create a new draft edition when saving changes" do
       guide = given_a_published_guide_exists title: "Standups"


### PR DESCRIPTION
We intend to deploy the application to production but we are not ready to
publish any documents yet (we need to coordinate old content replacement,
prepare topic pages etc.). Having the application in production will allow
content designers to work on drafts without losing them every night (as in
preview/integration environment).

We intend to set this environment variable in production instances only (not
staging).