### PR TITLE
Store Guide id in topic tree instead of edition id

### DIFF
--- a/app/assets/javascripts/topics.js
+++ b/app/assets/javascripts/topics.js
@@ -4,17 +4,17 @@ $(function() {
     return;
   }
 
-  function createNewEdition(value) {
-    var $edition = $topics.find(".topics-templates .js-edition-template").clone();
-    $edition.find(".js-topic-edition").val(value);
-    $edition.removeClass("js-edition-template");
-    $edition.removeClass("hidden");
-    $edition.addClass("draggable-edition");
-    $topics.find(".js-sortable-topic-list").append($edition);
+  function createNewGuide(value) {
+    var $guide = $topics.find(".topics-templates .js-guide-template").clone();
+    $guide.find(".js-topic-guide").val(value);
+    $guide.removeClass("js-guide-template");
+    $guide.removeClass("hidden");
+    $guide.addClass("draggable-guide");
+    $topics.find(".js-sortable-topic-list").append($guide);
   }
 
   function createNewHeading(title, description) {
-    $(".js-add-edition").attr("disabled", false);
+    $(".js-add-guide").attr("disabled", false);
 
     var heading = $topics.find(".topics-templates .js-heading-template").clone();
     heading.find(".js-topic-title").val(title);
@@ -24,7 +24,7 @@ $(function() {
     heading.removeClass("hidden");
   }
 
-  $topics.on("click", ".js-add-edition", function(){createNewEdition("")});
+  $topics.on("click", ".js-add-guide", function(){createNewGuide("")});
   $topics.on("click", ".js-add-heading", function(){createNewHeading("","")});
 
   $topics.on("click", ".js-delete-list-group-item", function() {
@@ -49,11 +49,11 @@ $(function() {
         if (currentTopic != null) {
           topics.push(currentTopic);
         }
-        currentTopic = {title: topicInput.val(), editions: []};
+        currentTopic = {title: topicInput.val(), guides: []};
       } else if (topicInput.hasClass("js-topic-description")) {
         currentTopic["description"] = topicInput.val();
-      } else if (topicInput.hasClass("js-topic-edition")) {
-        currentTopic["editions"].push(topicInput.children(":selected").val());
+      } else if (topicInput.hasClass("js-topic-guide")) {
+        currentTopic["guides"].push(topicInput.children(":selected").val());
       }
     });
 
@@ -65,8 +65,8 @@ $(function() {
   for (topicIndex = 0; topicIndex < json.length; topicIndex++) {
     var topic = json[topicIndex];
     createNewHeading(topic.title, topic.description);
-    for (editionIndex = 0; editionIndex < topic.editions.length; editionIndex++) {
-      createNewEdition(topic.editions[editionIndex]);
+    for (guideIndex = 0; guideIndex < topic.guides.length; guideIndex++) {
+      createNewGuide(topic.guides[guideIndex]);
     }
   }
 });

--- a/app/assets/javascripts/topics.js
+++ b/app/assets/javascripts/topics.js
@@ -46,14 +46,14 @@ $(function() {
     $(".js-topic-input").each(function() {
       var topicInput = $(this);
       if (topicInput.hasClass("js-topic-title")) {
-	if (currentTopic != null) {
-	  topics.push(currentTopic);
-	}
-	currentTopic = {title: topicInput.val(), editions: []};
+        if (currentTopic != null) {
+          topics.push(currentTopic);
+        }
+        currentTopic = {title: topicInput.val(), editions: []};
       } else if (topicInput.hasClass("js-topic-description")) {
-	currentTopic["description"] = topicInput.val();
+        currentTopic["description"] = topicInput.val();
       } else if (topicInput.hasClass("js-topic-edition")) {
-	currentTopic["editions"].push(topicInput.children(":selected").val());
+        currentTopic["editions"].push(topicInput.children(":selected").val());
       }
     });
 

--- a/app/assets/stylesheets/topics.scss
+++ b/app/assets/stylesheets/topics.scss
@@ -15,7 +15,7 @@
   }
 }
 
-.draggable-edition {
+.draggable-guide {
   margin-left: 2em;
   background-color: #f5f5f5;
 }

--- a/app/views/topics/new.html.erb
+++ b/app/views/topics/new.html.erb
@@ -34,7 +34,7 @@
 
         <div class="form-group">
           <%= button_tag "Add Heading", type: "button", class: "js-add-heading btn btn-success" %>
-          <%= button_tag "Add Guide", type: "button", class: "js-add-edition btn btn-success", disabled: true %>
+          <%= button_tag "Add Guide", type: "button", class: "js-add-guide btn btn-success", disabled: true %>
         </div>
       </div>
 
@@ -59,13 +59,13 @@
           <input type="text" placeholder="Heading Description" class="js-topic-input js-topic-description form-control">
         </div>
       </li>
-      <li class="list-group-item js-edition-template hidden">
+      <li class="list-group-item js-guide-template hidden">
         <div class="left">
           <span class="glyphicon glyphicon-move"></span>
           <span class="glyphicon glyphicon-trash js-delete-list-group-item"></span>
         </div>
         <div class="right">
-          <%= select_tag nil, options_for_select(latest_editions.map { |e| [e.title, e.id] }), {class: 'js-topic-input js-topic-edition input-md-12 form-control'} %>
+          <%= select_tag nil, options_for_select(latest_editions.map { |e| [e.title, e.guide.id] }), {class: 'js-topic-input js-topic-guide input-md-12 form-control'} %>
         </div>
       </li>
     </div>

--- a/spec/features/topic_spec.rb
+++ b/spec/features/topic_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe "topic editor", type: :feature do
   it "can create a new topic", js: true do
     edition1 = Generators.valid_edition(title: "Title 1")
     edition2 = Generators.valid_edition(title: "Title 2")
-    Guide.create!(slug: "/service-manual/edition1", latest_edition: edition1)
-    Guide.create!(slug: "/service-manual/edition2", latest_edition: edition2)
+    guide1 = Guide.create!(slug: "/service-manual/edition1", latest_edition: edition1)
+    guide2 = Guide.create!(slug: "/service-manual/edition2", latest_edition: edition2)
 
     visit root_path
     click_link "Manage Topics"
@@ -30,10 +30,10 @@ RSpec.describe "topic editor", type: :feature do
     fill_in "Heading Description", with: "The heading description"
 
     click_button "Add Guide"
-    all(".js-topic-edition")[0].find("option[value='#{edition1.id}']").select_option
+    all(".js-topic-guide")[0].find("option[value='#{guide1.id}']").select_option
 
     click_button "Add Guide"
-    all(".js-topic-edition")[1].find("option[value='#{edition2.id}']").select_option
+    all(".js-topic-guide")[1].find("option[value='#{guide2.id}']").select_option
 
     click_button "Save"
 
@@ -46,7 +46,7 @@ RSpec.describe "topic editor", type: :feature do
       [
         {
           "title": "The heading title",
-          "editions": [edition1.id.to_s, edition2.id.to_s],
+          "guides": [guide1.id.to_s, guide2.id.to_s],
           "description": "The heading description",
         }
       ].to_json

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -10,11 +10,11 @@ RSpec.describe TopicPresenter do
       path: "/service-manual/test-topic",
       description: "Topic description",
       tree: [{ title: "Group 1",
-               editions: [edition_1.id, edition_2.id],
+               guides: [edition_1.guide.id, edition_2.guide.id],
                description: "Fruits"
              }, {
                title: "Group 2",
-               editions: [edition_3.id],
+               guides: [edition_3.guide.id],
                description: "Berries"
              }].to_json
     )


### PR DESCRIPTION
This allows us to publish topics without having to update editions in the
topic to new versions.