### PR TITLE
Allow slug migrations to point to Topic pages

### DIFF
--- a/app/controllers/slug_migrations_controller.rb
+++ b/app/controllers/slug_migrations_controller.rb
@@ -1,7 +1,6 @@
 class SlugMigrationsController < ApplicationController
   def index
-    @migrations = SlugMigration.includes(:guide)
-                  .order(updated_at: :desc)
+    @migrations = SlugMigration.order(updated_at: :desc)
     if params[:completed].present?
       @migrations.where!(completed: params[:completed])
     end
@@ -12,28 +11,38 @@ class SlugMigrationsController < ApplicationController
 
   def edit
     @slug_migration = SlugMigration.find(params[:id])
-    @select_options = Guide.order(:slug).pluck(:slug, :id)
-    @selected_guide_id = @slug_migration.guide_id
+    @select_options = select_options
+    @selected_slug = @slug_migration.redirect_to
+  end
+
+  def select_options
+    guide_select_options = Guide
+      .with_published_editions
+      .order(:slug).pluck(:slug)
+      .map{|g| [g, g]}
+    topic_select_options = Topic
+      .order(:path).pluck(:path)
+      .map{|g| [g, g]}
+    {
+      "Topics" => topic_select_options,
+      "Guides" => guide_select_options,
+    }
   end
 
   def update
     @slug_migration = SlugMigration.find(params[:id])
-    @select_options = Guide.order(:slug).pluck(:slug, :id)
+    @select_options = select_options
 
     slug_migration_parameters = params.require(:slug_migration)
-      .permit(:guide_id)
-    slug_migration_parameters[:completed] = true if params[:save_and_migrate].present?
+      .permit(:redirect_to)
+    slug_migration_parameters[:completed] = true
 
     ActiveRecord::Base.transaction do
       if @slug_migration.update_attributes(slug_migration_parameters)
-        @selected_guide_id = @slug_migration.guide.try(:id)
+        @selected_slug = @slug_migration.redirect_to
 
-        if @slug_migration.completed?
-          SlugMigrationPublisher.new.process(@slug_migration)
-          redirect_to slug_migration_path(@slug_migration), notice: "Slug Migration has been completed"
-        else
-          redirect_to edit_slug_migration_path(@slug_migration), notice: "Slug Migration has been saved"
-        end
+        SlugMigrationPublisher.new.process(@slug_migration)
+        redirect_to slug_migration_path(@slug_migration), notice: "Slug Migration has been completed"
       else
         render action: :edit
       end

--- a/app/controllers/slug_migrations_controller.rb
+++ b/app/controllers/slug_migrations_controller.rb
@@ -12,7 +12,6 @@ class SlugMigrationsController < ApplicationController
   def edit
     @slug_migration = SlugMigration.find(params[:id])
     @select_options = select_options
-    @selected_slug = @slug_migration.redirect_to
   end
 
   def select_options
@@ -39,8 +38,6 @@ class SlugMigrationsController < ApplicationController
 
     ActiveRecord::Base.transaction do
       if @slug_migration.update_attributes(slug_migration_parameters)
-        @selected_slug = @slug_migration.redirect_to
-
         SlugMigrationPublisher.new.process(@slug_migration)
         redirect_to slug_migration_path(@slug_migration), notice: "Slug Migration has been completed"
       else

--- a/app/controllers/slug_migrations_controller.rb
+++ b/app/controllers/slug_migrations_controller.rb
@@ -23,6 +23,7 @@ class SlugMigrationsController < ApplicationController
       .order(:path).pluck(:path)
       .map{|g| [g, g]}
     {
+      "Other" => ["/service-manual"],
       "Topics" => topic_select_options,
       "Guides" => guide_select_options,
     }

--- a/app/models/slug_migration.rb
+++ b/app/models/slug_migration.rb
@@ -13,9 +13,7 @@ class SlugMigration < ActiveRecord::Base
     @search_client ||= GdsApi::Rummager.new(Plek.current.find('rummager'), disable_cache: true)
     begin
       @search_client.get_content!(slug)
-    rescue GdsApi::HTTPNotFound => e
-      false
-    rescue GdsApi::HTTPServerError => e
+    rescue GdsApi::HTTPErrorResponse => e
       false
     end
   end

--- a/app/models/slug_migration_publisher.rb
+++ b/app/models/slug_migration_publisher.rb
@@ -11,7 +11,7 @@ class SlugMigrationPublisher
         {
           path: slug_migration.slug,
           type: "exact",
-          destination: slug_migration.guide.slug,
+          destination: slug_migration.redirect_to,
         }
       ]
     }

--- a/app/views/slug_migrations/edit.html.erb
+++ b/app/views/slug_migrations/edit.html.erb
@@ -1,23 +1,20 @@
 <div class='well'>
   <%= form_for @slug_migration do |f| %>
     <h2>Slug Migration <small><%= @slug_migration.slug %></small></h2>
+
     <div class="form-group">
-      <%= f.label :guide_id, "Guide" %>
+      <%= f.label :redirect_to, "Redirect to" %>
       <%=
-        f.select :guide_id,
-          options_for_select(@select_options, @selected_guide_id),
-          {include_blank: "Please choose a guide to redirect to"},
-          {class: "select2 slug-migration-select-guide input-md-12 form-control"}
+        f.select :redirect_to,
+          grouped_options_for_select(@select_options, @selected_slug),
+          {include_blank: "Please choose a path to redirect to"},
+          {class: "select2 slug-migration-redirect-to input-md-12 form-control"}
       %>
-      <%= f.error_list :guide %>
+      <%= f.error_list :redirect_to %>
     </div>
+
     <div class="form-group">
-      <%= f.submit "Save", class: "btn btn-success" %>
-      <% if @slug_migration.guide.try(:has_published_edition?) %>
-        <%= f.submit "Migrate", name: :save_and_migrate, class: "btn btn-warning" %>
-      <% else %>
-        <%= f.submit "Needs a published guide to migrate", class: "btn btn-disabled", disabled: true %>
-      <% end %>
+      <%= f.submit "Migrate", class: "btn btn-warning" %>
     </div>
   <% end %>
 </div>

--- a/app/views/slug_migrations/edit.html.erb
+++ b/app/views/slug_migrations/edit.html.erb
@@ -3,7 +3,9 @@
     <h2>Slug Migration <small><%= @slug_migration.slug %></small></h2>
 
     <div class="form-group">
-      <%= f.label :redirect_to, "Redirect to" %>
+      <%= f.label :redirect_to do %>
+        Redirect to (<span class="text-info">only published guides and topics will appear in this list</span>)
+      <% end %>
       <%=
         f.select :redirect_to,
           grouped_options_for_select(@select_options),

--- a/app/views/slug_migrations/edit.html.erb
+++ b/app/views/slug_migrations/edit.html.erb
@@ -6,7 +6,7 @@
       <%= f.label :redirect_to, "Redirect to" %>
       <%=
         f.select :redirect_to,
-          grouped_options_for_select(@select_options, @selected_slug),
+          grouped_options_for_select(@select_options),
           {include_blank: "Please choose a path to redirect to"},
           {class: "select2 slug-migration-redirect-to input-md-12 form-control"}
       %>

--- a/app/views/slug_migrations/index.html.erb
+++ b/app/views/slug_migrations/index.html.erb
@@ -40,9 +40,7 @@
                 <%= link_to slug_migration.slug, "#{Plek.find('www')}#{slug_migration.slug}" %>
               </td>
               <td>
-                <% if slug_migration.guide.present? %>
-                  <%= slug_migration.guide.slug %>
-                <% end %>
+                <%= slug_migration.redirect_to %>
               </td>
             </tr>
           <% end %>

--- a/app/views/slug_migrations/show.html.erb
+++ b/app/views/slug_migrations/show.html.erb
@@ -2,7 +2,7 @@
   <h2>Slug Migration <small><%= @slug_migration.slug %></small></h2>
   <% if @slug_migration.completed? %>
     <p>
-      This migration has been completed, and redirects to: <%= @slug_migration.guide.try(:slug) %>
+      This migration has been completed, and redirects to: <%= @slug_migration.redirect_to %>
     </p>
   <% else %>
     <p>

--- a/db/migrate/20160224111338_make_slug_migrations_generic.rb
+++ b/db/migrate/20160224111338_make_slug_migrations_generic.rb
@@ -1,0 +1,13 @@
+class MakeSlugMigrationsGeneric < ActiveRecord::Migration
+  def change
+    add_column :slug_migrations, :redirect_to, :string
+
+    execute <<-SQL
+      UPDATE slug_migrations
+        SET redirect_to = guides.slug
+        FROM guides
+        WHERE slug_migrations.guide_id IS NOT NULL
+        AND slug_migrations.guide_id = guides.id
+    SQL
+  end
+end

--- a/db/migrate/20160224143937_remove_guide_id_from_slug_migrations.rb
+++ b/db/migrate/20160224143937_remove_guide_id_from_slug_migrations.rb
@@ -1,0 +1,5 @@
+class RemoveGuideIdFromSlugMigrations < ActiveRecord::Migration
+  def change
+    remove_column :slug_migrations, :guide_id
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -269,8 +269,8 @@ CREATE TABLE slug_migrations (
     completed boolean DEFAULT false NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    guide_id integer,
-    content_id character varying NOT NULL
+    content_id character varying NOT NULL,
+    redirect_to character varying
 );
 
 
@@ -651,4 +651,8 @@ INSERT INTO schema_migrations (version) VALUES ('20160223095349');
 INSERT INTO schema_migrations (version) VALUES ('20160223101735');
 
 INSERT INTO schema_migrations (version) VALUES ('20160223160404');
+
+INSERT INTO schema_migrations (version) VALUES ('20160224111338');
+
+INSERT INTO schema_migrations (version) VALUES ('20160224143937');
 

--- a/spec/features/slug_migration_spec.rb
+++ b/spec/features/slug_migration_spec.rb
@@ -101,6 +101,22 @@ RSpec.describe "Slug migration", type: :feature do
     end
   end
 
+  it "migrates to the root" do
+    slug_migration = create_slug_migration_without_redirect_to(
+      "/service-manual/some-jekyll-path.html",
+    )
+    expect_any_instance_of(SlugMigrationPublisher).to receive(:process).with(slug_migration)
+
+    manage_first_migration
+
+    select "/service-manual", from: "Redirect to"
+    click_button "Migrate"
+
+    expect(page).to have_content "Slug Migration has been completed"
+    expect(slug_migration.reload.completed).to eq true
+    expect(page.current_path).to eq slug_migration_path(slug_migration)
+  end
+
   it "migrates to a guide slug" do
     edition = Generators.valid_published_edition
     Guide.create!(slug: "/service-manual/new-path", latest_edition: edition)

--- a/spec/features/slug_migration_spec.rb
+++ b/spec/features/slug_migration_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Slug migration", type: :feature do
         [
           m.completed? ? "Show" : "Manage",
           m.slug,
-          String(m.try(:guide).try(:slug)),
+          m.redirect_to || "",
         ]
       end.reverse
       expect(table_data).to eq(expected)
@@ -47,10 +47,16 @@ RSpec.describe "Slug migration", type: :feature do
     end
   end
 
+  def create_slug_migration_without_redirect_to slug
+    slug_migration = SlugMigration.new(slug: slug, completed: false)
+    slug_migration.save!(validate: false)
+    slug_migration
+  end
+
   context "with incomplete migrations" do
     before do
       @migrations = (1..3).map do |i|
-        SlugMigration.create!(completed: false, slug: "/old/bar#{i}")
+        create_slug_migration_without_redirect_to "/old/bar/#{i}"
       end
     end
 
@@ -61,29 +67,33 @@ RSpec.describe "Slug migration", type: :feature do
     end
   end
 
-  context "can filter migrations" do
+  context "migration filter" do
     before do
       @incompleted = (1..2).map do |i|
-        SlugMigration.create!(completed: false, slug: "/old/bar#{i}")
+        create_slug_migration_without_redirect_to "/old/bar/#{i}"
       end
 
       edition = Generators.valid_published_edition
       guide = Guide.create!(slug: "/service-manual/something", latest_edition: edition)
       @complete = (1..2).map do |i|
-        SlugMigration.create!(completed: true, slug: "/old/foo#{i}", guide: guide)
+        SlugMigration.create!(
+          completed: true,
+          slug: "/old/foo#{i}",
+          redirect_to: guide.slug,
+        )
       end
 
       manage_migrations
     end
 
-    it "based on complete" do
+    it "filters on complete" do
       within ".slug-filters" do
         click_link "Completed 2"
       end
       expect_table_to_match_migrations @complete
     end
 
-    it "based on incompleted" do
+    it "filters on incompleted" do
       within ".slug-filters" do
         click_link "Not completed 2"
       end
@@ -91,39 +101,48 @@ RSpec.describe "Slug migration", type: :feature do
     end
   end
 
-  it "can save a slug migration" do
+  it "migrates to a guide slug" do
     edition = Generators.valid_published_edition
     Guide.create!(slug: "/service-manual/new-path", latest_edition: edition)
 
-    SlugMigration.create!(completed: false, slug: "/service-manual/some-jekyll-path.html")
-
-    manage_first_migration
-
-    select "/service-manual/new-path", from: "Guide"
-    click_button "Save"
-
-    expect(page).to have_content "Slug Migration has been saved"
-    selected_text = find(:css, ".slug-migration-select-guide option[selected]").text
-    expect(selected_text).to eq "/service-manual/new-path"
-  end
-
-  it "can not migrate an old slug to a new slug without a guide" do
-    SlugMigration.create!(completed: false, slug: "/service-manual/some-jekyll-path.html")
-    manage_first_migration
-    expect(page).to have_button('Needs a published guide to migrate', disabled: true)
-  end
-
-  it "migrates an old url to a new url" do
-    edition = Generators.valid_published_edition
-    Guide.create!(slug: "/service-manual/new-path", latest_edition: edition)
-    slug_migration = SlugMigration.create!(completed: false, slug: "/service-manual/some-jekyll-path.html")
-
+    slug_migration = create_slug_migration_without_redirect_to(
+      "/service-manual/some-jekyll-path.html",
+    )
     expect_any_instance_of(SlugMigrationPublisher).to receive(:process).with(slug_migration)
 
     manage_first_migration
-    select "/service-manual/new-path", from: "Guide"
 
-    click_button "Save"
+    select "/service-manual/new-path", from: "Redirect to"
+    click_button "Migrate"
+
+    expect(page).to have_content "Slug Migration has been completed"
+    expect(slug_migration.reload.completed).to eq true
+    expect(page.current_path).to eq slug_migration_path(slug_migration)
+  end
+
+  it "can't migrate to unpublished guides" do
+    edition = Generators.valid_edition
+    Guide.create!(slug: "/service-manual/new-path", latest_edition: edition)
+
+    create_slug_migration_without_redirect_to(
+      "/service-manual/some-jekyll-path.html",
+    )
+    manage_first_migration
+
+    expect(page).to_not have_content "/service-manual/new-path"
+  end
+
+  it "migrates to a topic path" do
+    Generators.valid_topic!(path: "/service-manual/topic-1")
+
+    slug_migration = create_slug_migration_without_redirect_to(
+      "/service-manual/some-jekyll-path.html",
+    )
+    expect_any_instance_of(SlugMigrationPublisher).to receive(:process).with(slug_migration)
+
+    manage_first_migration
+
+    select "/service-manual/topic-1", from: "Redirect to"
     click_button "Migrate"
 
     expect(page).to have_content "Slug Migration has been completed"
@@ -133,9 +152,11 @@ RSpec.describe "Slug migration", type: :feature do
 
   context "completed slug migrations" do
     it "only shows the migration, and does not allow editing" do
-      edition = Generators.valid_published_edition
-      guide = Guide.create!(slug: "/service-manual/something", latest_edition: edition)
-      slug_migration = SlugMigration.create!(completed: true, slug: "/old/foo", guide: guide)
+      slug_migration = SlugMigration.create!(
+        completed: true,
+        slug: "/old/foo",
+        redirect_to: "/some-path",
+      )
       show_first_migration
       expect(page.current_path).to eq slug_migration_path(slug_migration)
     end
@@ -145,15 +166,16 @@ RSpec.describe "Slug migration", type: :feature do
     it "is not marked as completed" do
       edition = Generators.valid_published_edition
       Guide.create!(slug: "/service-manual/new-path", latest_edition: edition)
-      slug_migration = SlugMigration.create!(completed: false, slug: "/service-manual/some-jekyll-path.html")
+      slug_migration = create_slug_migration_without_redirect_to(
+        "/service-manual/some-jekyll-path.html",
+      )
 
       api_error = GdsApi::HTTPClientError.new(422, "Error message stub", "error" => { "message" => "Error message stub" })
       expect_any_instance_of(SlugMigrationPublisher).to receive(:process).and_raise api_error
 
       manage_first_migration
-      select "/service-manual/new-path", from: "Guide"
+      select "/service-manual/new-path", from: "Redirect to"
 
-      click_button "Save"
       click_button "Migrate"
 
       expect(page).to have_content "Error message stub"
@@ -166,7 +188,11 @@ RSpec.describe "Slug migration", type: :feature do
     before do
       edition = Generators.valid_published_edition
       guide = Guide.create!(slug: "/service-manual/path", latest_edition: edition)
-      @slug_migration = SlugMigration.create!(completed: false, slug: "/service-manual/path.html", guide: guide)
+      @slug_migration = SlugMigration.create!(
+        completed: false,
+        slug: "/service-manual/path.html",
+        redirect_to: guide.slug,
+      )
     end
 
     context "that has a search index" do

--- a/spec/features/slug_migration_spec.rb
+++ b/spec/features/slug_migration_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe "Slug migration", type: :feature do
   end
 
   it "migrates to a topic path" do
-    Generators.valid_topic!(path: "/service-manual/topic-1")
+    Generators.create_valid_topic!(path: "/service-manual/topic-1")
 
     slug_migration = create_slug_migration_without_redirect_to(
       "/service-manual/some-jekyll-path.html",

--- a/spec/models/slug_migration_publisher_spec.rb
+++ b/spec/models/slug_migration_publisher_spec.rb
@@ -4,7 +4,11 @@ RSpec.describe SlugMigrationPublisher, type: :model do
   it "publishes slug migrations" do
     edition = Generators.valid_published_edition
     guide = Guide.create!(slug: "/service-manual/new-path", latest_edition: edition)
-    slug_migration = SlugMigration.create!(completed: true, slug: "/service-manual/some-jekyll-path.html", guide: guide)
+    slug_migration = SlugMigration.create!(
+      completed: true,
+      slug: "/service-manual/some-jekyll-path.html",
+      redirect_to: guide.slug,
+    )
 
     expected_redirect = {
       content_id: slug_migration.content_id,
@@ -15,7 +19,7 @@ RSpec.describe SlugMigrationPublisher, type: :model do
         {
           path: slug_migration.slug,
           type: "exact",
-          destination: slug_migration.guide.slug,
+          destination: slug_migration.redirect_to,
         }
       ]
     }
@@ -33,7 +37,11 @@ RSpec.describe SlugMigrationPublisher, type: :model do
   it "publishes slug migrations that are valid" do
     edition = Generators.valid_published_edition
     guide = Guide.create!(slug: "/service-manual/new-path", latest_edition: edition)
-    slug_migration = SlugMigration.create!(completed: true, slug: "/service-manual/some-jekyll-path.html", guide: guide)
+    slug_migration = SlugMigration.create!(
+      completed: true,
+      slug: "/service-manual/some-jekyll-path.html",
+      redirect_to: guide.slug,
+    )
 
     api_double = double(:publishing_api)
     expect(GdsApi::PublishingApiV2).to receive(:new).and_return(api_double)

--- a/spec/models/slug_migration_spec.rb
+++ b/spec/models/slug_migration_spec.rb
@@ -3,56 +3,35 @@ require 'rails_helper'
 RSpec.describe SlugMigration, type: :model do
   describe "on create callbacks" do
     it "generates and sets content_id on create" do
-      slug_migration = SlugMigration.create!(completed: false, slug: "/service-manual/some-jekyll-path.html")
+      slug_migration = SlugMigration.create!(
+        completed: false,
+        slug: "/service-manual/some-jekyll-path.html",
+        redirect_to: "/some-path",
+      )
       expect(slug_migration.content_id).to be_present
     end
   end
 
   it "is not completed by default" do
-    migration = SlugMigration.create(slug: "/some/slug")
+    migration = SlugMigration.create(slug: "/some/slug", redirect_to: "/some-path")
     expect(migration.completed).to eq false
   end
 
   it "has uniqueness validation on slug" do
-    SlugMigration.create!(slug: "/something")
-
-    migration = SlugMigration.new(slug: "/something")
+    SlugMigration.create!(slug: "/something", redirect_to: "/some-path")
+    migration = SlugMigration.new(slug: "/something", redirect_to: "/some-other-path")
     expect(migration.valid?).to eq false
     expect(migration.errors.full_messages_for(:slug).size).to eq 1
   end
 
-  it "validates that guide has a published edition" do
-    edition = Generators.valid_edition(state: "draft")
-    guide = Guide.create!(slug: "/service-manual/slug", latest_edition: edition)
-
-    migration = SlugMigration.new(slug: "/something", guide: guide, completed: true)
+  it "validates redirect_to is present" do
+    migration = SlugMigration.new(slug: "/something", redirect_to: nil, completed: true)
     expect(migration.valid?).to eq false
-    expect(migration.errors.full_messages_for(:guide).size).to eq 1
+    expect(migration.errors.full_messages_for(:redirect_to).size).to eq 1
   end
 
-  it "allows non-published guides for migrations that are not completed" do
-    edition = Generators.valid_edition(state: "draft")
-    guide = Guide.create!(slug: "/service-manual/slug", latest_edition: edition)
-
-    migration = SlugMigration.new(slug: "/something", guide: guide)
-    expect(migration).to be_valid
-  end
-
-  it "allows empty guides" do
-    migration = SlugMigration.new(slug: "/something", guide: nil)
-    expect(migration.valid?).to eq true
-  end
-
-  it "does not allow empty guides when migrating" do
-    migration = SlugMigration.new(slug: "/something", guide: nil, completed: true)
-    expect(migration.valid?).to eq false
-    expect(migration.errors.full_messages_for(:guide).size).to eq 1
-  end
-
-  it "does not allow saving if it is already marked as completed" do
-    edition = Generators.valid_published_edition
-    guide = Guide.create!(slug: "/service-manual/slug", latest_edition: edition)
-    migration = SlugMigration.create!(slug: "/something", guide: guide, completed: true)
+  it "does not allow saving if it is completed" do
+    migration = SlugMigration.create!(slug: "/something", redirect_to: "/some-path", completed: true)
     expect(migration.valid?).to eq false
     expect(migration.errors.full_messages_for(:base).size).to eq 1
   end

--- a/spec/support/generators.rb
+++ b/spec/support/generators.rb
@@ -44,7 +44,7 @@ class Generators
     User.new(attrs)
   end
 
-  def self.valid_topic!(attributes = {})
+  def self.create_valid_topic!(attributes = {})
     topic = valid_topic(attributes)
     topic.save!
     topic

--- a/spec/support/generators.rb
+++ b/spec/support/generators.rb
@@ -44,6 +44,12 @@ class Generators
     User.new(attrs)
   end
 
+  def self.valid_topic!(attributes = {})
+    topic = valid_topic(attributes)
+    topic.save!
+    topic
+  end
+
   def self.valid_topic(attributes = {})
     attrs = { title: "Agile Delivery", path: "/service-manual/agile-delivery", description: "Agile description" }
     attrs.merge!(attributes)


### PR DESCRIPTION
Also, remove the Save -> Migrate flow from "manage migrations". It's not
useful and adds a lot of additional complexity.

https://trello.com/c/o2B2aWXl/162-allow-migrating-old-slugs-to-new-topics-and-the-home-page