### PR TITLE
Add pry-remote to Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :development, :test do
   gem 'simplecov', '0.10.0', require: false
   gem 'simplecov-rcov', '0.2.3', require: false
   gem 'pry'
+  gem 'pry-remote'
   gem 'pry-nav'
   gem 'govuk-content-schema-test-helpers', '~> 1.3.0'
   gem 'jasmine'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,9 @@ GEM
       slop (~> 3.4)
     pry-nav (0.2.4)
       pry (>= 0.9.10, < 0.11.0)
+    pry-remote (0.1.8)
+      pry (~> 0.9)
+      slop (~> 3.0)
     rack (1.6.4)
     rack-accept (0.4.5)
       rack (>= 0.4)
@@ -325,6 +328,7 @@ DEPENDENCIES
   poltergeist
   pry
   pry-nav
+  pry-remote
   rails (= 4.2.4)
   redcarpet (~> 3.3.3)
   rspec-rails (~> 3.3)


### PR DESCRIPTION
We normally run our dev environment with foreman/bowler so our process to be debugged is not in the foreground.