### PR TITLE
Never fail when indexing content

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -97,7 +97,7 @@ private
     ActiveRecord::Base.transaction do
       @guide.latest_edition.update_attributes!(state: 'published')
       GuidePublisher.new(guide: @guide).publish
-      SearchIndexer.new(@guide).index
+      index_for_search(@guide)
       redirect_to back_or_default, notice: "Guide has been published"
     end
   rescue GdsApi::HTTPErrorResponse => e
@@ -134,5 +134,12 @@ private
         :change_note,
         :change_summary,
       ]).deep_merge(with)
+  end
+
+  def index_for_search(guide)
+    SearchIndexer.new(guide).index
+  rescue => e
+    notify_airbrake(e)
+    Rails.logger.error(e.message)
   end
 end

--- a/spec/controllers/guides_controller_spec.rb
+++ b/spec/controllers/guides_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe GuidesController, type: :controller do
+  before do
+    login_as User.create(name: "Content Designer")
+    allow_any_instance_of(GuidePublisher).to receive(:publish)
+  end
+
+  describe "#update" do
+    it 'notifies about search indexing errors but does not fail the transaction' do
+      expect_any_instance_of(Rummageable::Index).to receive(:add_batch).and_raise("Something went wrong")
+      edition = Generators.valid_edition(state: 'approved')
+      guide = Guide.create!(slug: "/service-manual/test", editions: [edition])
+      expect(controller).to receive(:notify_airbrake)
+
+      put :update, id: edition.guide_id, publish: true
+
+      expect(response).to redirect_to(root_url)
+      expect(flash[:notice]).to eq "Guide has been published"
+    end
+  end
+end


### PR DESCRIPTION
Local persistence, publishing and indexing happens in the same transaction. If
any of those steps fail, the local database transaction is rolled back. Having
two external API requests that can fail leaves a margin for an inconsistency
between local DB and publishing API, e.g.:

- publishing-api call succeeds
- search indexing fails
- DB transaction gets rolled back
=> Publishing API has a published guide, local DB has an unpublished guide.

Make sure search indexing never fails the operation, but still notify developers
about the error so they can re-index manually e.g. by re-publishing a minor
edition of the guide.