### PR TITLE
Allow approving your own guides if allowed in config

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -49,7 +49,9 @@ class Edition < ActiveRecord::Base
   end
 
   def can_be_approved?(by_user)
-    persisted? && review_requested? && user != by_user
+    return false if new_record?
+    return false unless review_requested?
+    user != by_user || ENV['ALLOW_SELF_APPROVAL'].present?
   end
 
   def can_be_published?

--- a/app/views/editions/_actions.html.erb
+++ b/app/views/editions/_actions.html.erb
@@ -19,7 +19,7 @@
           <% end %>
           <% if edition.can_be_approved? current_user %>
             <%= form.submit "Approve for publication", name: :approve_for_publication, class: 'btn btn-success add-right-margin' %>
-          <% else %>
+          <% elsif edition.review_requested? %>
             <%= form.submit "Approve for publication", disabled: true, title: "You can't approve an edition that you created", class: 'btn btn-success add-right-margin' %>
           <% end %>
 

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -131,11 +131,19 @@ RSpec.describe Edition, type: :model do
         expect(edition.can_be_approved?(edition.user)).to eq false
       end
 
+      it "returns true when the user is also the editor but the ALLOW_SELF_APPROVAL flag is set" do
+        edition.state = "review_requested"
+        edition.user = User.create!(name: "anotehr", email: "email@address.org")
+        edition.save!
+        ENV['ALLOW_SELF_APPROVAL'] = '1'
+        expect(edition.can_be_approved?(edition.user)).to eq true
+        ENV.delete('ALLOW_SELF_APPROVAL')
+      end
+
       it "returns false when latest_edition has not been saved" do
         allow(edition).to receive(:persisted?) { false }
         expect(edition.can_be_approved?(user)).to be false
       end
-
     end
 
     describe "#can_request_review?" do


### PR DESCRIPTION
While useful in real life, when developing on a local machine it gets rather
annoying that the author can not approve their own guides. Allow developers to
set ALLOW_SELF_APPROVAL env variable that skips the authorship check.

This also fixes a bug introduced earlier that shows a disabled 'Approve' button when it needs to be hidden.