### PR TITLE
Require 'signin' permission to access the application

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   include GDS::SSO::ControllerMethods
-  before_filter :authenticate_user!
+  before_filter :require_signin_permission!
 
   def guide_preview_url(guide)
     [Plek.find('draft-origin'), guide.slug].join('')

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ApplicationController do
 
   describe "authentication" do
     it "should authenticate users before every request served by a controller that inherits from ApplicationController" do
-      expect(controller).to receive(:authenticate_user!).and_return(true)
+      expect(controller).to receive(:require_signin_permission!).and_return(true)
       get :index
     end
   end

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe CommentsController, type: :controller do
-  before { login_as User.create(name: "Commenter") }
+  before { login_as User.create(name: "Commenter", permissions: ['signin']) }
 
   describe "#create" do
     it 'redirects to a url with a unique anchor tag pointing to a comment' do

--- a/spec/controllers/guides_controller_spec.rb
+++ b/spec/controllers/guides_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe GuidesController, type: :controller do
   before do
-    login_as User.create(name: "Content Designer")
+    login_as User.create(name: "Content Designer", permissions: ["signin"])
     allow_any_instance_of(GuidePublisher).to receive(:publish)
   end
 

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -3,6 +3,7 @@ module AuthenticationHelpers
     @stub_user ||= User.create!(
       uid: SecureRandom.hex,
       name: "Stub User",
+      permissions: ["signin"],
     )
   end
 


### PR DESCRIPTION
Requiring 'signin' permission allows access only to the users who are
explicitly granted access to the application. This replaces previous behaviour
where anyone with a GDS signon account was able to access it.