### PR TITLE
Return ability to save documents without notifying users

### DIFF
--- a/app/views/editions/_actions.html.erb
+++ b/app/views/editions/_actions.html.erb
@@ -6,8 +6,8 @@
         <%= link_to "Preview", guide_preview_url(guide), class: 'btn btn-default add-right-margin' %>
       <% end %>
       <% if !publish_controls_only %>
-        <%= form.submit "Save", class: 'btn btn-default add-right-margin', name: :save, data: disable_if_new_record(guide) %>
-        <%= form.submit "Save and preview", class: 'btn btn-default add-right-margin', name: :save_and_preview, data: disable_if_new_record(guide) %>
+        <%= form.submit "Save", class: 'btn btn-default add-right-margin js-ok-to-navigate-away', name: :save, data: disable_if_new_record(guide) %>
+        <%= form.submit "Save and preview", class: 'btn btn-default add-right-margin js-ok-to-navigate-away', name: :save_and_preview, data: disable_if_new_record(guide) %>
         <% if !edition.persisted? %>
           <%= link_to "Discard new guide", guides_path, class: "btn btn-danger add-right-margin" %>
         <% end %>

--- a/spec/features/preventing_loss_of_changes_spec.rb
+++ b/spec/features/preventing_loss_of_changes_spec.rb
@@ -14,4 +14,13 @@ RSpec.describe "Preventing users from losing unsaved changes in the form", type:
     click_first_button "Send for review"
     expect(page.driver.browser.modal_message).to include "unsaved changes"
   end
+
+  it "does not notify the user when navigating away via 'Save'", js: true do
+    edition = Generators.valid_edition(title: "Standups", state: 'draft')
+    guide = Guide.create!(latest_edition: edition, slug: "/service-manual/test")
+    visit edit_guide_path(guide)
+    fill_in "Body", with: "This has changed"
+    click_first_button "Save"
+    expect(page.driver.browser.modal_message).to be_blank
+  end
 end


### PR DESCRIPTION
Looks like one of the commits [1] has accidentally removed css classes that
white-list 'Save' buttons for user notification about unsaved changes in the
forms. I've added a regression test to make sure this does not happen again.

[1] - https://github.com/alphagov/service-manual-publisher/commit/e5bd9c9bf7ca0c8ea0147781c5e9bcaee5ddf659#diff-e42add9607e3c520f26a660d0555cd8b