### PR TITLE
Clickable button allowing users to upload files to markdown textarea

### DIFF
--- a/app/assets/javascripts/image-upload-markdown.js
+++ b/app/assets/javascripts/image-upload-markdown.js
@@ -1,24 +1,21 @@
 // This is a modified version of https://github.com/stuartnelson3/blog/blob/master/public/js/script.js
 
-function ImageUploadMarkdown(event){
+function ImageUploadMarkdown(files){
   var that = this;
 
   this.init = function(){
-    event.preventDefault();
-    this.$textarea = $(event.currentTarget);
-    var dataTransfer = event.originalEvent.dataTransfer;
+    this.$textarea = $(".js-markdown-image-upload");
 
-    this.addUploadPlaceholders(dataTransfer);
-    for (var i = 0; i < dataTransfer.files.length; i++) {
-      var file = dataTransfer.files[i];
-      this.handleFileUpload(file);
+    this.addUploadPlaceholders();
+    for (var i = 0; i < files.length; i++) {
+      this.handleFileUpload(files[i]);
     }
   };
 
-  this.addUploadPlaceholders = function(dataTransfer) {
+  this.addUploadPlaceholders = function() {
     var placeholders = [];
-    for (var i = 0; i < dataTransfer.files.length; i++) {
-      var fileName = dataTransfer.files[i].name;
+    for (var i = 0; i < files.length; i++) {
+      var fileName = files[i].name;
       placeholders.push(this.placeholderValue(fileName));
     }
 
@@ -69,6 +66,15 @@ function ImageUploadMarkdown(event){
   return this;
 }
 
+$(document).on("click", ".js-markdown-file-input-trigger", function() {
+  $(".js-markdown-file-input").click();
+});
+
+$(document).on("change", ".js-markdown-file-input", function(e) {
+  ImageUploadMarkdown(e.target.files).init();
+});
+
 $(document).on('drop', '.js-markdown-image-upload', function(e) {
-  ImageUploadMarkdown(e).init();
+  e.preventDefault();
+  ImageUploadMarkdown(e.originalEvent.dataTransfer.files).init();
 });

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -78,11 +78,11 @@
         <div class="form-group">
           <%= editions_form.label :body %>
           <%= editions_form.error_list :body %>
-          <%= editions_form.text_area :body, class: 'js-markdown-image-upload input-md-12 form-control markdown-textarea text-area-auto-size text-area-auto-size-large js-text-area-auto-size', rows: 14 %>
-          <p class="help-block text-right">
-            <i class="glyphicon glyphicon-picture"></i>
-            To insert images drag and drop them to the text area above
+          <%= file_field_tag 'attachment', multiple: true, class: "js-markdown-file-input hidden" %>
+          <p class="help-block">
+            To insert images either <a class="js-markdown-file-input-trigger" href="javascript:void(0);">click here</a>, or drag and drop them into the text area below
           </p>
+          <%= editions_form.text_area :body, class: 'js-markdown-image-upload input-md-12 form-control markdown-textarea text-area-auto-size text-area-auto-size-large js-text-area-auto-size', rows: 14 %>
         </div>
 
         <div class='form-group'>

--- a/spec/javascripts/image-upload-markdown-spec.js
+++ b/spec/javascripts/image-upload-markdown-spec.js
@@ -2,7 +2,7 @@ describe("Drag and drop image upload", function() {
   "use strict";
 
   var uploadableTextarea,
-      mockDropEvent;
+      mockFiles;
 
   beforeEach(function() {
     uploadableTextarea = $("<textarea class='js-markdown-image-upload'>First paragraph\n\nSecond paragraph</textarea>");
@@ -10,16 +10,7 @@ describe("Drag and drop image upload", function() {
     $('body').append(uploadableTextarea);
     setCursorAfter("First paragraph\n");
 
-    mockDropEvent = {
-      preventDefault: function(){},
-      currentTarget: $('body .js-markdown-image-upload'),
-      originalEvent: {
-        dataTransfer: {
-          files: [{ name: "nice-pic.jpg"}]
-        }
-      }
-    };
-
+    mockFiles = [{ name: "nice-pic.jpg"}];
     jasmine.Ajax.install();
   });
 
@@ -34,7 +25,7 @@ describe("Drag and drop image upload", function() {
       status: '201'
     });
 
-    var upload = new ImageUploadMarkdown(mockDropEvent);
+    var upload = new ImageUploadMarkdown(mockFiles);
     upload.init();
     var markdown = "First paragraph\n![nice-pic.jpg](http://asset-api.dev.gov.uk/nice-pic.jpg)\nSecond paragraph";
     expect($('body .js-markdown-image-upload').val()).toEqual(markdown);
@@ -47,7 +38,7 @@ describe("Drag and drop image upload", function() {
     });
     spyOn(window, 'alert');
 
-    var upload = new ImageUploadMarkdown(mockDropEvent);
+    var upload = new ImageUploadMarkdown(mockFiles);
     upload.init();
     var markdown = "First paragraph\n\nSecond paragraph";
 


### PR DESCRIPTION
Some users aren't able to drag+drop

https://trello.com/c/ZMllBHEJ/137-add-an-image-upload-button-as-another-way-to-initiate-image-upload

Awaiting merge of https://github.com/alphagov/service-manual-publisher/pull/129



![screenshot](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-19-01-2016-15-11-57-ciigeghe.png)