### PR TITLE
Change TopicPresenter tests to ensure they reflect reality

### DIFF
--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -41,7 +41,7 @@ private
     topic_groups.map do |group|
       ids = group["guides"]
       guides = Guide.find(ids)
-      guides = ids.map{|id| guides.detect{|guide| guide.id == id}}
+      guides = ids.map{|id| guides.detect{|guide| guide.id == Integer(id)}}
 
       {
         name: group['title'],

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -10,11 +10,11 @@ RSpec.describe TopicPresenter do
       path: "/service-manual/test-topic",
       description: "Topic description",
       tree: [{ title: "Group 1",
-               guides: [edition_1.guide.id, edition_2.guide.id],
+               guides: [edition_1.guide.id.to_s, edition_2.guide.id.to_s],
                description: "Fruits"
              }, {
                title: "Group 2",
-               guides: [edition_3.guide.id],
+               guides: [edition_3.guide.id.to_s],
                description: "Berries"
              }].to_json
     )


### PR DESCRIPTION
In reality, we get a list of guides: ["int", "int"]. Notice those are
not integers, they're strings.

The tests were testing using ints, so in reality the code was not being
tested properly.