### PR TITLE
[Discuss] Opening preview links in a new tab

### DIFF
--- a/app/assets/javascripts/save_before_continuing.js
+++ b/app/assets/javascripts/save_before_continuing.js
@@ -1,0 +1,23 @@
+$(function() {
+  $(document).on("click", ".js-save-before-continuing", function(event){
+    var link = $(event.currentTarget);
+    var form = link.closest('form');
+    var serialisedForm = form.serialize();
+
+    $.ajax({
+      async: false, // wait for this to finish proceeding with the event
+      type: form.attr('method').toUpperCase(),
+      url: form.attr('action'),
+      data: form.serialize(),
+      complete: function(response) {
+        if (response.status == 200){
+          return true;
+        } else {
+          event.preventDefault();
+          form.submit(); // submit the form (not via ajax) so the user can see the errors
+          return false;
+        }
+      }
+    });
+  });
+});

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -70,12 +70,20 @@ class GuidesController < ApplicationController
         GuidePublisher.new(guide: @guide).put_draft
         redirect_to success_url(@guide), notice: "Guide has been updated"
       else
-        render action: :edit
+        respond_to do |format|
+          format.js { head :unprocessable_entity }
+          format.html { render action: :edit }
+        end
       end
     end
   rescue GdsApi::HTTPErrorResponse => e
-    flash[:error] = e.error_details["error"]["message"]
-    render template: 'guides/edit'
+    respond_to do |format|
+      format.js { head :unprocessable_entity }
+      format.html do
+        flash[:error] = e.error_details["error"]["message"]
+        render template: 'guides/edit'
+      end
+    end
   end
 
 private

--- a/app/views/editions/_actions.html.erb
+++ b/app/views/editions/_actions.html.erb
@@ -3,7 +3,7 @@
     <div class="btn-toolbar" role="toolbar">
       <div class='btn-group'>
         <% if edition.persisted? %>
-          <%= link_to "Preview", guide_preview_url(guide), class: 'btn btn-default' %>
+          <%= link_to "Preview", guide_preview_url(guide), target: '_blank', class: 'btn btn-default' %>
         <% end %>
         <% if !publish_controls_only %>
           <%= form.submit "Save", class: 'btn btn-default', name: :save, data: disable_if_new_record(guide) %>

--- a/app/views/editions/_actions.html.erb
+++ b/app/views/editions/_actions.html.erb
@@ -7,7 +7,8 @@
         <% end %>
         <% if !publish_controls_only %>
           <%= form.submit "Save", class: 'btn btn-default', name: :save, data: disable_if_new_record(guide) %>
-          <%= form.submit "Save and preview", class: 'btn btn-default', name: :save_and_preview, data: disable_if_new_record(guide) %>
+          <%# form.submit "Save and preview", class: 'btn btn-default', name: :save_and_preview, data: disable_if_new_record(guide) %>
+          <%= link_to "Save and Preview", guide_preview_url(guide), target: '_blank', class: 'btn btn-default js-save-before-continuing' %>
           <% if !edition.persisted? %>
             <%= link_to "Discard new guide", guides_path, class: "btn btn-danger" %>
           <% end %>


### PR DESCRIPTION
User research and early user feedback has shown that vast majority of the users
expect this to open in a new tab. Some users found it difficult to navigate
back to the form when we open the preview window in the same tab.

The "Preview" link is simple, adding `target="_blank"` solves it.

However, "Save and Preview" is a bit more challenging. To save the draft first we need to submit the form. Unfortunately buttons do not have a `target="_blank"` equivalent. After trying a few hackish
solutions I've come to the conclusion that it is best to:

1) Submit the form via Ajax
2.1) If the save succeeds, proceed opening the preview link in a new tab
2.2) If the save fails, prevent the new tab opening and submit the form once
     again, this time without Ajax so that the user can see a validation message

There is a slight downside when the save fails and the user fixes the errors
and tries to "Save and Preview" once more: since the saving happens via Ajax,
validation messages do not disappear. Any ideas how to prevent this?

If we think this approach is the best there is, we should add some tests and make sure non-javascript version uses the previous behaviour (progressive enhancement etc etc).