### PR TITLE
Publish 'service_manual_topic's rather than 'topic's.

### DIFF
--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -8,7 +8,7 @@ class TopicPresenter
       content_id: topic.content_id,
       publishing_app: "service-manual-publisher",
       rendering_app: "government-frontend",
-      format: "topic",
+      format: "service_manual_topic",
       locale: "en",
       update_type: "minor",
       base_path: topic.path,

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe TopicPresenter do
 
   describe "#exportable_attributes" do
     it "conforms to the schema" do
-      expect(presented_topic.exportable_attributes).to be_valid_against_schema('topic')
+      expect(presented_topic.exportable_attributes).to be_valid_against_schema('service_manual_topic')
     end
 
     it "exports all necessary metadata" do
@@ -34,7 +34,7 @@ RSpec.describe TopicPresenter do
         phase: "beta",
         publishing_app: "service-manual-publisher",
         rendering_app: "government-frontend",
-        format: "topic",
+        format: "service_manual_topic",
         locale: "en",
         base_path: "/service-manual/test-topic"
       )


### PR DESCRIPTION
The new format is similar to 'topic' but the benefit is a conceptual grouping with the other service manual schema.