### PR TITLE
Allow to prepare for URL slug migrations up-front

### DIFF
--- a/app/controllers/slug_migrations_controller.rb
+++ b/app/controllers/slug_migrations_controller.rb
@@ -12,13 +12,13 @@ class SlugMigrationsController < ApplicationController
 
   def edit
     @slug_migration = SlugMigration.find(params[:id])
-    @select_options = Guide.with_published_editions.pluck(:slug, :id)
+    @select_options = Guide.order(:slug).pluck(:slug, :id)
     @selected_guide_id = @slug_migration.guide_id
   end
 
   def update
     @slug_migration = SlugMigration.find(params[:id])
-    @select_options = Guide.with_published_editions.pluck(:slug, :id)
+    @select_options = Guide.order(:slug).pluck(:slug, :id)
 
     slug_migration_parameters = params.require(:slug_migration)
       .permit(:guide_id)

--- a/app/models/slug_migration.rb
+++ b/app/models/slug_migration.rb
@@ -5,8 +5,7 @@ class SlugMigration < ActiveRecord::Base
 
   validates :slug, uniqueness: true
   validate(
-    :guide_must_be_nil_or_published,
-    :guide_cant_be_empty_when_migrating,
+    :has_published_guide_when_migrating,
     :is_not_already_completed,
   )
 
@@ -30,15 +29,9 @@ class SlugMigration < ActiveRecord::Base
 
   private
 
-    def guide_must_be_nil_or_published
-      if guide && !guide.editions.where(state: "published").any?
-        errors.add(:guide, "must have a published edition")
-      end
-    end
-
-    def guide_cant_be_empty_when_migrating
-      if completed? && guide.nil?
-        errors.add(:guide, "must not be blank")
+    def has_published_guide_when_migrating
+      if completed? && (guide.nil? || !guide.has_published_edition?)
+        errors.add(:guide, "must have a published guide in order to migrate")
       end
     end
 

--- a/app/views/slug_migrations/edit.html.erb
+++ b/app/views/slug_migrations/edit.html.erb
@@ -13,7 +13,11 @@
     </div>
     <div class="form-group">
       <%= f.submit "Save", class: "btn btn-success" %>
-      <%= f.submit "Save and Migrate", name: :save_and_migrate, class: "btn btn-warning" %>
+      <% if @slug_migration.guide.try(:has_published_edition?) %>
+        <%= f.submit "Migrate", name: :save_and_migrate, class: "btn btn-warning" %>
+      <% else %>
+        <%= f.submit "Needs a published guide to migrate", class: "btn btn-disabled", disabled: true %>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/spec/models/slug_migration_spec.rb
+++ b/spec/models/slug_migration_spec.rb
@@ -25,9 +25,17 @@ RSpec.describe SlugMigration, type: :model do
     edition = Generators.valid_edition(state: "draft")
     guide = Guide.create!(slug: "/service-manual/slug", latest_edition: edition)
 
-    migration = SlugMigration.new(slug: "/something", guide: guide)
+    migration = SlugMigration.new(slug: "/something", guide: guide, completed: true)
     expect(migration.valid?).to eq false
     expect(migration.errors.full_messages_for(:guide).size).to eq 1
+  end
+
+  it "allows non-published guides for migrations that are not completed" do
+    edition = Generators.valid_edition(state: "draft")
+    guide = Guide.create!(slug: "/service-manual/slug", latest_edition: edition)
+
+    migration = SlugMigration.new(slug: "/something", guide: guide)
+    expect(migration).to be_valid
   end
 
   it "allows empty guides" do


### PR DESCRIPTION
https://trello.com/c/rQmNLdr1/164-allow-to-do-url-migration-setup-up-front

Originally we only allowed users to select published guides as a redirect target.
After talking to the users it has became clear that they would prefer doing
the mapping up-front. Once the target guide is published the UI allows users
to click "Migrate" that creates the redirect rule.

This way the laborious part (mapping) can be done before the topics and guides
are published and it needs only a button click later.

**With a draft associated:**
![cbotqrly-2016 01 27-17-16-52](https://cloud.githubusercontent.com/assets/218239/12621705/b4249b70-c519-11e5-8dc0-58f4e33a0bc1.png)


**With a published guide associated**
![etuifovj-2016 01 27-17-17-12](https://cloud.githubusercontent.com/assets/218239/12621712/b8f3d51c-c519-11e5-8685-05e0d1718760.png)
