### PR TITLE
Do not show the Update type form fields for new guides

### DIFF
--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -8,45 +8,49 @@
     <%= render 'shared/form_error_summary', object: guide %>
     <%= f.fields_for :latest_edition, guide.latest_editable_edition do |editions_form| %>
 
-      <div class="well">
-        <h2>About this update</h2>
+      <% if guide.new_record? %>
+        <%= editions_form.hidden_field :update_type, value: "minor" %>
+      <% else %>
+        <div class="well">
+          <h2>About this update</h2>
 
-        <div class='form-group'>
-          <label>Impact of the update</label>
-          <%= editions_form.error_list :update_type %>
-          <div class="radio">
-            <%= label_tag do %>
-              <%= editions_form.radio_button :update_type, "minor", { class: 'update-type-select'} %>
-              Minor update
-              <span class='text-muted'>e.g. spelling or typographic corrections.</span>
-            <% end %>
+          <div class='form-group'>
+            <label>Impact of the update</label>
+            <%= editions_form.error_list :update_type %>
+            <div class="radio">
+              <%= label_tag do %>
+                <%= editions_form.radio_button :update_type, "minor", { class: 'update-type-select'} %>
+                Minor update
+                <span class='text-muted'>e.g. spelling or typographic corrections.</span>
+              <% end %>
+            </div>
+            <div class="radio">
+              <%= label_tag do %>
+                <%= editions_form.radio_button :update_type, "major", { class: 'update-type-select'} %>
+                Major update
+                <span class='text-muted'>e.g. updates that change the meaning of the guidance.</span>
+              <% end %>
+            </div>
           </div>
-          <div class="radio">
-            <%= label_tag do %>
-              <%= editions_form.radio_button :update_type, "major", { class: 'update-type-select'} %>
-              Major update
-              <span class='text-muted'>e.g. updates that change the meaning of the guidance.</span>
-            <% end %>
+
+          <div class="form-group change-note-form-group">
+            <%= editions_form.label :change_summary, "Summary of change" %>
+            <div class="help-block">What is being changed in this update</div>
+            <%= editions_form.text_field :change_summary, class: 'input-md-12 form-control', rows: 5 %>
           </div>
-        </div>
 
-        <div class="form-group change-note-form-group">
-          <%= editions_form.label :change_summary, "Summary of change" %>
-          <div class="help-block">What is being changed in this update</div>
-          <%= editions_form.text_field :change_summary, class: 'input-md-12 form-control', rows: 5 %>
-        </div>
+          <div class="form-group change-note-form-group">
+            <%= editions_form.label :change_note, "Why the change is being made" %>
+            <div class="help-block">Include any evidence from research and links to any related discussions</div>
+            <%= editions_form.text_area :change_note, class: 'input-md-12 form-control', rows: 5 %>
+          </div>
 
-        <div class="form-group change-note-form-group">
-          <%= editions_form.label :change_note, "Why the change is being made" %>
-          <div class="help-block">Include any evidence from research and links to any related discussions</div>
-          <%= editions_form.text_area :change_note, class: 'input-md-12 form-control', rows: 5 %>
+          <p class="text-strong change-note-form-group">
+            <span class="glyphicon glyphicon-warning-sign text-warning" aria-hidden="true"></span>
+            <strong>These notes will be made visible to the public and subscribed users will receive an email update when this guide is published.</strong>
+          </p>
         </div>
-
-        <p class="text-strong change-note-form-group">
-          <span class="glyphicon glyphicon-warning-sign text-warning" aria-hidden="true"></span>
-          <strong>These notes will be made visible to the public and subscribed users will receive an email update when this guide is published.</strong>
-        </p>
-      </div>
+      <% end %>
 
       <div class="well">
         <h2>Guide content</h2>

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -42,8 +42,7 @@ RSpec.describe "creating guides", type: :feature do
     expect(edition.content_owner.href).to eq "http://sm-11.herokuapp.com/designing-services/design-community/"
     expect(edition.title).to eq "First Edition Title"
     expect(edition.body).to eq "## First Edition Title"
-    expect(edition.update_type).to eq "major"
-    expect(edition.change_note).to eq "Change Note"
+    expect(edition.update_type).to eq "minor"
     expect(edition.draft?).to eq true
     expect(edition.published?).to eq false
 
@@ -72,7 +71,7 @@ RSpec.describe "creating guides", type: :feature do
                             .with(an_instance_of(String), be_valid_against_schema('service_manual_guide'))
     expect(api_double).to receive(:publish)
                             .once
-                            .with(an_instance_of(String), 'major')
+                            .with(an_instance_of(String), 'minor')
 
     click_first_button "Save"
     guide = Guide.first
@@ -273,9 +272,5 @@ private
 
     fill_in "Guide title", with: "First Edition Title"
     fill_in "Body", with: "## First Edition Title"
-
-    choose "Major update"
-    fill_in "Summary of change", with: "Factual change"
-    fill_in "Why the change is being made", with: "Change Note"
   end
 end


### PR DESCRIPTION
User testing has revealed that the 'Update' type box when creating a new guide
is very confusing. Hide this part of the form for new guides and default to
'minor' update type. 'Minor' is the default, because 'Major' requires a change
note to be present and it's not possible to add that if the form is hidden.

Sample user feedback:
> Why does it come up with info about minor or major change when I click “create a guide”? To me that would mean only creating a new guide.