### PR TITLE
Show a custom search header based on search query parameters

### DIFF
--- a/app/presenters/search_header_presenter.rb
+++ b/app/presenters/search_header_presenter.rb
@@ -1,0 +1,40 @@
+class SearchHeaderPresenter
+  attr_reader :params, :current_user
+
+  def initialize(params, current_user)
+    @params = params
+    @current_user = current_user
+  end
+
+  def to_s
+    [ownership, state, "guides", match, published_by].compact.join(" ")
+  end
+
+  def search?
+    [:user, :state, :content_owner, :q].any? { |field| params[field].present? }
+  end
+
+  def ownership
+    if params[:user].to_i == current_user.id
+      "My"
+    elsif params[:user].present?
+      "#{User.find(params[:user]).name}'s"
+    else
+      "Everyone's"
+    end
+  end
+
+  def state
+    params[:state].to_s.humanize.downcase.presence
+  end
+
+  def match
+    "matching \"#{params[:q]}\"" if params[:q].present?
+  end
+
+  def published_by
+    if params[:content_owner].present?
+      "published by #{ContentOwner.find(params[:content_owner]).title}"
+    end
+  end
+end

--- a/app/views/guides/index.html.erb
+++ b/app/views/guides/index.html.erb
@@ -23,6 +23,11 @@
   </div>
 
   <div class="col-md-9">
+    <% SearchHeaderPresenter.new(params, current_user).tap do |search_header| %>
+      <% if search_header.search? %>
+        <h2><%= search_header.to_s %></h2>
+      <% end %>
+    <% end %>
     <table class='table table-bordered'>
       <thead>
         <tr class='table-header'>

--- a/spec/features/filter_spec.rb
+++ b/spec/features/filter_spec.rb
@@ -93,6 +93,21 @@ RSpec.describe "filtering guides", type: :feature do
     expect(page).to_not have_text "Reviewed Standups"
   end
 
+  it "displays a page header that's based on the query" do
+    ContentOwner.create!(title: "Design Community", href: "example.com")
+    User.create!(name: "Ronan", email: "ronan@example.com")
+    visit root_path
+    within ".filters" do
+      fill_in "Title or slug", with: "Form Design"
+      select "Ronan", from: "User"
+      select "Design Community", from: "Published by"
+      select "Draft", from: "State"
+      click_button "Filter guides"
+    end
+
+    expect(page).to have_text "Ronan's draft guides matching \"Form Design\" published by Design Community"
+  end
+
   [:user, :state, :published_by].each do |n|
     define_method("filter_by_#{n}") do |value|
       visit root_path

--- a/spec/presenters/search_header_presenter_spec.rb
+++ b/spec/presenters/search_header_presenter_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe SearchHeaderPresenter do
+  describe "#search" do
+    it "is false if there are no search params present" do
+      subject = described_class.new({ test: :test }, User.new)
+      expect(subject.search?).to be false
+    end
+
+    [:user, :state, :content_owner, :q].each do |search_param|
+      it "is true if at least :#{search_param} param is present" do
+        subject = described_class.new({ search_param.to_sym => :test }, User.new)
+        expect(subject.search?).to be true
+      end
+    end
+  end
+
+  describe "#to_s" do
+    let(:john) { User.create!(name: "John", email: "john@example.com") }
+
+    it "starts with 'My' if the user is looking for their guides" do
+      header = described_class.new({ user: john.id }, john).to_s
+      expect(header).to start_with "My"
+    end
+
+    it "starts with 'Everyone's' if the user has not selected an author" do
+      header = described_class.new({ user: "" }, john).to_s
+      expect(header).to start_with "Everyone's"
+    end
+
+    it "starts with 'John's' if the user is looking for John's guides" do
+      header = described_class.new({ user: john.id }, User.new).to_s
+      expect(header).to start_with "John's"
+    end
+
+    it "humanizes the state parameter" do
+      header = described_class.new({ state: 'review_requested' }, User.new).to_s
+      expect(header).to include "review requested guides"
+    end
+
+    it "displays the free-text query" do
+      header = described_class.new({ q: 'Agile Development' }, User.new).to_s
+      expect(header).to include "matching \"Agile Development\""
+    end
+
+    it "appends the selected content owner" do
+      agile_community = ContentOwner.create!(title: "Agile Community", href: 'example.com')
+      header = described_class.new({ content_owner: agile_community.id }, User.new).to_s
+      expect(header).to end_with "published by Agile Community"
+    end
+  end
+end


### PR DESCRIPTION
This feature might be useful for adding context when directly linking to a
filtered page and help users detect any errors they might make when searching.

Only the last commit needs reviewing, tis branch is based on https://github.com/alphagov/service-manual-publisher/pull/113 so 113 should be reviewed and merged first.