### PR TITLE
Remove references to topics in structure.sql

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -262,38 +262,6 @@ ALTER SEQUENCE slug_migrations_id_seq OWNED BY slug_migrations.id;
 
 
 --
--- Name: topics; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE topics (
-    id integer NOT NULL,
-    path character varying NOT NULL,
-    title character varying NOT NULL,
-    description character varying NOT NULL,
-    tree json DEFAULT '{}'::json NOT NULL
-);
-
-
---
--- Name: topics_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE topics_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: topics_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE topics_id_seq OWNED BY topics.id;
-
-
---
 -- Name: users; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -377,13 +345,6 @@ ALTER TABLE ONLY slug_migrations ALTER COLUMN id SET DEFAULT nextval('slug_migra
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY topics ALTER COLUMN id SET DEFAULT nextval('topics_id_seq'::regclass);
-
-
---
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
---
-
 ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
 
 
@@ -433,14 +394,6 @@ ALTER TABLE ONLY guides
 
 ALTER TABLE ONLY slug_migrations
     ADD CONSTRAINT slug_migrations_pkey PRIMARY KEY (id);
-
-
---
--- Name: topics_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
---
-
-ALTER TABLE ONLY topics
-    ADD CONSTRAINT topics_pkey PRIMARY KEY (id);
 
 
 --
@@ -564,8 +517,6 @@ INSERT INTO schema_migrations (version) VALUES ('20151119131239');
 INSERT INTO schema_migrations (version) VALUES ('20151211164627');
 
 INSERT INTO schema_migrations (version) VALUES ('20151216125006');
-
-INSERT INTO schema_migrations (version) VALUES ('20160107144631');
 
 INSERT INTO schema_migrations (version) VALUES ('20160113110500');
 


### PR DESCRIPTION
A change to structure.sql was committed by accident [1] and it added some DB structure changes from a WIP branch. This commit undoes the error.

I've undone the change by running `rake db:drop db:create db:migrate` locally.

[1] - See commit 5e929e82407268a25fb8055bd57b1f4b5de18863