### PR TITLE
Include the service manual root as a parent in the links.

### DIFF
--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -1,4 +1,6 @@
 class TopicPresenter
+  SERVICE_MANUAL_ROOT_CONTENT_ID = '51dd8775-cd2a-4fb3-b6df-8ed03591122d'
+
   def initialize(topic)
     @topic = topic
   end
@@ -28,6 +30,14 @@ class TopicPresenter
   def links
     {
       links: {
+        parent: [
+          {
+            content_id: SERVICE_MANUAL_ROOT_CONTENT_ID,
+            title: 'Service manual',
+            base_path: '/service-manual',
+            locale: 'en'
+          }
+        ],
         linked_items: eagerloaded_editions.map { |edition| edition.guide.content_id }
       }
     }

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -57,5 +57,18 @@ RSpec.describe TopicPresenter do
         expect(edition.guide.content_id).to be_in(linked_items)
       end
     end
+
+    it 'contains the service manual root as a parent for use in generating the breadcrumbs' do
+      expect(presented_topic.links[:links]).to a_hash_including(
+        parent: [
+          {
+            content_id: '51dd8775-cd2a-4fb3-b6df-8ed03591122d',
+            title: 'Service manual',
+            base_path: '/service-manual',
+            locale: 'en'
+          }
+        ]
+      )
+    end
   end
 end


### PR DESCRIPTION
This will be used to build the breadcrumbs on the topic page in government-frontend.