### PR TITLE
Shuffle field descriptions in guides form.

### DIFF
--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -64,15 +64,15 @@
         <div class='form-group'>
           <%= f.label :slug  %>
           <%= f.error_list :slug  %>
-          <%= f.text_field :slug, class: 'input-md-12 form-control guide-slug js-guide-slug', disabled: guide.has_published_edition? %>
           <span class="help-block">Must start with '/service-manual/' and contain only letters and dashes e.g. '/service-manual/stand-up-meetings'. See <a href="https://insidegovuk.blog.gov.uk/url-standards-for-gov-uk/">URL standards for GOV.UK</a>.</span>
+          <%= f.text_field :slug, class: 'input-md-12 form-control guide-slug js-guide-slug', disabled: guide.has_published_edition? %>
         </div>
 
         <div class='form-group'>
           <%= editions_form.label :description, "Guide description" %>
           <%= editions_form.error_list :description %>
-          <%= editions_form.text_area :description, rows: 5, class: 'input-md-12 form-control text-area-auto-size js-text-area-auto-size' %>
           <span class="help-block">To be used for displaying search results, linking content etc.</span>
+          <%= editions_form.text_area :description, rows: 5, class: 'input-md-12 form-control text-area-auto-size js-text-area-auto-size' %>
         </div>
 
         <div class="form-group">


### PR DESCRIPTION
The user research revealed that users missed the descriptions for the form fields because they came after the element itself.

https://trello.com/c/qsOzsuiy