### PR TITLE
Add a slug migration for broken slug url (that was added by mistake)

### DIFF
--- a/db/migrate/20160223095349_add_slug_migration_for_guide_mistake.rb
+++ b/db/migrate/20160223095349_add_slug_migration_for_guide_mistake.rb
@@ -1,0 +1,13 @@
+class AddSlugMigrationForGuideMistake < ActiveRecord::Migration
+  def up
+    return say("Skipping slug creation in test environment") if Rails.env.test?
+
+    SLUGS.each do |s|
+      execute "INSERT INTO slug_migrations (slug, created_at, updated_at, content_id) VALUES ('#{s}', now(), now(), '#{SecureRandom.uuid}')"
+    end
+  end
+
+  SLUGS = [
+    "/service-manual/service-manual/digital-foundation-day-training",
+  ]
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -646,3 +646,5 @@ INSERT INTO schema_migrations (version) VALUES ('20160120143132');
 
 INSERT INTO schema_migrations (version) VALUES ('20160209114249');
 
+INSERT INTO schema_migrations (version) VALUES ('20160223095349');
+


### PR DESCRIPTION
This guide didn't have a topic in the url: https://www.gov.uk/service-manual/digital-foundation-day-training

```
== 20160223095349 AddSlugMigrationForGuideMistake: migrating ==================
-- execute("INSERT INTO slug_migrations (slug, created_at, updated_at, content_id) VALUES ('/service-manual/service-manual/digital-foundation-day-training', now(), now(), 'e033072d-14a4-4152-bd97-a8c77a93ac20')")
   -> 0.0027s
== 20160223095349 AddSlugMigrationForGuideMistake: migrated (0.0029s) =========

```