### PR TITLE
Notify users when there are unsaved changes

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,4 +13,5 @@
 //= require jquery
 //= require jquery_ujs
 //= require select2
+//= require protect_form_data
 //= require_tree .

--- a/app/assets/javascripts/protect_form_data.js
+++ b/app/assets/javascripts/protect_form_data.js
@@ -1,0 +1,50 @@
+$(function(){
+  window.okToNavigateAway = false;
+
+  $("form.js-protect-data").each(function(_, form) {
+    var $form = $(form);
+    recordChecksum($form);
+    $form.on("click", ".js-ok-to-navigate-away", function(evt){
+      window.okToNavigateAway = true;
+    });
+  });
+
+  window.onbeforeunload = function() {
+    if (window.okToNavigateAway){
+      return undefined;
+    }
+
+    forms = $("form.js-protect-data");
+    for (var i = forms.length - 1; i >= 0; i--) {
+      var form = forms[i];
+      if (hasChanged($(form))) {
+        return "It looks like there are some unsaved changes in the form.\n\nLeaving the page will discard all unsaved changes.";
+      }
+    }
+  };
+
+  function hasChanged(form){
+    if (form) {
+      var currentChecksum = checksum(form.serialize()).toString();
+      var previousChecksum = form.attr("data-checksum");
+      return currentChecksum != previousChecksum;
+    }
+    return false;
+  }
+});
+
+function checksum(string) {
+  var hashValue = 0, i, chr, len;
+  if (string.length === 0) return hashValue;
+  for (i = 0, len = string.length; i < len; i++) {
+    chr   = string.charCodeAt(i);
+    hashValue  = ((hashValue << 5) - hashValue) + chr;
+    hashValue |= 0; // Convert to 32bit integer
+  }
+  return hashValue;
+}
+
+function recordChecksum(form) {
+  var checksumValue = checksum(form.serialize());
+  form.attr("data-checksum", checksumValue);
+}

--- a/app/views/editions/_actions.html.erb
+++ b/app/views/editions/_actions.html.erb
@@ -6,8 +6,8 @@
           <%= link_to "Preview", guide_preview_url(guide), class: 'btn btn-default' %>
         <% end %>
         <% if !publish_controls_only %>
-          <%= form.submit "Save", class: 'btn btn-default', name: :save, data: disable_if_new_record(guide) %>
-          <%= form.submit "Save and preview", class: 'btn btn-default', name: :save_and_preview, data: disable_if_new_record(guide) %>
+          <%= form.submit "Save", class: 'btn btn-default js-ok-to-navigate-away', name: :save, data: disable_if_new_record(guide) %>
+          <%= form.submit "Save and preview", class: 'btn btn-default js-ok-to-navigate-away', name: :save_and_preview, data: disable_if_new_record(guide) %>
           <% if !edition.persisted? %>
             <%= link_to "Discard new guide", guides_path, class: "btn btn-danger" %>
           <% end %>

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for guide do |f| %>
+<%= form_for guide, html: { class: "js-protect-data" } do |f| %>
 
   <div class="col-md-12">
     <%= render 'editions/actions', publish_controls_only: false, form: f, guide: @guide, edition: @guide.latest_edition %>

--- a/spec/features/preventing_loss_of_changes_spec.rb
+++ b/spec/features/preventing_loss_of_changes_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe "Preventing users from losing unsaved changes in the form", type: :feature do
+  before do
+    allow_any_instance_of(GuidePublisher).to receive(:put_draft)
+    allow_any_instance_of(SearchIndexer).to receive(:index)
+  end
+
+  it "asks the user for confirmation when navigating away via 'Request review'", js: true do
+    edition = Generators.valid_edition(title: "Standups", state: 'draft')
+    guide = Guide.create!(latest_edition: edition, slug: "/service-manual/test")
+    visit edit_guide_path(guide)
+    fill_in "Body", with: "This has changed"
+    click_first_button "Send for review"
+    expect(page.driver.browser.modal_message).to include "unsaved changes"
+  end
+end


### PR DESCRIPTION
Ask users to confirm their navigation away when the guides form has unsaved
changes. It works by recording a checksum of the form values on page load, then
checking if the checksum has changed before the user tries to navigate away.
This is better than relying on 'change' events of form inputs because it takes
into account the fact that users may change the values back to the previous
ones.

~~A known shortcoming: elements that navigate away have to be explicitly marked
with a css class '.js-disable-when-dirty'. If a user navigates away clicking on
other links this will not trigger. I've tried using 'onbeforeunload' event, but
it also triggers when "Save" and "Save and preview" buttons are clicked - I am
not sure how to make it work without using ugly hacks.~~

closes #116 

If we're happy with this approach, should we add some (PhantomJS?) tests?

![shwnpwmi-2016 01 04-11-29-25](https://cloud.githubusercontent.com/assets/218239/12088800/6f323d1a-b2d6-11e5-8f70-f164c188dbc2.png)
