### PR TITLE
Users can delete search documents from search index for slug migrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'airbrake', '~> 4.2.1'
 gem 'govuk_admin_template', '~> 3.5.0'
 
 gem 'gds-sso', '~> 11.0.0'
-gem 'gds-api-adapters', '~> 25.1.0'
+gem 'gds-api-adapters', '~> 26.7'
 gem 'govspeak', '~> 3.4.0'
 gem 'kaminari', '~> 0.16.3'
 gem 'acts_as_commentable', '~> 4.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
     execjs (2.6.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (25.1.0)
+    gds-api-adapters (26.7.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -304,7 +304,7 @@ DEPENDENCIES
   capybara
   database_cleaner
   diffy (~> 3.0, >= 3.0.7)
-  gds-api-adapters (~> 25.1.0)
+  gds-api-adapters (~> 26.7)
   gds-sso (~> 11.0.0)
   govspeak (~> 3.4.0)
   govuk-content-schema-test-helpers (~> 1.3.0)

--- a/app/controllers/slug_migrations_controller.rb
+++ b/app/controllers/slug_migrations_controller.rb
@@ -46,4 +46,11 @@ class SlugMigrationsController < ApplicationController
   def show
     @slug_migration = SlugMigration.find(params[:id])
   end
+
+  def delete_search_index
+    @slug_migration = SlugMigration.find(params[:slug_migration_id])
+    @slug_migration.delete_search_document!
+
+    redirect_to edit_slug_migration_path(@slug_migration), notice: "Document has been removed from search"
+  end
 end

--- a/app/models/slug_migration.rb
+++ b/app/models/slug_migration.rb
@@ -1,3 +1,5 @@
+require 'gds_api/rummager'
+
 class SlugMigration < ActiveRecord::Base
   belongs_to :guide
 
@@ -10,6 +12,20 @@ class SlugMigration < ActiveRecord::Base
 
   before_validation on: :create do |object|
     object.content_id = SecureRandom.uuid
+  end
+
+  def has_search_document?
+    @search_client ||= GdsApi::Rummager.new(Plek.current.find('rummager'), disable_cache: true)
+    begin
+      @search_client.get_content!(slug)
+    rescue GdsApi::HTTPNotFound => e
+      false
+    end
+  end
+
+  def delete_search_document!
+    @search_client ||= GdsApi::Rummager.new(Plek.current.find('rummager'), disable_cache: true)
+    @search_client.delete_content!(slug)
   end
 
   private

--- a/app/views/slug_migrations/edit.html.erb
+++ b/app/views/slug_migrations/edit.html.erb
@@ -17,3 +17,16 @@
     </div>
   <% end %>
 </div>
+
+<div class='well'>
+  <h2>Search index</h2>
+  <% if @slug_migration.has_search_document? %>
+    <%= form_tag slug_migration_delete_search_index_path(slug_migration_id: @slug_migration.id) do |f| %>
+      <%= submit_tag "Delete from search index", class: "btn btn-danger" %>
+    <% end %>
+  <% else %>
+    <p>
+      This url has nothing indexed in search
+    </p>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,9 @@ Rails.application.routes.draw do
   resources :approvals
   resources :comments
 
-  resources :slug_migrations
+  resources :slug_migrations do
+    post '/delete_search_index' => 'slug_migrations#delete_search_index', as: :delete_search_index
+  end
 
   get '/edition_changes(/:old_edition_id)/:new_edition_id' => 'edition_changes#show', as: :edition_changes
   get '/edition_comments/:id' => 'editions#comments', as: :edition_comments

--- a/spec/features/slug_migration_spec.rb
+++ b/spec/features/slug_migration_spec.rb
@@ -2,6 +2,12 @@ require 'rails_helper'
 require 'capybara/rails'
 
 RSpec.describe "Slug migration", type: :feature do
+  before do
+    @rummager_double = double(:rummager)
+    allow(GdsApi::Rummager).to receive(:new).and_return @rummager_double
+    allow(@rummager_double).to receive(:get_content!).and_return(true)
+  end
+
   def expect_table_to_match_migrations migrations
     within ".slug-migrations .table" do
       table_data = page.all("tr").map do |row|
@@ -167,6 +173,39 @@ RSpec.describe "Slug migration", type: :feature do
       expect(page).to have_content "Error message stub"
       expect(slug_migration.reload.completed).to eq false
       expect(page.current_path).to eq slug_migration_path(slug_migration)
+    end
+  end
+
+  context "with a slug migration" do
+    before do
+      edition = Generators.valid_published_edition
+      guide = Guide.create!(slug: "/service-manual/path", latest_edition: edition)
+      @slug_migration = SlugMigration.create!(completed: false, slug: "/service-manual/path.html", guide: guide)
+    end
+
+    context "that has a search index" do
+      it "allows the search index to be deleted" do
+        expect(@rummager_double).to receive(:get_content!).with(@slug_migration.slug).twice.and_return(true)
+        expect(@rummager_double).to receive(:delete_content!).with(@slug_migration.slug)
+
+        visit root_path
+        click_link "Manage Migrations"
+        click_link "Manage"
+        click_button "Delete from search index"
+        expect(page).to have_content "Document has been removed from search"
+      end
+    end
+
+    context "that does not have a search index" do
+      it "does not allow the search index to be deleted" do
+        not_found_error = GdsApi::HTTPNotFound.new(404, "error", "error")
+        expect(@rummager_double).to receive(:get_content!).with(@slug_migration.slug).and_raise(not_found_error)
+
+        visit root_path
+        click_link "Manage Migrations"
+        click_link "Manage"
+        expect(page).to_not have_button "Delete from search index"
+      end
     end
   end
 end


### PR DESCRIPTION
This allows users to delete search indexes for the old service manual,
at their leisure.

~~We should update `gds-api-adapters` to the latest version when this gets a gem release: https://github.com/alphagov/gds-api-adapters/pull/413~~

![image](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-22-12-2015-14-22-39-siedeege.png)

![image](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-22-12-2015-14-23-00-eephiedo.png)