### PR TITLE
Present topic content owners to publishing API

### DIFF
--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -26,9 +26,13 @@ class TopicPresenter
   end
 
   def links
+    content_owners = @topic.content_owners.map do |c|
+      { "title" => c.title, "base_path" => c.href }
+    end
     {
       links: {
-        linked_items: eagerloaded_guides.map { |guide| guide.content_id }
+        linked_items: eagerloaded_guides.map(&:content_id),
+        content_owners: content_owners,
       }
     }
   end

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -9,14 +9,22 @@ RSpec.describe TopicPresenter do
       title: "Test topic",
       path: "/service-manual/test-topic",
       description: "Topic description",
-      tree: [{ title: "Group 1",
-               guides: [edition_1.guide.id.to_s, edition_2.guide.id.to_s],
-               description: "Fruits"
-             }, {
-               title: "Group 2",
-               guides: [edition_3.guide.id.to_s],
-               description: "Berries"
-             }].to_json
+      tree: [
+        {
+          title: "Group 1",
+          guides: [edition_1.guide.to_param, edition_2.guide.to_param],
+          description: "Fruits",
+        },
+        {
+          title: "Group 2",
+          guides: [edition_3.guide.to_param],
+          description: "Berries",
+        }
+      ].to_json,
+      content_owners: [
+        ContentOwner.new(title: "Content Owner 1", href: "/service-manual/content-owner-1"),
+        ContentOwner.new(title: "Content Owner 2", href: "/service-manual/content-owner-2"),
+      ]
     )
   end
 
@@ -56,6 +64,17 @@ RSpec.describe TopicPresenter do
       [edition_1, edition_2, edition_3].each do |edition|
         expect(edition.guide.content_id).to be_in(linked_items)
       end
+    end
+
+    it "references all content owners" do
+      expected = 1.upto(2).map do |i|
+       {
+         "title"     => "Content Owner #{i}",
+         "base_path" => "/service-manual/content-owner-#{i}"
+       }
+      end
+      content_owners = presented_topic.links[:links][:content_owners]
+      expect(content_owners).to eq expected
     end
   end
 end


### PR DESCRIPTION
In order to render a list of content owners on topic pages.