### PR TITLE
Improve slug validation

### DIFF
--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -1,10 +1,6 @@
 class Guide < ActiveRecord::Base
   validates :content_id, presence: true, uniqueness: true
-  validates :slug, presence: true
-  validates :slug, format: {
-    with: /\A\/service-manual\//,
-    message: "must be be prefixed with /service-manual/"
-  }
+  validate :slug_format
 
   has_many :editions
   has_one :latest_edition, -> { order(created_at: :desc) }, class_name: "Edition"
@@ -52,6 +48,16 @@ class Guide < ActiveRecord::Base
       end
     else
       latest_edition
+    end
+  end
+
+private
+
+  def slug_format
+    if !slug.to_s.match(/\A\/service-manual\//)
+      errors.add(:slug, "must be present and start with '/service-manual/'")
+    elsif !slug.to_s.match(/\A\/service-manual\/\w+/)
+      errors.add(:slug, "must be filled in")
     end
   end
 end

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -40,7 +40,14 @@ RSpec.describe Guide do
       edition = Generators.valid_published_edition
       edition = Guide.new(slug: "/something", latest_edition: edition)
       edition.valid?
-      expect(edition.errors.full_messages_for(:slug)).to eq ["Slug must be be prefixed with /service-manual/"]
+      expect(edition.errors.full_messages_for(:slug)).to eq ["Slug must be present and start with '/service-manual/'"]
+    end
+
+    it "reminds users if they've forgotten to change the default pre-filled slug value" do
+      edition = Generators.valid_published_edition
+      edition = Guide.new(slug: "/service-manual/", latest_edition: edition)
+      edition.valid?
+      expect(edition.errors.full_messages_for(:slug)).to eq ["Slug must be filled in"]
     end
   end
 


### PR DESCRIPTION
We've received feedback that the form shows the following error:
"Base path is not a valid absolute URL path, Routes is not a valid absolute URL
path" when a user forgets to changed the slug value that is pre-filled with
'/service-manual/' by default. That error comes from the publishing API and is
a bit confusing. Validate it in the application and improve the error messages.