### PR TITLE
Resize textareas automatically when the content changes

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,4 +14,5 @@
 //= require jquery_ujs
 //= require select2
 //= require protect_form_data
+//= require jquery.textarea_autosize
 //= require_tree .

--- a/app/assets/javascripts/text-area-autosize.js
+++ b/app/assets/javascripts/text-area-autosize.js
@@ -1,0 +1,3 @@
+$(function() {
+  $(".js-text-area-auto-size").textareaAutoSize();
+});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,3 +2,4 @@
 @import 'select2';
 @import 'diffy';
 @import 'textarea';
+@import 'text-area-auto-size';

--- a/app/assets/stylesheets/text-area-auto-size.scss
+++ b/app/assets/stylesheets/text-area-auto-size.scss
@@ -1,0 +1,9 @@
+textarea.text-area-auto-size {
+  box-sizing: border-box;
+  min-height: 31 * 5px;
+  overflow-x: hidden; /* for Firefox (issue #5) */
+}
+
+textarea.text-area-auto-size-large {
+  min-height: 31 * 14px;
+}

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -42,7 +42,7 @@
           <div class="form-group change-note-form-group">
             <%= editions_form.label :change_note, "Why the change is being made" %>
             <div class="help-block">Include any evidence from research and links to any related discussions</div>
-            <%= editions_form.text_area :change_note, class: 'input-md-12 form-control', rows: 5 %>
+            <%= editions_form.text_area :change_note, class: 'input-md-12 form-control text-area-auto-size js-text-area-auto-size', rows: 5 %>
           </div>
 
           <p class="text-strong change-note-form-group">
@@ -71,14 +71,14 @@
         <div class='form-group'>
           <%= editions_form.label :description, "Guide description" %>
           <%= editions_form.error_list :description %>
-          <%= editions_form.text_area :description, rows: 4, class: 'input-md-12 form-control' %>
+          <%= editions_form.text_area :description, rows: 5, class: 'input-md-12 form-control text-area-auto-size js-text-area-auto-size' %>
           <span class="help-block">To be used for displaying search results, linking content etc.</span>
         </div>
 
         <div class="form-group">
           <%= editions_form.label :body %>
           <%= editions_form.error_list :body %>
-          <%= editions_form.text_area :body, class: 'input-md-12 form-control markdown-textarea', rows: 14 %>
+          <%= editions_form.text_area :body, class: 'input-md-12 form-control markdown-textarea text-area-auto-size text-area-auto-size-large js-text-area-auto-size', rows: 14 %>
         </div>
 
         <div class='form-group'>

--- a/vendor/assets/javascripts/jquery.textarea_autosize.js
+++ b/vendor/assets/javascripts/jquery.textarea_autosize.js
@@ -1,0 +1,54 @@
+/*!
+ * jQuery Textarea AutoSize plugin
+ * Author: Javier Julio
+ * Licensed under the MIT license
+ */
+;(function ($, window, document, undefined) {
+
+  var pluginName = "textareaAutoSize";
+  var pluginDataName = "plugin_" + pluginName;
+
+  var containsText = function (value) {
+    return (value.replace(/\s/g, '').length > 0);
+  };
+
+  function Plugin(element, options) {
+    this.element = element;
+    this.$element = $(element);
+    this.init();
+  }
+
+  Plugin.prototype = {
+    init: function() {
+      var height = this.$element.outerHeight();
+      var diff = parseInt(this.$element.css('paddingBottom')) +
+                 parseInt(this.$element.css('paddingTop')) || 0;
+
+      if (containsText(this.element.value)) {
+        this.$element.height(this.element.scrollHeight - diff);
+      }
+
+      // keyup is required for IE to properly reset height when deleting text
+      this.$element.on('input keyup', function(event) {
+        var $window = $(window);
+        var currentScrollPosition = $window.scrollTop();
+
+        $(this)
+          .height(0)
+          .height(this.scrollHeight - diff);
+
+        $window.scrollTop(currentScrollPosition);
+      });
+    }
+  };
+
+  $.fn[pluginName] = function (options) {
+    this.each(function() {
+      if (!$.data(this, pluginDataName)) {
+        $.data(this, pluginDataName, new Plugin(this, options));
+      }
+    });
+    return this;
+  };
+
+})(jQuery, window, document);


### PR DESCRIPTION
Content editors find the smaller textarea to be hard to work with, so
adjust the size automatically.