### PR TITLE
Automatically generate url slug from guide title

### DIFF
--- a/app/assets/javascripts/slug-generation.js
+++ b/app/assets/javascripts/slug-generation.js
@@ -1,0 +1,25 @@
+$(function() {
+  var $title = $(".js-guide-title");
+  var $slug = $(".js-guide-slug");
+  var autoGenerate = $slug.val() == "/service-manual/";
+
+  $(document).on("input", ".js-guide-slug", function() {
+    autoGenerate = false;
+  });
+
+  $(document).on("input", ".js-guide-title", function() {
+    if (autoGenerate) {
+      $slug.val("/service-manual/" + slugify($title.val()));
+    }
+  });
+
+  function slugify(text) {
+    // https://gist.github.com/mathewbyrne/1280286
+    return text.toString().toLowerCase()
+      .replace(/\s+/g, '-')        // Replace spaces with -
+      .replace(/[^\w\-]+/g, '')    // Remove all non-word chars
+      .replace(/\-\-+/g, '-')      // Replace multiple - with single -
+      .replace(/^[-_]+/, '')       // Trim - and _ from start
+      .replace(/[-_]+$/, '');      // Trim - and _ from end
+  }
+});

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -54,13 +54,13 @@
         <div class="form-group">
           <%= editions_form.label :title, "Guide title" %>
           <%= editions_form.error_list :title %>
-          <%= editions_form.text_field :title, class: 'input-md-12 form-control' %>
+          <%= editions_form.text_field :title, class: 'input-md-12 form-control js-guide-title' %>
         </div>
 
         <div class='form-group'>
           <%= f.label :slug  %>
           <%= f.error_list :slug  %>
-          <%= f.text_field :slug, class: 'input-md-12 form-control guide-slug', disabled: guide.persisted? %>
+          <%= f.text_field :slug, class: 'input-md-12 form-control guide-slug js-guide-slug', disabled: guide.persisted? %>
           <span class="help-block">Must start with '/service-manual/' and contain only letters and dashes e.g. '/service-manual/stand-up-meetings'</span>
         </div>
 

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -61,7 +61,7 @@
           <%= f.label :slug  %>
           <%= f.error_list :slug  %>
           <%= f.text_field :slug, class: 'input-md-12 form-control guide-slug js-guide-slug', disabled: guide.persisted? %>
-          <span class="help-block">Must start with '/service-manual/' and contain only letters and dashes e.g. '/service-manual/stand-up-meetings'</span>
+          <span class="help-block">Must start with '/service-manual/' and contain only letters and dashes e.g. '/service-manual/stand-up-meetings'. See <a href="https://insidegovuk.blog.gov.uk/url-standards-for-gov-uk/">URL standards for GOV.UK</a>.</span>
         </div>
 
         <div class='form-group'>

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -236,6 +236,30 @@ RSpec.describe "creating guides", type: :feature do
     end
   end
 
+  describe "slug generation" do
+    it "generates slug", js: true do
+      {
+        "Guide title": "guide-title",
+        "slug--with-----hyphens": "slug-with-hyphens",
+        "       space    slugs  ": "space-slugs",
+        'other things !@#$%^&*()_-+=/\\': "other-things",
+      }.each do |title, expected_slug|
+        expected_slug = "/service-manual/#{expected_slug}"
+
+        fill_in "Guide title", with: title
+        expect(find_field('Slug').value).to eq expected_slug
+      end
+    end
+
+    context "user edits slug manually" do
+      it "does not generate slug" do
+        fill_in "Slug", with: "/service-manual/something"
+        fill_in "Guide title", with: "My Guide Title"
+        expect(find_field('Slug').value).to eq '/service-manual/something'
+      end
+    end
+  end
+
 private
 
   def fill_in_guide_form


### PR DESCRIPTION
Still allow editor to change slug while creating guides though.