### PR TITLE
Fix slug migration with invalid "/service-manual/service-manual" prefix

### DIFF
--- a/db/migrate/20160223160404_fix_incorrect_slug_migration.rb
+++ b/db/migrate/20160223160404_fix_incorrect_slug_migration.rb
@@ -1,0 +1,7 @@
+class FixIncorrectSlugMigration < ActiveRecord::Migration
+  def change
+    old_slug = '/service-manual/service-manual/digital-foundation-day-training'
+    new_slug = '/service-manual/digital-foundation-day-training'
+    execute "UPDATE slug_migrations SET slug = '#{new_slug}' WHERE slug = '#{old_slug}'"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -650,3 +650,5 @@ INSERT INTO schema_migrations (version) VALUES ('20160223095349');
 
 INSERT INTO schema_migrations (version) VALUES ('20160223101735');
 
+INSERT INTO schema_migrations (version) VALUES ('20160223160404');
+


### PR DESCRIPTION
```
[~/.../service-manual-publisher] fix-topic-presenter-tests* ∞ rake db:migrate
== 20160223160404 FixIncorrectSlugMigration: migrating ========================
-- execute("UPDATE slug_migrations SET slug = '/service-manual/digital-foundation-day-training' WHERE slug = '/service-manual/service-manual/digital-foundation-day-training'")
   -> 0.0010s
== 20160223160404 FixIncorrectSlugMigration: migrated (0.0011s) ===============

```

```
irb(main):003:0* SlugMigration.find_by_slug("/service-manual/digital-foundation-day-training")
  SlugMigration Load (0.3ms)  SELECT  "slug_migrations".* FROM "slug_migrations" WHERE "slug_migrations"."slug" = $1 LIMIT 1  [["slug", "/service-manual/digital-foundation-day-training"]]
=> #<SlugMigration id: 409, slug: "/service-manual/digital-foundation-day-training", completed: false, created_at: "2016-02-23 10:14:26", updated_at: "2016-02-23 10:14:26", guide_id: nil, content_id: "a480a310-1c60-4cc6-a105-dffb400c8657">

```