### PR TITLE
Use bearer token for publishing API authentication

### DIFF
--- a/app/models/guide_publisher.rb
+++ b/app/models/guide_publisher.rb
@@ -21,6 +21,9 @@ private
   end
 
   def publishing_api
-    GdsApi::PublishingApiV2.new(Plek.new.find('publishing-api'))
+    GdsApi::PublishingApiV2.new(
+      Plek.new.find('publishing-api'),
+      bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
+    )
   end
 end

--- a/app/models/slug_migration_publisher.rb
+++ b/app/models/slug_migration_publisher.rb
@@ -15,7 +15,10 @@ class SlugMigrationPublisher
         }
       ]
     }
-    publishing_api = GdsApi::PublishingApiV2.new(Plek.new.find('publishing-api'))
+    publishing_api = GdsApi::PublishingApiV2.new(
+      Plek.new.find('publishing-api'),
+      bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
+    )
     publishing_api.put_content(slug_migration.content_id, data)
     publishing_api.publish(slug_migration.content_id, "minor")
   end

--- a/spec/models/guide_publisher_spec.rb
+++ b/spec/models/guide_publisher_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe GuidePublisher do
         double_api = double(:publishing_api)
         expected_plek = Plek.new.find('publishing-api')
         expected_json = {test: :json}
+        expected_token = { bearer_token: 'example' }
         double_guide_presenter = double(:guide_presenter)
         expect(double_guide_presenter).to receive(:exportable_attributes)
                                             .and_return(expected_json)
@@ -20,7 +21,7 @@ RSpec.describe GuidePublisher do
                                     .with(guide, guide.latest_edition)
                                     .and_return(double_guide_presenter)
         expect(GdsApi::PublishingApiV2).to receive(:new)
-                                           .with(expected_plek)
+                                           .with(expected_plek, expected_token)
                                            .and_return(double_api)
         expect(double_api).to receive(:put_content)
                                 .with(guide.content_id, expected_json)
@@ -38,10 +39,11 @@ RSpec.describe GuidePublisher do
 
       double_api = double(:publishing_api)
       expected_plek = Plek.new.find('publishing-api')
+      expected_token = { bearer_token: 'example' }
       payload_double = { test: :json }
 
       expect(GdsApi::PublishingApiV2).to receive(:new)
-                                        .with(expected_plek)
+                                        .with(expected_plek, expected_token)
                                         .and_return(double_api)
 
       expect(double_api).to receive(:publish)


### PR DESCRIPTION
https://trello.com/c/tx50hSOx/492-add-bearer-token-value-to-all-apps-using-publishing-api