### PR TITLE
Improve diffing UI based on user feedback

### DIFF
--- a/app/assets/stylesheets/diffy.scss.erb
+++ b/app/assets/stylesheets/diffy.scss.erb
@@ -1,7 +1,19 @@
 <%= Diffy::CSS %>
 
 .diff {
+  $symbol-spacing: 1.5em;
+
+  del {
+    text-decoration: line-through;
+  }
   ul {
     background: transparent;
+    padding-left: $symbol-spacing;
+  }
+  span.symbol {
+    display: inline-block;
+    margin-left: -$symbol-spacing;
+    width: $symbol-spacing;
+    font-weight: bold;
   }
 }


### PR DESCRIPTION
The results from the content design survey weren't totally conclusive but the
eventual winner was "+/- at the start of the rows with a strike through for
deletions".

The only point of confusion around this option was the +/- sit a little too
close to the rest of the body copy, and thus looks a bit like the markdown
itself. Increase the margin between the two.

![lwklgajw-2015 12 16-16-05-57](https://cloud.githubusercontent.com/assets/218239/11846168/4cb597ee-a40f-11e5-986e-481881408e94.png)
