### PR TITLE
DO NOT MERGE - Content owner is a guide

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -125,7 +125,7 @@ private
 
     params
       .require(:guide)
-      .permit(:slug, latest_edition_attributes: [
+      .permit(:community, :slug, latest_edition_attributes: [
         :title,
         :body,
         :description,

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -2,7 +2,6 @@ class GuidesController < ApplicationController
   def index
     @user_options = User.pluck(:name, :id)
     @state_options = %w(draft published review_requested approved).map { |s| [s.titleize, s] }
-    @content_owner_options = ContentOwner.pluck(:title, :id)
 
     @guides = Guide.includes(latest_edition: [:user, :content_owner])
                    .by_user(params[:user])

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -3,7 +3,8 @@ class GuidesController < ApplicationController
     @user_options = User.pluck(:name, :id)
     @state_options = %w(draft published review_requested approved).map { |s| [s.titleize, s] }
 
-    @guides = Guide.includes(latest_edition: [:user, :content_owner])
+    # TODO: :content_owner not being included is resulting in an N+1 query
+    @guides = Guide.includes(latest_edition: [:user])
                    .by_user(params[:user])
                    .in_state(params[:state])
                    .owned_by(params[:content_owner])

--- a/app/models/content_owner.rb
+++ b/app/models/content_owner.rb
@@ -1,2 +1,3 @@
 class ContentOwner < ActiveRecord::Base
+  belongs_to :guide
 end

--- a/app/models/content_owner.rb
+++ b/app/models/content_owner.rb
@@ -1,3 +1,0 @@
-class ContentOwner < ActiveRecord::Base
-  belongs_to :guide
-end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -12,7 +12,8 @@ class Edition < ActiveRecord::Base
   scope :published, -> { where(state: 'published') }
   scope :review_requested, -> { where(state: 'review_requested') }
 
-  validates_presence_of [:state, :phase, :description, :title, :update_type, :body, :content_owner, :user]
+  validates_presence_of [:state, :phase, :description, :title, :update_type, :body, :user]
+  validates_presence_of :content_owner, unless: :community_guide?
   validates_inclusion_of :state, in: %w(draft published review_requested approved)
   validates :change_note, presence: true, if: :major?
   validates :change_summary, presence: true, if: :major?
@@ -94,6 +95,11 @@ class Edition < ActiveRecord::Base
   end
 
 private
+
+  # TODO: Not all guides are community guides..
+  def community_guide?
+    true
+  end
 
   def published_cant_change
     if state_was == 'published' && changes.except('updated_at').present?

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -96,9 +96,8 @@ class Edition < ActiveRecord::Base
 
 private
 
-  # TODO: Not all guides are community guides..
   def community_guide?
-    true
+    guide.present? && guide.community?
   end
 
   def published_cant_change

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -6,7 +6,7 @@ class Edition < ActiveRecord::Base
 
   has_one :approval
 
-  belongs_to :content_owner
+  belongs_to :content_owner, class_name: 'Guide'
 
   scope :draft, -> { where(state: 'draft') }
   scope :published, -> { where(state: 'published') }

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -4,7 +4,7 @@ class Guide < ActiveRecord::Base
   validate :slug_cant_be_changed_if_an_edition_has_been_published
 
   has_many :editions
-  has_one :latest_edition, -> { order(created_at: :desc) }, class_name: "Edition"
+  has_one :latest_edition, -> { order(created_at: :desc) }, class_name: "Edition", inverse_of: :guide
 
   accepts_nested_attributes_for :latest_edition
   scope :by_user, ->(user_id) { where(editions: { user_id: user_id }) if user_id.present? }

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -10,10 +10,13 @@ class Guide < ActiveRecord::Base
   scope :by_user, ->(user_id) { where(editions: { user_id: user_id }) if user_id.present? }
   scope :in_state, ->(state) { where(editions: { state: state }) if state.present? }
   scope :owned_by, ->(content_owner_id) { where(editions: { content_owner_id: content_owner_id }) if content_owner_id.present? }
+  scope :community_guides, -> { where(community: true) }
 
   before_validation on: :create do |object|
     object.content_id = SecureRandom.uuid
   end
+
+  delegate :title, to: :latest_edition
 
   def self.with_published_editions
     joins(:editions)

--- a/app/models/slug_migration.rb
+++ b/app/models/slug_migration.rb
@@ -1,5 +1,3 @@
-require 'gds_api/rummager'
-
 class SlugMigration < ActiveRecord::Base
   belongs_to :guide
 

--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -33,11 +33,7 @@ private
   def details
     details = {
       body: govspeak_body.to_html,
-      header_links: level_two_headers,
-      content_owner: {
-        title: edition.content_owner.title,
-        href: edition.content_owner.href
-      }
+      header_links: level_two_headers
     }
 
     if edition.related_discussion_title.present? && edition.related_discussion_href.present?

--- a/app/presenters/search_header_presenter.rb
+++ b/app/presenters/search_header_presenter.rb
@@ -34,7 +34,7 @@ class SearchHeaderPresenter
 
   def published_by
     if params[:content_owner].present?
-      "published by #{ContentOwner.find(params[:content_owner]).title}"
+      "published by #{Guide.find(params[:content_owner]).latest_edition.title}"
     end
   end
 end

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -88,7 +88,7 @@
         <div class='form-group'>
           <%= editions_form.label :content_owner_id, "Published by" %>
           <%= editions_form.error_list :content_owner_id %>
-          <%= editions_form.select :content_owner_id, ContentOwner.all.pluck(:title, :id), {}, {class: 'select2 input-md-12 form-control'} %>
+          <%= editions_form.collection_select :content_owner_id, Guide.community_guides, :id, :title, { include_blank: true }, { class: 'select2 input-md-12 form-control' } %>
         </div>
       </div>
     <% end %>

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -90,6 +90,15 @@
           <%= editions_form.error_list :content_owner_id %>
           <%= editions_form.collection_select :content_owner_id, Guide.community_guides, :id, :title, { include_blank: true }, { class: 'select2 input-md-12 form-control' } %>
         </div>
+
+        <div class='form-group'>
+          <%= f.label :community, 'Is community page' %>
+          <%= f.error_list :community %>
+          <p class="help-block">
+            Each guide links to a community page. The 'Published by' dropdown above will be populated with guides marked as 'Is community page'.
+          </p>
+          <%= f.check_box :community %>
+        </div>
       </div>
     <% end %>
   </div>

--- a/app/views/guides/index.html.erb
+++ b/app/views/guides/index.html.erb
@@ -15,7 +15,7 @@
         <%= select_tag :state, options_for_select(@state_options, params[:state]), {include_blank: "All", class: "select2 input-md-12 form-control"} %>
 
         <%= label_tag :content_owner, "Published by", class: "add-top-margin nav-header" %>
-        <%= select_tag :content_owner, options_for_select(@content_owner_options, params[:content_owner]), {include_blank: "All", class: "select2 input-md-12 form-control"} %>
+        <%= select_tag :content_owner, options_for_select(Guide.community_guides.map{|g| [g.title, g.id] }, params[:content_owner]), {include_blank: "All", class: "select2 input-md-12 form-control"} %>
 
         <input type="submit" class="add-top-margin btn btn-default" value="Filter guides">
       </form>
@@ -48,7 +48,7 @@
             </td>
             <td>
               <% if guide.latest_edition.content_owner %>
-                <%= guide.latest_edition.content_owner.title %>
+                <%= guide.latest_edition.content_owner.latest_edition.title %>
               <% end %>
             </td>
             <td class='last-edited-by'>

--- a/app/views/guides/index.html.erb
+++ b/app/views/guides/index.html.erb
@@ -47,7 +47,9 @@
               <div class='text-muted'><%= guide.slug %></div>
             </td>
             <td>
-              <%= guide.latest_edition.content_owner.title %>
+              <% if guide.latest_edition.content_owner %>
+                <%= guide.latest_edition.content_owner.title %>
+              <% end %>
             </td>
             <td class='last-edited-by'>
               <%= latest_editor_name(guide) %>

--- a/config/initializers/rummager.rb
+++ b/config/initializers/rummager.rb
@@ -1,0 +1,1 @@
+require 'gds_api/rummager'

--- a/db/migrate/20160125182431_remove_not_null_constraint_from_editions_content_owner_id.rb
+++ b/db/migrate/20160125182431_remove_not_null_constraint_from_editions_content_owner_id.rb
@@ -1,0 +1,5 @@
+class RemoveNotNullConstraintFromEditionsContentOwnerId < ActiveRecord::Migration
+  def change
+    change_column :editions, :content_owner_id, :integer, null: true
+  end
+end

--- a/db/migrate/20160126093503_remove_not_null_constraints_from_content_owners.rb
+++ b/db/migrate/20160126093503_remove_not_null_constraints_from_content_owners.rb
@@ -1,0 +1,6 @@
+class RemoveNotNullConstraintsFromContentOwners < ActiveRecord::Migration
+  def change
+    change_column :content_owners, :href, :string, null: true
+    change_column :content_owners, :title, :string, null: true
+  end
+end

--- a/db/migrate/20160126150430_add_guides_community.rb
+++ b/db/migrate/20160126150430_add_guides_community.rb
@@ -1,0 +1,5 @@
+class AddGuidesCommunity < ActiveRecord::Migration
+  def change
+    add_column :guides, :community, :boolean, default: false
+  end
+end

--- a/db/migrate/20160126183222_drop_content_owners.rb
+++ b/db/migrate/20160126183222_drop_content_owners.rb
@@ -1,0 +1,5 @@
+class DropContentOwners < ActiveRecord::Migration
+  def change
+    drop_table :content_owners
+  end
+end

--- a/db/migrate/20160127165107_clear_all_guides_content_owner_ids.rb
+++ b/db/migrate/20160127165107_clear_all_guides_content_owner_ids.rb
@@ -1,0 +1,5 @@
+class ClearAllGuidesContentOwnerIds < ActiveRecord::Migration
+  def change
+    execute 'UPDATE editions SET content_owner_id = NULL;'
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -45,10 +45,11 @@ end
 
 if Rails.env.development? || ENV["GOVUK_APP_DOMAIN"] == "preview.alphagov.co.uk"
   author = User.first || User.create!(name: "Unknown", email: "unknown@example.com")
-  if ContentOwner.count == 0
-    ContentOwner.create!(
-      title: "Design Community",
-      href: "http://sm-11.herokuapp.com/designing-services/design-community/"
+  if Guide.community_guides.empty?
+    Guide.create!(
+      community: true,
+      latest_edition: Generators.valid_edition(title: 'Design Community'),
+      slug: "/service-manual/design-community"
     )
   end
 
@@ -73,7 +74,7 @@ if Rails.env.development? || ENV["GOVUK_APP_DOMAIN"] == "preview.alphagov.co.uk"
       description:     "Description",
       update_type:     "minor",
       body:            object[:body].gsub(/\n/, "\r\n"),
-      content_owner:   ContentOwner.first,
+      content_owner:   Guide.community_guides.first,
       user:            author,
     )
     guide = Guide.create!(slug: object[:url], content_id: nil, latest_edition: edition)

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -195,7 +195,8 @@ CREATE TABLE guides (
     content_id character varying,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    tsv tsvector
+    tsv tsvector,
+    community boolean DEFAULT false
 );
 
 
@@ -572,4 +573,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160113110500');
 INSERT INTO schema_migrations (version) VALUES ('20160125182431');
 
 INSERT INTO schema_migrations (version) VALUES ('20160126093503');
+
+INSERT INTO schema_migrations (version) VALUES ('20160126150430');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -113,36 +113,6 @@ ALTER SEQUENCE comments_id_seq OWNED BY comments.id;
 
 
 --
--- Name: content_owners; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE content_owners (
-    id integer NOT NULL,
-    title character varying,
-    href character varying
-);
-
-
---
--- Name: content_owners_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE content_owners_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: content_owners_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE content_owners_id_seq OWNED BY content_owners.id;
-
-
---
 -- Name: editions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -350,13 +320,6 @@ ALTER TABLE ONLY comments ALTER COLUMN id SET DEFAULT nextval('comments_id_seq':
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY content_owners ALTER COLUMN id SET DEFAULT nextval('content_owners_id_seq'::regclass);
-
-
---
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
---
-
 ALTER TABLE ONLY editions ALTER COLUMN id SET DEFAULT nextval('editions_id_seq'::regclass);
 
 
@@ -402,14 +365,6 @@ ALTER TABLE ONLY approvals
 
 ALTER TABLE ONLY comments
     ADD CONSTRAINT comments_pkey PRIMARY KEY (id);
-
-
---
--- Name: content_owners_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
---
-
-ALTER TABLE ONLY content_owners
-    ADD CONSTRAINT content_owners_pkey PRIMARY KEY (id);
 
 
 --
@@ -575,4 +530,8 @@ INSERT INTO schema_migrations (version) VALUES ('20160125182431');
 INSERT INTO schema_migrations (version) VALUES ('20160126093503');
 
 INSERT INTO schema_migrations (version) VALUES ('20160126150430');
+
+INSERT INTO schema_migrations (version) VALUES ('20160126183222');
+
+INSERT INTO schema_migrations (version) VALUES ('20160127165107');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -118,8 +118,8 @@ ALTER SEQUENCE comments_id_seq OWNED BY comments.id;
 
 CREATE TABLE content_owners (
     id integer NOT NULL,
-    title character varying NOT NULL,
-    href character varying NOT NULL
+    title character varying,
+    href character varying
 );
 
 
@@ -161,7 +161,7 @@ CREATE TABLE editions (
     updated_at timestamp without time zone NOT NULL,
     state text,
     change_note text,
-    content_owner_id integer NOT NULL,
+    content_owner_id integer,
     change_summary text
 );
 
@@ -262,6 +262,38 @@ ALTER SEQUENCE slug_migrations_id_seq OWNED BY slug_migrations.id;
 
 
 --
+-- Name: topics; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE topics (
+    id integer NOT NULL,
+    path character varying NOT NULL,
+    title character varying NOT NULL,
+    description character varying NOT NULL,
+    tree json DEFAULT '{}'::json NOT NULL
+);
+
+
+--
+-- Name: topics_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE topics_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: topics_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE topics_id_seq OWNED BY topics.id;
+
+
+--
 -- Name: users; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -345,6 +377,13 @@ ALTER TABLE ONLY slug_migrations ALTER COLUMN id SET DEFAULT nextval('slug_migra
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY topics ALTER COLUMN id SET DEFAULT nextval('topics_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
 
 
@@ -394,6 +433,14 @@ ALTER TABLE ONLY guides
 
 ALTER TABLE ONLY slug_migrations
     ADD CONSTRAINT slug_migrations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: topics_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY topics
+    ADD CONSTRAINT topics_pkey PRIMARY KEY (id);
 
 
 --
@@ -518,5 +565,11 @@ INSERT INTO schema_migrations (version) VALUES ('20151211164627');
 
 INSERT INTO schema_migrations (version) VALUES ('20151216125006');
 
+INSERT INTO schema_migrations (version) VALUES ('20160107144631');
+
 INSERT INTO schema_migrations (version) VALUES ('20160113110500');
+
+INSERT INTO schema_migrations (version) VALUES ('20160125182431');
+
+INSERT INTO schema_migrations (version) VALUES ('20160126093503');
 

--- a/spec/features/comments_spec.rb
+++ b/spec/features/comments_spec.rb
@@ -3,7 +3,7 @@ require 'capybara/rails'
 
 RSpec.describe "Commenting", type: :feature do
   let!(:guide) do
-    edition = Generators.valid_edition
+    edition = Generators.valid_edition(title: 'The Title')
     Guide.create!(
       latest_edition: edition,
       slug: "/service-manual/test/comment"
@@ -12,7 +12,9 @@ RSpec.describe "Commenting", type: :feature do
 
   it "allows discourse" do
     visit root_path
-    click_link "Edit"
+    within_guide_index_row('The Title') do
+      click_link "Edit"
+    end
     click_link "Comments and history"
 
     within ".comments" do

--- a/spec/features/filter_spec.rb
+++ b/spec/features/filter_spec.rb
@@ -44,7 +44,12 @@ RSpec.describe "filtering guides", type: :feature do
 
   it "filters by published by" do
     [1, 2].each do |i|
-      content_owner = ContentOwner.create!(title: "Content Owner #{i}", href: "some href")
+      content_owner = Guide.create!(
+        community: true,
+        latest_edition: Generators.valid_edition(title: "Content Owner #{i}"),
+        slug: "/service-manual/content-owner-#{i}"
+      )
+
       edition = Generators.valid_edition(
         state: "review_requested",
         title: "Edition #{i}",
@@ -94,7 +99,11 @@ RSpec.describe "filtering guides", type: :feature do
   end
 
   it "displays a page header that's based on the query" do
-    ContentOwner.create!(title: "Design Community", href: "example.com")
+    Guide.create!(
+      community: true,
+      latest_edition: Generators.valid_edition(title: 'Design Community'),
+      slug: "/service-manual/design-community")
+
     User.create!(name: "Ronan", email: "ronan@example.com")
     visit root_path
     within ".filters" do

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -120,11 +120,14 @@ RSpec.describe "creating guides", type: :feature do
       end
 
       it "does not store a guide" do
-        fill_in_guide_form
+        fill_in_guide_form(guide_title: 'Getting things done')
         click_first_button "Save"
 
-        expect(Guide.count).to eq 0
-        expect(Edition.count).to eq 0
+        relevant_editions = Edition.where(title: 'Getting things done')
+        relevant_guides = Guide.joins(:editions).merge(relevant_editions)
+
+        expect(relevant_guides.count).to eq 0
+        expect(relevant_editions.count).to eq 0
       end
     end
   end
@@ -272,12 +275,14 @@ RSpec.describe "creating guides", type: :feature do
 
 private
 
-  def fill_in_guide_form
+  def fill_in_guide_form(attributes = {})
+    guide_title = attributes.fetch(:guide_title, "First Edition Title")
+
     fill_in "Slug", with: "/service-manual/the/path"
     select "Design Community", from: "Published by"
     fill_in "Guide description", with: "This guide acts as a test case"
 
-    fill_in "Guide title", with: "First Edition Title"
+    fill_in "Guide title", with: guide_title
     fill_in "Body", with: "## First Edition Title"
   end
 

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -40,13 +40,13 @@ RSpec.describe "creating guides", type: :feature do
     edition = guide.latest_edition
     content_id = guide.content_id
     expect(content_id).to be_present
-    expect(edition.content_owner.title).to eq "Design Community"
-    expect(edition.content_owner.href).to eq "http://sm-11.herokuapp.com/designing-services/design-community/"
     expect(edition.title).to eq "First Edition Title"
     expect(edition.body).to eq "## First Edition Title"
     expect(edition.update_type).to eq "minor"
     expect(edition.draft?).to eq true
     expect(edition.published?).to eq false
+
+    expect(find_published_by_dropdown('Design Community')).to be_selected
 
     visit edit_guide_path(guide)
     fill_in "Guide title", with: "Second Edition Title"
@@ -279,5 +279,11 @@ private
 
     fill_in "Guide title", with: "First Edition Title"
     fill_in "Body", with: "## First Edition Title"
+  end
+
+  # The select2 plugin makes Capybara's have_select helper unusable for the
+  # Published By dropdown
+  def find_published_by_dropdown(text)
+    find(:css, '#guide_latest_edition_attributes_content_owner_id option', text: text)
   end
 end

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -2,6 +2,34 @@ require 'rails_helper'
 require 'capybara/rails'
 require 'gds_api/publishing_api_v2'
 
+RSpec.describe "creating community guides", type: :feature do
+  let(:api_double) { double(:publishing_api) }
+
+  it 'persists the community flag' do
+    expect(GdsApi::PublishingApiV2).to receive(:new).and_return(api_double)
+    expect(api_double).to receive(:put_content)
+                            .with(an_instance_of(String), be_valid_against_schema('service_manual_guide'))
+
+    visit root_path
+    click_link "Create a Guide"
+
+    check 'Is community page'
+    fill_in "Slug", with: "/service-manual/the/path"
+    fill_in "Guide description", with: "This guide acts as a test case"
+    fill_in "Guide title", with: 'Design Community'
+    fill_in "Body", with: "## First Edition Title"
+
+    click_first_button "Save"
+
+    visit root_path
+    within_guide_index_row('Design Community') do
+      click_link 'Edit'
+    end
+
+    expect(page).to have_checked_field('Is community page')
+  end
+end
+
 RSpec.describe "creating guides", type: :feature do
   let(:api_double) { double(:publishing_api) }
 

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -6,10 +6,12 @@ RSpec.describe "creating guides", type: :feature do
   let(:api_double) { double(:publishing_api) }
 
   before do
-    ContentOwner.first_or_initialize(
-      title: "Design Community",
-      href:  "http://sm-11.herokuapp.com/designing-services/design-community/"
-    ).save!
+    community_guide_edition = Generators.valid_edition(title: 'Design Community')
+    community_guide = Guide.create!(
+      community: true,
+      latest_edition: community_guide_edition,
+      slug: "/service-manual/design-community"
+    )
     visit root_path
     click_link "Create a Guide"
 

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -184,9 +184,8 @@ RSpec.describe "creating guides", type: :feature do
         fill_in "Guide title", with: "Changed Title"
         click_first_button "Save"
 
-        expect(Guide.count).to eq 1
-        expect(Guide.first.latest_edition.title).to_not eq "Changed Title"
-        expect(Edition.count).to eq 1
+        expect(guide.latest_edition.title).to_not eq "Changed Title"
+        expect(guide.editions.count).to eq 1
       end
     end
   end

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -76,11 +76,11 @@ RSpec.describe "creating guides", type: :feature do
                             .with(an_instance_of(String), 'minor')
 
     click_first_button "Save"
-    guide = Guide.first
+    guide = Guide.joins(:editions).merge(Edition.where(title: 'First Edition Title')).first
     visit edit_guide_path(guide)
     click_first_button "Send for review"
 
-    Edition.first.tap do |edition|
+    guide.editions.first.tap do |edition|
       # set editor to another user so we can approve this edition
       edition.user = User.create!(name: "Editor", email: "email@example.org")
       edition.save!

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -57,6 +57,23 @@ RSpec.describe Edition, type: :model do
       expect(edition.errors.full_messages_for(:user).size).to eq 1
     end
 
+    describe "content owner" do
+      it "requires a content owner" do
+        edition = Edition.new
+
+        expect(edition).to be_invalid
+        expect(edition.errors.messages).to include(content_owner: ["can't be blank"])
+      end
+
+      it "does not require a content owner when it is part of a community guide" do
+        guide = Guide.new(community: true)
+        edition = Edition.new(guide: guide)
+
+        expect(edition).to be_invalid
+        expect(edition.errors.messages).to_not have_key(:content_owner)
+      end
+    end
+
     it "does not allow updating already published editions" do
       edition = Generators.valid_published_edition
       edition.save!

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -207,6 +207,8 @@ RSpec.describe Edition, type: :model do
       it "returns false if it's not the latest edition of a guide" do
         edition.state = "approved"
         guide.editions << edition.dup
+
+        edition.guide.reload
         expect(edition.can_be_published?).to be false
       end
 

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -5,17 +5,14 @@ RSpec.describe Guide do
 
   describe '.community_guides' do
     it 'returns community flavoured guides only' do
-      design_community_guide = Guide.create!(
-        community: true,
-        latest_edition: Generators.valid_edition(title: 'Design Community'),
-        slug: "/service-manual/design-community"
-      )
+      community_guide = Generators.valid_community_guide
+      community_guide.save!
       Guide.create!(
-        latest_edition: Generators.valid_edition(title: 'A proper guide page'),
+        editions: [Generators.valid_edition(title: 'A proper guide page', content_owner: community_guide)],
         slug: "/service-manual/proper-guide"
       )
 
-      expect(Guide.community_guides).to eq([design_community_guide])
+      expect(Guide.community_guides).to eq([community_guide])
     end
   end
 

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -3,6 +3,22 @@ require 'rails_helper'
 RSpec.describe Guide do
   let(:edition) { Generators.valid_published_edition }
 
+  describe '.community_guides' do
+    it 'returns community flavoured guides only' do
+      design_community_guide = Guide.create!(
+        community: true,
+        latest_edition: Generators.valid_edition(title: 'Design Community'),
+        slug: "/service-manual/design-community"
+      )
+      Guide.create!(
+        latest_edition: Generators.valid_edition(title: 'A proper guide page'),
+        slug: "/service-manual/proper-guide"
+      )
+
+      expect(Guide.community_guides).to eq([design_community_guide])
+    end
+  end
+
   describe "#ensure_draft_exists" do
     let(:guide) do
       Guide.create!(slug: "/service-manual/slug", latest_edition: edition)

--- a/spec/presenters/guide_presenter_spec.rb
+++ b/spec/presenters/guide_presenter_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe GuidePresenter do
       description:         "Description",
       update_type:         "major",
       body:                "# Heading",
-      content_owner:       ContentOwner.new(title: "Publisher Name", href: "http://gov.uk"),
       updated_at:          Time.now
     )
   end

--- a/spec/presenters/search_header_presenter_spec.rb
+++ b/spec/presenters/search_header_presenter_spec.rb
@@ -44,7 +44,12 @@ RSpec.describe SearchHeaderPresenter do
     end
 
     it "appends the selected content owner" do
-      agile_community = ContentOwner.create!(title: "Agile Community", href: 'example.com')
+      agile_community = Guide.create!(
+        community: true,
+        latest_edition: Generators.valid_edition(title: "Agile Community"),
+        slug: "/service-manual/agile-community"
+      )
+
       header = described_class.new({ content_owner: agile_community.id }, User.new).to_s
       expect(header).to end_with "published by Agile Community"
     end

--- a/spec/support/capybara_helpers.rb
+++ b/spec/support/capybara_helpers.rb
@@ -2,6 +2,10 @@ module CapybaraHelpers
   def click_first_button(value)
     click_button value, match: :first
   end
+
+  def within_guide_index_row(name, &block)
+    within(:xpath, %{//a[.="#{name}"]/ancestor::tr}, &block)
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/support/generators.rb
+++ b/spec/support/generators.rb
@@ -1,6 +1,6 @@
 class Generators
   def self.valid_edition(attributes = {})
-    content_owner = ContentOwner.first || ContentOwner.create(title: "content owner title", href: "content_owner_href")
+    content_owner = attributes.delete(:content_owner)
 
     attributes = {
       title:          "The Title",

--- a/spec/support/generators.rb
+++ b/spec/support/generators.rb
@@ -1,9 +1,20 @@
 class Generators
   def self.valid_edition(attributes = {})
-    content_owner = attributes.delete(:content_owner)
+    content_owner = attributes.delete(:content_owner) || valid_community_guide
 
     attributes = {
-      title:          "The Title",
+      content_owner: content_owner
+    }.merge(attributes)
+
+    valid_edition_minus_content_owner(attributes)
+  end
+
+  def self.valid_edition_minus_content_owner(attributes = {})
+    content_owner = attributes.delete(:content_owner)
+    title = attributes.delete(:title) || "The Title"
+
+    attributes = {
+      title:          title,
       state:          "draft",
       phase:          "beta",
       description:    "Description",
@@ -30,5 +41,18 @@ class Generators
     attrs.merge!(attributes)
     attrs[:email] ||= "#{attrs[:name].parameterize}@example.com"
     User.new(attrs)
+  end
+
+  def self.valid_community_guide(attributes = {})
+    editions = attributes.delete(:editions) || [valid_edition_minus_content_owner(title: 'Community Guide')]
+    slug = attributes.delete(:slug) || '/service-manual/community-guide'
+
+    attributes = {
+      community: true,
+      editions: editions,
+      slug: slug
+    }.merge(attributes)
+
+    Guide.new(attributes)
   end
 end


### PR DESCRIPTION
https://trello.com/c/sri14201

We introduce the idea of a 'Community Guide' which is a flavour of the Guide we already have. A community guide uses the same schema (service_design_guide). Non-community guides will link to community guides to show who manages the page.

We ditch the ContentOwner and create a self referential link between guides and community guides (the relational link is actually from editions to guides).

I expect CI is bust because the schema no longer matches. We need a new version of schemas.

Todo:

* We need to publish the link to the publishing API.
* UX discussion about the checkbox which is not easy to understand.