### PR TITLE
Disable publish/approve/review actions when form is modified

### DIFF
--- a/app/assets/javascripts/disable-when-dirty.js
+++ b/app/assets/javascripts/disable-when-dirty.js
@@ -1,0 +1,12 @@
+$(function() {
+  $("form").each(function() {
+    var form = $(this);
+    if (form.find(".disable-when-dirty").length > 0) {
+      $(form).on('input change', function() {
+        var elements = form.find(".disable-when-dirty");
+        elements.prop("disabled", true);
+        elements.attr("title", "Your form has unsaved changes");
+      });
+    }
+  });
+});

--- a/app/views/editions/_actions.html.erb
+++ b/app/views/editions/_actions.html.erb
@@ -15,17 +15,17 @@
 
         <% if edition.persisted? %>
           <% if edition.can_request_review? %>
-            <%= form.submit "Send for review", name: :send_for_review, class: 'btn btn-success' %>
+            <%= form.submit "Send for review", name: :send_for_review, class: 'btn btn-success disable-when-dirty' %>
           <% end %>
           <% if edition.can_be_approved? %>
-            <%= form.submit "Approve for publication", name: :approve_for_publication, class: 'btn btn-success' %>
+            <%= form.submit "Approve for publication", name: :approve_for_publication, class: 'btn btn-success disable-when-dirty' %>
           <% end %>
 
           <% if edition.can_be_published? %>
-            <%= form.submit "Publish", class: 'btn btn-success', name: :publish %>
+            <%= form.submit "Publish", class: 'btn btn-success disable-when-dirty', name: :publish %>
           <% end %>
         <% else %>
-          <%= form.submit "Send for review", name: :send_for_review, class: 'btn btn-success', disabled: true %>
+          <%= form.submit "Send for review", name: :send_for_review, class: 'btn btn-success disable-when-dirty', disabled: true %>
         <% end %>
 
       </div>


### PR DESCRIPTION
![image](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-23-12-2015-14-09-28-oogeidoe.png)

I'm not entirely sure I like this approach. Could the reviewer focus on UX too.

Just noticed some issues:
- doesn't work with radio buttons
- event gets attached to form multiple times

https://trello.com/c/Gflw1nRP/296-disable-the-send-for-review-button-when-the-edit-form-is-dirty