### PR TITLE
Community as a type of guide again

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -18,7 +18,9 @@ class GuidesController < ApplicationController
   end
 
   def new
-    @guide = Guide.new(slug: "/service-manual/")
+    type = params[:community].present? ? 'GuideCommunity' : nil
+
+    @guide = Guide.new(slug: "/service-manual/", type: type)
     @guide.build_latest_edition(update_type: 'major')
   end
 
@@ -126,7 +128,7 @@ private
 
     params
       .require(:guide)
-      .permit(:slug, latest_edition_attributes: [
+      .permit(:slug, :type, latest_edition_attributes: [
         :title,
         :body,
         :description,

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -2,9 +2,9 @@ class GuidesController < ApplicationController
   def index
     @user_options = User.pluck(:name, :id)
     @state_options = %w(draft published review_requested approved).map { |s| [s.titleize, s] }
-    @content_owner_options = ContentOwner.pluck(:title, :id)
 
-    @guides = Guide.includes(latest_edition: [:user, :content_owner])
+    # TODO: :content_owner not being included is resulting in an N+1 query
+    @guides = Guide.includes(latest_edition: [:user])
                    .by_user(params[:user])
                    .in_state(params[:state])
                    .owned_by(params[:content_owner])

--- a/app/helpers/guide_helper.rb
+++ b/app/helpers/guide_helper.rb
@@ -25,4 +25,10 @@ module GuideHelper
   def latest_editor_name(guide)
     guide.latest_edition.user.try(:name).to_s
   end
+
+  def guide_community_options_for_select
+    GuideCommunity.includes(:latest_edition).
+          sort_by{ |guide| guide.title }.
+          map{ |g| [g.title, g.id] }
+  end
 end

--- a/app/models/content_owner.rb
+++ b/app/models/content_owner.rb
@@ -1,2 +1,0 @@
-class ContentOwner < ActiveRecord::Base
-end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -6,7 +6,7 @@ class Edition < ActiveRecord::Base
 
   has_one :approval
 
-  belongs_to :content_owner
+  belongs_to :content_owner, class_name: 'GuideCommunity'
 
   scope :draft, -> { where(state: 'draft') }
   scope :published, -> { where(state: 'published') }

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -12,7 +12,7 @@ class Edition < ActiveRecord::Base
   scope :published, -> { where(state: 'published') }
   scope :review_requested, -> { where(state: 'review_requested') }
 
-  validates_presence_of [:state, :phase, :description, :title, :update_type, :body, :content_owner, :user]
+  validates_presence_of [:state, :phase, :description, :title, :update_type, :body, :user]
   validates_inclusion_of :state, in: %w(draft published review_requested approved)
   validates :change_note, presence: true, if: :major?
   validates :change_summary, presence: true, if: :major?

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -69,11 +69,11 @@ class Guide < ActiveRecord::Base
     end
   end
 
-private
-
   def requires_content_owner?
     true
   end
+
+private
 
   def slug_format
     if !slug.to_s.match(/\A\/service-manual\//)

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -2,6 +2,7 @@ class Guide < ActiveRecord::Base
   include ContentIdentifiable
   validate :slug_format
   validate :slug_cant_be_changed_if_an_edition_has_been_published
+  validate :latest_edition_has_content_owner, if: :requires_content_owner?
 
   has_many :editions
   has_one :latest_edition, -> { order(created_at: :desc) }, class_name: "Edition"
@@ -70,6 +71,10 @@ class Guide < ActiveRecord::Base
 
 private
 
+  def requires_content_owner?
+    true
+  end
+
   def slug_format
     if !slug.to_s.match(/\A\/service-manual\//)
       errors.add(:slug, "must be present and start with '/service-manual/'")
@@ -83,6 +88,12 @@ private
   def slug_cant_be_changed_if_an_edition_has_been_published
     if slug_changed? && has_published_edition?
       errors.add(:slug, "can't be changed if guide has a published edition")
+    end
+  end
+
+  def latest_edition_has_content_owner
+    if latest_edition && latest_edition.content_owner.nil?
+      errors.add(:latest_edition, 'must have a content owner')
     end
   end
 end

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -5,12 +5,14 @@ class Guide < ActiveRecord::Base
   validate :latest_edition_has_content_owner, if: :requires_content_owner?
 
   has_many :editions
-  has_one :latest_edition, -> { order(created_at: :desc) }, class_name: "Edition"
+  has_one :latest_edition, -> { order(created_at: :desc) }, class_name: "Edition", inverse_of: :guide
 
   accepts_nested_attributes_for :latest_edition
   scope :by_user, ->(user_id) { where(editions: { user_id: user_id }) if user_id.present? }
   scope :in_state, ->(state) { where(editions: { state: state }) if state.present? }
   scope :owned_by, ->(content_owner_id) { where(editions: { content_owner_id: content_owner_id }) if content_owner_id.present? }
+
+  delegate :title, to: :latest_edition
 
   def self.with_published_editions
     joins(:editions)

--- a/app/models/guide_community.rb
+++ b/app/models/guide_community.rb
@@ -1,0 +1,5 @@
+class GuideCommunity < Guide
+  def requires_content_owner?
+    false
+  end
+end

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -9,6 +9,7 @@ class Publisher
   def save_draft(content_for_publication)
     save_catching_gds_api_errors do
       publishing_api.put_content(content_model.content_id, content_for_publication.exportable_attributes)
+      publishing_api.put_links(content_model.content_id, content_for_publication.links_payload)
     end
   end
 

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -8,7 +8,7 @@ class Publisher
 
   def save_draft(content_for_publication)
     save_catching_gds_api_errors do
-      publishing_api.put_content(content_model.content_id, content_for_publication.exportable_attributes)
+      publishing_api.put_content(content_model.content_id, content_for_publication.content_payload)
       publishing_api.put_links(content_model.content_id, content_for_publication.links_payload)
     end
   end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,6 +1,5 @@
 class Topic < ActiveRecord::Base
   include ContentIdentifiable
-  has_and_belongs_to_many :content_owners
   validate :path_can_be_set_once
   validate :path_format
 

--- a/app/models/topic_publisher.rb
+++ b/app/models/topic_publisher.rb
@@ -6,7 +6,7 @@ class TopicPublisher
   end
 
   def put_draft
-    data = TopicPresenter.new(topic).exportable_attributes
+    data = TopicPresenter.new(topic).content_payload
     publishing_api.put_content(topic.content_id, data)
   end
 

--- a/app/models/topic_publisher.rb
+++ b/app/models/topic_publisher.rb
@@ -15,7 +15,7 @@ class TopicPublisher
   end
 
   def put_links
-    link_data = TopicPresenter.new(topic).links
+    link_data = TopicPresenter.new(topic).links_payload
     publishing_api.put_links(topic.content_id, link_data)
 
     GuideTaggerJob.batch_perform_later(

--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -6,7 +6,7 @@ class GuidePresenter
     @edition = edition
   end
 
-  def exportable_attributes
+  def content_payload
     {
       content_id: guide.content_id,
       publishing_app: "service-manual-publisher",

--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -26,6 +26,10 @@ class GuidePresenter
     }
   end
 
+  def links_payload
+    {}
+  end
+
 private
 
   attr_reader :guide, :edition

--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -36,15 +36,6 @@ private
       header_links: level_two_headers,
     }
 
-    if edition.content_owner
-      details.merge!(
-        content_owner: {
-          title: edition.content_owner.title,
-          href: edition.content_owner.href,
-        }
-      )
-    end
-
     if edition.related_discussion_title.present? && edition.related_discussion_href.present?
       details[:related_discussion] = {
         title: edition.related_discussion_title,

--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -27,7 +27,13 @@ class GuidePresenter
   end
 
   def links_payload
-    {}
+    links = {}.tap do |payload|
+      if edition.content_owner
+        payload[:content_owners] = [edition.content_owner.content_id]
+      end
+    end
+
+    { links: links }
   end
 
 private

--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -34,11 +34,16 @@ private
     details = {
       body: govspeak_body.to_html,
       header_links: level_two_headers,
-      content_owner: {
-        title: edition.content_owner.title,
-        href: edition.content_owner.href
-      }
     }
+
+    if edition.content_owner
+      details.merge!(
+        content_owner: {
+          title: edition.content_owner.title,
+          href: edition.content_owner.href,
+        }
+      )
+    end
 
     if edition.related_discussion_title.present? && edition.related_discussion_href.present?
       details[:related_discussion] = {

--- a/app/presenters/search_header_presenter.rb
+++ b/app/presenters/search_header_presenter.rb
@@ -34,7 +34,7 @@ class SearchHeaderPresenter
 
   def published_by
     if params[:content_owner].present?
-      "published by #{ContentOwner.find(params[:content_owner]).title}"
+      "published by #{GuideCommunity.find(params[:content_owner]).title}"
     end
   end
 end

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -26,13 +26,9 @@ class TopicPresenter
   end
 
   def links
-    content_owners = @topic.content_owners.map do |c|
-      { "title" => c.title, "base_path" => c.href }
-    end
     {
       links: {
         linked_items: eagerloaded_guides.map(&:content_id),
-        content_owners: content_owners,
       }
     }
   end

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -25,7 +25,7 @@ class TopicPresenter
     }
   end
 
-  def links
+  def links_payload
     {
       links: {
         linked_items: eagerloaded_guides.map(&:content_id),

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -3,7 +3,7 @@ class TopicPresenter
     @topic = topic
   end
 
-  def exportable_attributes
+  def content_payload
     {
       content_id: topic.content_id,
       publishing_app: "service-manual-publisher",

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -87,11 +87,13 @@
           <%= editions_form.text_area :body, class: 'js-markdown-image-upload input-md-12 form-control markdown-textarea text-area-auto-size text-area-auto-size-large js-text-area-auto-size', rows: 14 %>
         </div>
 
-        <div class='form-group'>
-          <%= editions_form.label :content_owner_id, "Published by" %>
-          <%= editions_form.error_list :content_owner_id %>
-          <%= editions_form.select :content_owner_id, ContentOwner.all.pluck(:title, :id), {}, {class: 'select2 input-md-12 form-control'} %>
-        </div>
+        <% if guide.requires_content_owner? %>
+          <div class='form-group'>
+            <%= editions_form.label :content_owner_id, "Published by" %>
+            <%= editions_form.error_list :content_owner_id %>
+            <%= editions_form.select :content_owner_id, ContentOwner.all.pluck(:title, :id), {}, {class: 'select2 input-md-12 form-control'} %>
+          </div>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -91,7 +91,7 @@
           <div class='form-group'>
             <%= editions_form.label :content_owner_id, "Published by" %>
             <%= editions_form.error_list :content_owner_id %>
-            <%= editions_form.select :content_owner_id, ContentOwner.all.pluck(:title, :id), {}, {class: 'select2 input-md-12 form-control'} %>
+            <%= editions_form.select :content_owner_id, guide_community_options_for_select, {}, {class: 'select2 input-md-12 form-control'} %>
           </div>
         <% end %>
       </div>

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -55,10 +55,10 @@
       <% end %>
 
       <div class="well">
-        <h2>Guide content</h2>
+        <h2><%= guide.model_name.human %> content</h2>
 
         <div class="form-group">
-          <%= editions_form.label :title, "Guide title" %>
+          <%= editions_form.label :title %>
           <%= editions_form.error_list :title %>
           <%= editions_form.text_field :title, class: 'input-md-12 form-control js-guide-title' %>
         </div>
@@ -71,7 +71,7 @@
         </div>
 
         <div class='form-group'>
-          <%= editions_form.label :description, "Guide description" %>
+          <%= editions_form.label :description %>
           <%= editions_form.error_list :description %>
           <span class="help-block">To be used for displaying search results, linking content etc.</span>
           <%= editions_form.text_area :description, rows: 5, class: 'input-md-12 form-control text-area-auto-size js-text-area-auto-size' %>

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -1,4 +1,6 @@
-<%= form_for guide, html: { class: "js-protect-data" } do |f| %>
+<%= form_for guide, as: :guide, url: url_for(guide.becomes(Guide)), html: { class: "js-protect-data" } do |f| %>
+
+  <%= f.hidden_field :type %>
 
   <div class="col-md-12">
     <%= render 'editions/actions', publish_controls_only: false, form: f, guide: @guide, edition: @guide.latest_edition %>

--- a/app/views/guides/index.html.erb
+++ b/app/views/guides/index.html.erb
@@ -50,7 +50,9 @@
               <div class='text-muted'><%= guide.slug %></div>
             </td>
             <td>
-              <%= guide.latest_edition.content_owner.title %>
+              <% if guide.latest_edition.content_owner %>
+                <%= guide.latest_edition.content_owner.title %>
+              <% end %>
             </td>
             <td class='last-edited-by'>
               <%= latest_editor_name(guide) %>

--- a/app/views/guides/index.html.erb
+++ b/app/views/guides/index.html.erb
@@ -18,7 +18,8 @@
         <%= select_tag :state, options_for_select(@state_options, params[:state]), {include_blank: "All", class: "select2 input-md-12 form-control"} %>
 
         <%= label_tag :content_owner, "Published by", class: "add-top-margin nav-header" %>
-        <%= select_tag :content_owner, options_for_select(@content_owner_options, params[:content_owner]), {include_blank: "All", class: "select2 input-md-12 form-control"} %>
+        <%= select_tag :content_owner, options_for_select(guide_community_options_for_select, params[:content_owner]), {include_blank: "All", class: "select2 input-md-12 form-control"} %>
+
 
         <input type="submit" class="add-top-margin btn btn-default" value="Filter guides">
       </form>

--- a/app/views/guides/index.html.erb
+++ b/app/views/guides/index.html.erb
@@ -3,6 +3,9 @@
     <p>
       <%= link_to "Create a Guide" , new_guide_path, class: 'btn btn-block btn-success' %>
     </p>
+    <p>
+      <%= link_to "Create a Guide Community" , new_guide_path(community: true), class: 'btn btn-block btn-success' %>
+    </p>
     <div class="filters well sidebar-nav">
       <form action="<%= guides_path%>" method="get">
         <%= label_tag :q, "Title or slug", class: "nav-header" %>

--- a/app/views/topics/new.html.erb
+++ b/app/views/topics/new.html.erb
@@ -21,10 +21,6 @@
           <%= f.label :description %>
           <%= f.text_field :description, class: "form-control" %>
         </div>
-        <div class="form-group">
-          <%= f.label :content_owner_ids, "Content Owners" %>
-          <%= f.select :content_owner_ids, options_for_select(ContentOwner.order(:title).map { |co| [co.title, co.id] }, selected: @topic.content_owner_ids), {}, {class: "form-control select2", multiple: true} %>
-        </div>
       </div>
 
       <div class="well">

--- a/db/migrate/20160225090417_add_type_to_guides.rb
+++ b/db/migrate/20160225090417_add_type_to_guides.rb
@@ -1,0 +1,5 @@
+class AddTypeToGuides < ActiveRecord::Migration
+  def change
+    add_column :guides, :type, :string
+  end
+end

--- a/db/migrate/20160225101236_remove_content_owner_not_null_constraint_from_editions.rb
+++ b/db/migrate/20160225101236_remove_content_owner_not_null_constraint_from_editions.rb
@@ -1,0 +1,5 @@
+class RemoveContentOwnerNotNullConstraintFromEditions < ActiveRecord::Migration
+  def change
+    change_column_null :editions, :content_owner_id, true
+  end
+end

--- a/db/migrate/20160225113207_drop_content_owners_topics.rb
+++ b/db/migrate/20160225113207_drop_content_owners_topics.rb
@@ -1,0 +1,5 @@
+class DropContentOwnersTopics < ActiveRecord::Migration
+  def change
+    drop_table :content_owners_topics
+  end
+end

--- a/db/migrate/20160225130400_drop_content_owners.rb
+++ b/db/migrate/20160225130400_drop_content_owners.rb
@@ -1,0 +1,61 @@
+class DropContentOwners < ActiveRecord::Migration
+  class FakeContentOwner < ActiveRecord::Base
+    self.table_name = 'content_owners'
+  end
+  class FakeGuide < ActiveRecord::Base
+    self.table_name = 'guides'
+
+    has_many :editions, class_name: 'FakeEdition', foreign_key: 'guide_id'
+  end
+  class FakeEdition < ActiveRecord::Base
+    self.table_name = 'editions'
+  end
+
+  def up
+    # Create a temporary column to store the relation to the relevant guide
+    add_column :editions, :new_content_owner_id, :integer
+
+    design_community_guide = FakeGuide.joins(:editions).
+                                       where('editions.title = ?', 'Design Community').
+                                       first
+    agile_community_guide  = FakeGuide.joins(:editions).
+                                       where('editions.title = ?', 'Agile Community').
+                                       first
+
+    design_content_owner = FakeContentOwner.find_by_title('Design Community')
+    agile_content_owner = FakeContentOwner.find_by_title('Agile Community')
+
+
+    if design_community_guide && design_content_owner
+      FakeEdition.where(content_owner_id: design_content_owner.id).
+                  update_all(new_content_owner_id: design_community_guide.id)
+    end
+
+    if agile_community_guide && agile_content_owner
+      FakeEdition.where(content_owner_id: agile_content_owner.id).
+                  update_all(new_content_owner_id: agile_community_guide.id)
+    end
+
+
+    [design_community_guide, agile_community_guide].each do |community_guide|
+      if community_guide.present?
+        # Mark the community guides with the community flag
+        community_guide.update_attribute(:type, 'GuideCommunity')
+
+        # Remove the content_owner_ids from all community guides as they do not have owners
+        community_guide.editions.update_all(new_content_owner_id: nil)
+      end
+    end
+
+    # Remove the old content_owner_id along with any relations we didn't know about
+    remove_column :editions, :content_owner_id
+    # Rename the temporary column to the same name as the old one
+    rename_column :editions, :new_content_owner_id, :content_owner_id
+
+    drop_table :content_owners
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -45,10 +45,19 @@ end
 
 if Rails.env.development? || ENV["GOVUK_APP_DOMAIN"] == "preview.alphagov.co.uk"
   author = User.first || User.create!(name: "Unknown", email: "unknown@example.com")
-  if ContentOwner.count == 0
-    ContentOwner.create!(
-      title: "Design Community",
-      href: "http://sm-11.herokuapp.com/designing-services/design-community/"
+  if !GuideCommunity.any?
+    community_guide_edition = Edition.new(
+      title:          'Design Community',
+      state:          "draft",
+      phase:          "beta",
+      description:    "Description",
+      update_type:    "minor",
+      body:           "# Heading",
+      user:           author,
+      )
+    GuideCommunity.create!(
+      latest_edition: community_guide_edition,
+      slug: "/service-manual/design-community"
     )
   end
 
@@ -73,7 +82,7 @@ if Rails.env.development? || ENV["GOVUK_APP_DOMAIN"] == "preview.alphagov.co.uk"
       description:     "Description",
       update_type:     "minor",
       body:            object[:body].gsub(/\n/, "\r\n"),
-      content_owner:   ContentOwner.first,
+      content_owner:   GuideCommunity.first,
       user:            author,
     )
     guide = Guide.create!(slug: object[:url], content_id: nil, latest_edition: edition)

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -143,38 +143,6 @@ ALTER SEQUENCE content_owners_id_seq OWNED BY content_owners.id;
 
 
 --
--- Name: content_owners_topics; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE content_owners_topics (
-    id integer NOT NULL,
-    content_owner_id integer,
-    topic_id integer,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone
-);
-
-
---
--- Name: content_owners_topics_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE content_owners_topics_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: content_owners_topics_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE content_owners_topics_id_seq OWNED BY content_owners_topics.id;
-
-
---
 -- Name: editions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -392,13 +360,6 @@ ALTER TABLE ONLY content_owners ALTER COLUMN id SET DEFAULT nextval('content_own
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY content_owners_topics ALTER COLUMN id SET DEFAULT nextval('content_owners_topics_id_seq'::regclass);
-
-
---
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
---
-
 ALTER TABLE ONLY editions ALTER COLUMN id SET DEFAULT nextval('editions_id_seq'::regclass);
 
 
@@ -452,14 +413,6 @@ ALTER TABLE ONLY comments
 
 ALTER TABLE ONLY content_owners
     ADD CONSTRAINT content_owners_pkey PRIMARY KEY (id);
-
-
---
--- Name: content_owners_topics_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
---
-
-ALTER TABLE ONLY content_owners_topics
-    ADD CONSTRAINT content_owners_topics_pkey PRIMARY KEY (id);
 
 
 --
@@ -528,20 +481,6 @@ CREATE INDEX index_comments_on_commentable_type ON comments USING btree (comment
 --
 
 CREATE INDEX index_comments_on_user_id ON comments USING btree (user_id);
-
-
---
--- Name: index_content_owners_topics_on_content_owner_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_content_owners_topics_on_content_owner_id ON content_owners_topics USING btree (content_owner_id);
-
-
---
--- Name: index_content_owners_topics_on_topic_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_content_owners_topics_on_topic_id ON content_owners_topics USING btree (topic_id);
 
 
 --
@@ -660,4 +599,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160224143937');
 INSERT INTO schema_migrations (version) VALUES ('20160225090417');
 
 INSERT INTO schema_migrations (version) VALUES ('20160225101236');
+
+INSERT INTO schema_migrations (version) VALUES ('20160225113207');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -193,7 +193,7 @@ CREATE TABLE editions (
     updated_at timestamp without time zone NOT NULL,
     state text,
     change_note text,
-    content_owner_id integer NOT NULL,
+    content_owner_id integer,
     change_summary text
 );
 
@@ -227,7 +227,8 @@ CREATE TABLE guides (
     content_id character varying,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    tsv tsvector
+    tsv tsvector,
+    type character varying
 );
 
 
@@ -655,4 +656,8 @@ INSERT INTO schema_migrations (version) VALUES ('20160223160404');
 INSERT INTO schema_migrations (version) VALUES ('20160224111338');
 
 INSERT INTO schema_migrations (version) VALUES ('20160224143937');
+
+INSERT INTO schema_migrations (version) VALUES ('20160225090417');
+
+INSERT INTO schema_migrations (version) VALUES ('20160225101236');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -113,36 +113,6 @@ ALTER SEQUENCE comments_id_seq OWNED BY comments.id;
 
 
 --
--- Name: content_owners; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE content_owners (
-    id integer NOT NULL,
-    title character varying NOT NULL,
-    href character varying NOT NULL
-);
-
-
---
--- Name: content_owners_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE content_owners_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: content_owners_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE content_owners_id_seq OWNED BY content_owners.id;
-
-
---
 -- Name: editions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -161,8 +131,8 @@ CREATE TABLE editions (
     updated_at timestamp without time zone NOT NULL,
     state text,
     change_note text,
-    content_owner_id integer,
-    change_summary text
+    change_summary text,
+    content_owner_id integer
 );
 
 
@@ -353,13 +323,6 @@ ALTER TABLE ONLY comments ALTER COLUMN id SET DEFAULT nextval('comments_id_seq':
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY content_owners ALTER COLUMN id SET DEFAULT nextval('content_owners_id_seq'::regclass);
-
-
---
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
---
-
 ALTER TABLE ONLY editions ALTER COLUMN id SET DEFAULT nextval('editions_id_seq'::regclass);
 
 
@@ -405,14 +368,6 @@ ALTER TABLE ONLY approvals
 
 ALTER TABLE ONLY comments
     ADD CONSTRAINT comments_pkey PRIMARY KEY (id);
-
-
---
--- Name: content_owners_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
---
-
-ALTER TABLE ONLY content_owners
-    ADD CONSTRAINT content_owners_pkey PRIMARY KEY (id);
 
 
 --
@@ -601,4 +556,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160225090417');
 INSERT INTO schema_migrations (version) VALUES ('20160225101236');
 
 INSERT INTO schema_migrations (version) VALUES ('20160225113207');
+
+INSERT INTO schema_migrations (version) VALUES ('20160225130400');
 

--- a/spec/features/comments_spec.rb
+++ b/spec/features/comments_spec.rb
@@ -3,7 +3,7 @@ require 'capybara/rails'
 
 RSpec.describe "Commenting", type: :feature do
   let!(:guide) do
-    edition = Generators.valid_edition
+    edition = Generators.valid_edition(title: 'Lean Startup')
     Guide.create!(
       latest_edition: edition,
       slug: "/service-manual/test/comment"
@@ -12,7 +12,9 @@ RSpec.describe "Commenting", type: :feature do
 
   it "allows discourse" do
     visit root_path
-    click_link "Edit"
+    within_guide_index_row('Lean Startup') do
+      click_link "Edit"
+    end
     click_link "Comments and history"
 
     within ".comments" do

--- a/spec/features/filter_spec.rb
+++ b/spec/features/filter_spec.rb
@@ -44,11 +44,13 @@ RSpec.describe "filtering guides", type: :feature do
 
   it "filters by published by" do
     [1, 2].each do |i|
-      content_owner = ContentOwner.create!(title: "Content Owner #{i}", href: "some href")
+      guide_community = Generators.valid_guide_community(
+        latest_edition: Generators.valid_edition(content_owner: nil, title: "Content Owner #{i}")
+        ).tap(&:save!)
       edition = Generators.valid_edition(
         state: "review_requested",
         title: "Edition #{i}",
-        content_owner: content_owner,
+        content_owner_id: guide_community.id,
       )
       Guide.create!(latest_edition: edition, slug: "/service-manual/#{i}")
     end
@@ -94,7 +96,9 @@ RSpec.describe "filtering guides", type: :feature do
   end
 
   it "displays a page header that's based on the query" do
-    ContentOwner.create!(title: "Design Community", href: "example.com")
+    Generators.valid_guide_community(
+        latest_edition: Generators.valid_edition(content_owner: nil, title: "Design Community")
+        ).tap(&:save!)
     User.create!(name: "Ronan", email: "ronan@example.com")
     visit root_path
     within ".filters" do

--- a/spec/features/guide_community_spec.rb
+++ b/spec/features/guide_community_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe 'Create a guide community', type: :feature do
+  it 'successfully creates a guide community' do
+    visit root_path
+    click_link "Create a Guide Community"
+
+    publishing_api = double(:publishing_api)
+    stub_const("PUBLISHING_API", publishing_api)
+    expect(publishing_api).to receive(:put_content)
+
+    fill_in 'Slug', with: '/service-manual/design-community'
+    fill_in "Guide description", with: "This acts as a test case"
+    fill_in "Guide title", with: "First Edition Title"
+    fill_in "Body", with: "## First Edition Title"
+    click_first_button "Save"
+
+    within ".alert" do
+      expect(page).to have_content('created')
+    end
+
+    # Reload the page to avoid any false positive assertions on
+    # the content of the fields
+    visit current_path
+
+    expect(page).to have_field('Slug', with: '/service-manual/design-community')
+    expect(page).to have_field('Guide description', with: 'This acts as a test case')
+    expect(page).to have_field('Guide title', with: 'First Edition Title')
+    expect(page).to have_field('Body', with: '## First Edition Title')
+  end
+end

--- a/spec/features/guide_community_spec.rb
+++ b/spec/features/guide_community_spec.rb
@@ -28,4 +28,11 @@ RSpec.describe 'Create a guide community', type: :feature do
     expect(page).to have_field('Guide title', with: 'First Edition Title')
     expect(page).to have_field('Body', with: '## First Edition Title')
   end
+
+  it 'does not have a content owner field' do
+    visit root_path
+    click_link "Create a Guide Community"
+
+    expect(page).to_not have_field('Published by')
+  end
 end

--- a/spec/features/guide_community_spec.rb
+++ b/spec/features/guide_community_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'Create a guide community', type: :feature do
     publishing_api = double(:publishing_api)
     stub_const("PUBLISHING_API", publishing_api)
     expect(publishing_api).to receive(:put_content)
+    expect(publishing_api).to receive(:put_links)
 
     fill_in 'Slug', with: '/service-manual/design-community'
     fill_in "Guide description", with: "This acts as a test case"

--- a/spec/features/guide_community_spec.rb
+++ b/spec/features/guide_community_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe 'Create a guide community', type: :feature do
     expect(publishing_api).to receive(:put_links)
 
     fill_in 'Slug', with: '/service-manual/design-community'
-    fill_in "Guide description", with: "This acts as a test case"
-    fill_in "Guide title", with: "First Edition Title"
+    fill_in "Description", with: "This acts as a test case"
+    fill_in "Title", with: "First Edition Title"
     fill_in "Body", with: "## First Edition Title"
     click_first_button "Save"
 
@@ -25,8 +25,8 @@ RSpec.describe 'Create a guide community', type: :feature do
     visit current_path
 
     expect(page).to have_field('Slug', with: '/service-manual/design-community')
-    expect(page).to have_field('Guide description', with: 'This acts as a test case')
-    expect(page).to have_field('Guide title', with: 'First Edition Title')
+    expect(page).to have_field('Description', with: 'This acts as a test case')
+    expect(page).to have_field('Title', with: 'First Edition Title')
     expect(page).to have_field('Body', with: '## First Edition Title')
   end
 

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -311,6 +311,9 @@ private
     def put_content(*args)
     end
 
+    def put_links(*args)
+    end
+
     def publish(*args)
     end
   end

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
         click_link "Edit"
       end
       the_form_should_be_prepopulated_with_title "Standups"
-      fill_in "Guide title", with: "Standup meetings"
+      fill_in "Title", with: "Standup meetings"
       fill_in "Why the change is being made", with: "Be more specific in the title"
       click_first_button 'Save'
 
@@ -67,7 +67,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
 
     guide.latest_edition.update_attributes(state: 'published') # someone else publishes it
 
-    fill_in "Guide title", with: "Agile"
+    fill_in "Title", with: "Agile"
 
     click_first_button 'Save'
 
@@ -86,7 +86,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       expect(fake_publishing_api).to receive(:put_content).and_raise api_error
 
       visit edit_guide_path(guide)
-      fill_in "Guide title", with: "Updated Title"
+      fill_in "Title", with: "Updated Title"
       fill_in "Why the change is being made", with: "Update Title"
       click_first_button 'Save'
 
@@ -137,7 +137,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     within_guide_index_row('Agile methodologies') do
       click_link "Edit"
     end
-    fill_in "Guide title", with: "Agile"
+    fill_in "Title", with: "Agile"
     click_first_button 'Save'
     expect(current_path).to eq edit_guide_path guide
 
@@ -149,7 +149,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     stub_user.update_attribute :name, "John Smith"
     guide = given_a_guide_exists title: 'Agile methodologies', state: 'draft'
     visit edit_guide_path(guide)
-    fill_in "Guide title", with: "An amended title"
+    fill_in "Title", with: "An amended title"
     click_first_button 'Save'
     visit guides_path
     within_guide_index_row('An amended title') do
@@ -162,7 +162,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
   it "should save a draft locally, sent it to Publishing API, then redirect to the front end when previewing" do
     guide = given_a_guide_exists state: 'draft', title: 'Test guide', slug: '/service-manual/preview-test'
     visit edit_guide_path(guide)
-    fill_in "Guide title", with: "Changed Title"
+    fill_in "Title", with: "Changed Title"
 
     expect(fake_publishing_api).to receive(:put_content)
 
@@ -244,7 +244,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     it "shows exact changes in any fields" do
       guide = given_a_published_guide_exists(title: "First Edition", body: "### Hello")
       visit edit_guide_path(guide)
-      fill_in "Guide title", with: "Second Edition"
+      fill_in "Title", with: "Second Edition"
       fill_in "Body", with: "## Hi"
       fill_in "Why the change is being made", with: "Better greeting"
       click_first_button 'Save'
@@ -296,7 +296,7 @@ private
   end
 
   def the_form_should_be_prepopulated_with_title(title)
-    expect(find_field('Guide title').value).to eq title
+    expect(find_field('Title').value).to eq title
   end
 
   def expect_external_redirect_to(external_url)

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -17,7 +17,9 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       guide = given_a_published_guide_exists title: "Standups"
 
       visit guides_path
-      click_link "Edit"
+      within_guide_index_row('Standups') do
+        click_link "Edit"
+      end
       the_form_should_be_prepopulated_with_title "Standups"
       fill_in "Guide title", with: "Standup meetings"
       fill_in "Why the change is being made", with: "Be more specific in the title"
@@ -33,19 +35,23 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       given_a_published_guide_exists title: "Standups"
       visit guides_path
 
-      click_link "Edit"
+      within_guide_index_row('Standups') do
+        click_link "Edit"
+      end
       expect(find_field("Why the change is being made").value).to be_blank
 
       expect(find_field("Major update")).to be_checked
     end
 
     it "indexes documents for search" do
-      given_a_guide_exists
+      given_a_guide_exists(title: 'My Article')
       indexer = double(:indexer)
       expect(SearchIndexer).to receive(:new).with(Guide.first).and_return(indexer)
       expect(indexer).to receive(:index)
       visit guides_path
-      click_link "Edit"
+      within_guide_index_row('My Article') do
+        click_link "Edit"
+      end
       click_first_button "Send for review"
       click_first_button "Approve for publication"
       click_first_button "Publish"
@@ -55,7 +61,9 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
   it "creates a new draft version if the original has been published in the meantime" do
     guide = given_a_guide_exists title: "Agile development"
     visit guides_path
-    click_link "Edit"
+    within_guide_index_row('Agile development') do
+      click_link "Edit"
+    end
 
     guide.latest_edition.update_attributes(state: 'published') # someone else publishes it
 
@@ -73,9 +81,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     end
 
     it "keeps the changes made in form fields" do
-      guide = given_a_published_guide_exists
-      expect(Guide.count).to eq 1
-      expect(Edition.count).to eq 1
+      guide = given_a_published_guide_exists title: 'My Guide'
 
       expect(fake_publishing_api).to receive(:put_content).and_raise api_error
 
@@ -86,18 +92,19 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
 
       the_form_should_be_prepopulated_with_title "Updated Title"
 
-      expect(Guide.count).to eq 1
-      expect(Edition.published.count).to eq 1
-      expect(Edition.draft.count).to eq 1
+      expect(guide.editions.published.count).to eq 1
+      expect(guide.editions.draft.count).to eq 1
     end
 
     it "shows api errors in the UI" do
-      given_a_published_guide_exists
+      given_a_published_guide_exists(title: 'My Article')
 
       expect(fake_publishing_api).to receive(:put_content).and_raise api_error
 
       visit guides_path
-      click_link "Edit"
+      within_guide_index_row('My Article') do
+        click_link "Edit"
+      end
       fill_in "Why the change is being made", with: "Fix a typo"
       click_first_button 'Save'
 
@@ -127,7 +134,9 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
   it "should not create a new edition if the latest edition isn't published" do
     guide = given_a_guide_exists state: 'draft', title: "Agile methodologies"
     visit guides_path
-    click_link "Edit"
+    within_guide_index_row('Agile methodologies') do
+      click_link "Edit"
+    end
     fill_in "Guide title", with: "Agile"
     click_first_button 'Save'
     expect(current_path).to eq edit_guide_path guide
@@ -138,13 +147,15 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
 
   it "should record who's the last editor" do
     stub_user.update_attribute :name, "John Smith"
-    guide = given_a_guide_exists state: 'draft'
+    guide = given_a_guide_exists title: 'Agile methodologies', state: 'draft'
     visit edit_guide_path(guide)
     fill_in "Guide title", with: "An amended title"
     click_first_button 'Save'
     visit guides_path
-    within ".last-edited-by" do
-      expect(page).to have_content "John Smith"
+    within_guide_index_row('An amended title') do
+      within ".last-edited-by" do
+        expect(page).to have_content "John Smith"
+      end
     end
   end
 
@@ -188,8 +199,10 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
         expect(page).to have_content "Changes approved by Keanu Reviews"
 
         visit root_path
-        within ".label" do
-          expect(page).to have_content "Approved"
+        within_guide_index_row('Standups') do
+          within ".label" do
+            expect(page).to have_content "Approved"
+          end
         end
       end
     end

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -81,11 +81,11 @@ RSpec.describe "creating guides", type: :feature do
                             .with(an_instance_of(String), 'minor')
 
     click_first_button "Save"
-    guide = Guide.first
+    guide = Guide.joins(:editions).merge(Edition.where(title: 'First Edition Title')).first
     visit edit_guide_path(guide)
     click_first_button "Send for review"
 
-    Edition.first.tap do |edition|
+    guide.editions.first.tap do |edition|
       # set editor to another user so we can approve this edition
       edition.user = User.create!(name: "Editor", email: "email@example.org")
       edition.save!

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -35,6 +35,9 @@ RSpec.describe "creating guides", type: :feature do
     expect(api_double).to receive(:put_content)
                             .twice
                             .with(an_instance_of(String), be_valid_against_schema('service_manual_guide'))
+    expect(api_double).to receive(:put_links)
+                            .twice
+                            .with(an_instance_of(String), an_instance_of(Hash))
 
     click_first_button "Save"
 
@@ -76,6 +79,9 @@ RSpec.describe "creating guides", type: :feature do
     expect(api_double).to receive(:put_content)
                             .once
                             .with(an_instance_of(String), be_valid_against_schema('service_manual_guide'))
+    expect(api_double).to receive(:put_links)
+                            .once
+                            .with(an_instance_of(String), an_instance_of(Hash))
     expect(api_double).to receive(:publish)
                             .once
                             .with(an_instance_of(String), 'minor')

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -46,8 +46,7 @@ RSpec.describe "creating guides", type: :feature do
     edition = guide.latest_edition
     content_id = guide.content_id
     expect(content_id).to be_present
-    expect(edition.content_owner.title).to eq "Design Community"
-    expect(edition.content_owner.href).to eq "http://sm-11.herokuapp.com/designing-services/design-community/"
+    expect(edition.content_owner.title).to eq "Technology Community"
     expect(edition.title).to eq "First Edition Title"
     expect(edition.body).to eq "## First Edition Title"
     expect(edition.update_type).to eq "minor"

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe "creating guides", type: :feature do
   let(:api_double) { double(:publishing_api) }
 
   before do
-    ContentOwner.first_or_initialize(
-      title: "Design Community",
-      href:  "http://sm-11.herokuapp.com/designing-services/design-community/"
-    ).save!
+    Generators.valid_guide_community(
+      latest_edition: Generators.valid_edition(content_owner: nil, title: 'Technology Community')
+      ).tap(&:save!)
+
     visit root_path
     click_link "Create a Guide"
 
@@ -289,7 +289,7 @@ private
 
   def fill_in_guide_form
     fill_in "Slug", with: "/service-manual/the/path"
-    select "Design Community", from: "Published by"
+    select "Technology Community", from: "Published by"
     fill_in "Guide description", with: "This guide acts as a test case"
 
     fill_in "Guide title", with: "First Edition Title"

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "creating guides", type: :feature do
     expect(edition.published?).to eq false
 
     visit edit_guide_path(guide)
-    fill_in "Guide title", with: "Second Edition Title"
+    fill_in "Title", with: "Second Edition Title"
     click_first_button "Save"
 
     within ".alert" do
@@ -184,7 +184,7 @@ RSpec.describe "creating guides", type: :feature do
     it "shows the summary of validation errors" do
       guide = Guide.create!(slug: "/service-manual/something", latest_edition: Generators.valid_edition)
       visit edit_guide_path(guide)
-      fill_in "Guide title", with: ""
+      fill_in "Title", with: ""
       click_first_button "Save"
 
       within(".full-error-list") do
@@ -276,7 +276,7 @@ RSpec.describe "creating guides", type: :feature do
       }.each do |title, expected_slug|
         expected_slug = "/service-manual/#{expected_slug}"
 
-        fill_in "Guide title", with: title
+        fill_in "Title", with: title
         expect(find_field('Slug').value).to eq expected_slug
       end
     end
@@ -284,7 +284,7 @@ RSpec.describe "creating guides", type: :feature do
     context "user edits slug manually" do
       it "does not generate slug", js: true do
         fill_in "Slug", with: "/service-manual/something"
-        fill_in "Guide title", with: "My Guide Title"
+        fill_in "Title", with: "My Guide Title"
         expect(find_field('Slug').value).to eq '/service-manual/something'
       end
     end
@@ -295,9 +295,9 @@ private
   def fill_in_guide_form
     fill_in "Slug", with: "/service-manual/the/path"
     select "Technology Community", from: "Published by"
-    fill_in "Guide description", with: "This guide acts as a test case"
+    fill_in "Description", with: "This guide acts as a test case"
 
-    fill_in "Guide title", with: "First Edition Title"
+    fill_in "Title", with: "First Edition Title"
     fill_in "Body", with: "## First Edition Title"
   end
 end

--- a/spec/features/topic_spec.rb
+++ b/spec/features/topic_spec.rb
@@ -5,8 +5,6 @@ require 'gds_api/publishing_api_v2'
 RSpec.describe "topic editor", type: :feature do
   before do
     allow_any_instance_of(TopicPublisher).to receive(:publish_immediately)
-    ContentOwner.create!(title: "Design Community", href: "example.com/design")
-    ContentOwner.create!(title: "Agile Community", href: "example.com/agile")
   end
 
   it "can create a new topic", js: true do
@@ -21,9 +19,6 @@ RSpec.describe "topic editor", type: :feature do
     fill_in "Path", with: "/service-manual/something"
     fill_in "Title", with: "The title"
     fill_in "Description", with: "The description"
-
-    select "Agile Community", from: "Content Owner"
-    select "Design Community", from: "Content Owner"
 
     click_button "Add Heading"
     fill_in "Heading Title", with: "The heading title"
@@ -41,7 +36,6 @@ RSpec.describe "topic editor", type: :feature do
     topic = Topic.first
     expect(topic.title).to eq "The title"
     expect(topic.description).to eq "The description"
-    expect(topic.content_owners.map(&:title)).to match_array(["Design Community", "Agile Community"])
     expect(topic.tree.to_json).to eq(
       [
         {

--- a/spec/helpers/guide_helper_spec.rb
+++ b/spec/helpers/guide_helper_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe GuideHelper, '#guide_community_options_for_select', type: :helper do
+  it 'returns an array of options for a select tag in alphabetical order' do
+    design = Generators.valid_guide_community(
+      latest_edition: Generators.valid_edition(content_owner: nil, title: 'Design Community')).tap(&:save!)
+    agile  = Generators.valid_guide_community(
+      latest_edition: Generators.valid_edition(content_owner: nil, title: 'Agile Community')).tap(&:save!)
+    tech   = Generators.valid_guide_community(
+      latest_edition: Generators.valid_edition(content_owner: nil, title: 'Tech Community')).tap(&:save!)
+
+    expect(helper.guide_community_options_for_select).to eq(
+      [
+        ['Agile Community',  agile.id],
+        ['Design Community', design.id],
+        ['Tech Community',   tech.id]
+      ]
+      )
+  end
+end

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -190,6 +190,8 @@ RSpec.describe Edition, type: :model do
       it "returns false if it's not the latest edition of a guide" do
         edition.state = "approved"
         guide.editions << edition.dup
+
+        edition.guide.reload
         expect(edition.can_be_published?).to be false
       end
 

--- a/spec/models/publisher_spec.rb
+++ b/spec/models/publisher_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Publisher, '#save_draft' do
         Publisher.new(content_model: guide, publishing_api: publishing_api_which_always_fails).
                   save_draft(GuidePresenter.new(guide, guide.latest_edition))
 
-      expect(guide).to be_new_record
+      expect(Guide.find_by_id(guide.id)).to eq(nil)
       expect(publication_response).to_not be_success
     end
 

--- a/spec/models/publisher_spec.rb
+++ b/spec/models/publisher_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe Publisher, '#save_draft' do
 
   it 'persists the content model and returns a successful response' do
     guide = Generators.valid_guide(latest_edition: Generators.valid_edition)
-    publishing_api = FakePublishingApi.new
+    publishing_api = double(:publishing_api)
+    allow(publishing_api).to receive(:put_content)
+    allow(publishing_api).to receive(:put_links)
 
     publication_response =
       Publisher.new(content_model: guide, publishing_api: publishing_api)
@@ -14,18 +16,15 @@ RSpec.describe Publisher, '#save_draft' do
     expect(publication_response).to be_success
   end
 
-  class FakePublishingApi
-    def put_content(content_id, data)
-    end
-  end
-
-  it 'sends the draft to the publishing api' do
+  it 'sends the draft and the links to the publishing api' do
     guide = Generators.valid_guide(latest_edition: Generators.valid_edition)
     guide.save!
     publishing_api = double(:publishing_api)
 
     expect(publishing_api).to receive(:put_content).
                               with(guide.content_id, a_hash_including(content_id: guide.content_id))
+    expect(publishing_api).to receive(:put_links).
+                              with(guide.content_id, a_kind_of(Hash))
 
     Publisher.new(content_model: guide, publishing_api: publishing_api).
               save_draft(GuidePresenter.new(guide, guide.latest_edition))

--- a/spec/models/topic_publisher_spec.rb
+++ b/spec/models/topic_publisher_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe TopicPublisher do
     it "puts links for the topic" do
       publisher = described_class.new(Topic.new(content_id: "content-id-hello"))
 
-      expect_any_instance_of(TopicPresenter).to receive(:links).and_return(links: { linked_items: [] })
+      expect_any_instance_of(TopicPresenter).to receive(:links_payload).and_return(links: { linked_items: [] })
 
       expect_any_instance_of(GdsApi::PublishingApiV2).to receive(:put_links).with("content-id-hello", links: { linked_items: [] }).and_return(true)
 
@@ -53,7 +53,7 @@ RSpec.describe TopicPublisher do
       allow_any_instance_of(GdsApi::PublishingApiV2).to receive(:put_links)
 
       publisher = described_class.new(Topic.new(content_id: "topic-content-id"))
-      expect_any_instance_of(TopicPresenter).to receive(:links).and_return(links: { linked_items: ['guide-1-content-id', 'guide-1-content-id'] })
+      expect_any_instance_of(TopicPresenter).to receive(:links_payload).and_return(links: { linked_items: ['guide-1-content-id', 'guide-1-content-id'] })
       expect(GuideTaggerJob).to receive(:perform_later).twice
 
       publisher.put_links

--- a/spec/models/topic_publisher_spec.rb
+++ b/spec/models/topic_publisher_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe TopicPublisher do
       it "sends draft payload to publishing API" do
         publisher = described_class.new(Topic.new(content_id: "content-id-hello"))
 
-        expect_any_instance_of(TopicPresenter).to receive(:exportable_attributes).and_return(nice: 'payload')
+        expect_any_instance_of(TopicPresenter).to receive(:content_payload).and_return(nice: 'payload')
 
         expect_any_instance_of(GdsApi::PublishingApiV2).to receive(:put_content).with("content-id-hello", { nice: 'payload' }).and_return(true)
 

--- a/spec/presenters/guide_presenter_spec.rb
+++ b/spec/presenters/guide_presenter_spec.rb
@@ -23,13 +23,13 @@ RSpec.describe GuidePresenter do
 
   let(:presenter) { described_class.new(guide, edition) }
 
-  describe "#exportable_attributes" do
+  describe "#content_payload" do
     it "conforms to the schema" do
-      expect(presenter.exportable_attributes).to be_valid_against_schema('service_manual_guide')
+      expect(presenter.content_payload).to be_valid_against_schema('service_manual_guide')
     end
 
     it "exports all necessary metadata" do
-      expect(presenter.exportable_attributes).to include(
+      expect(presenter.content_payload).to include(
         content_id: "220169e2-ae6f-44f5-8459-5a79e0a78537",
         description: "Description",
         update_type: "major",
@@ -45,7 +45,7 @@ RSpec.describe GuidePresenter do
     it "includes related_discusion when it's provided" do
       edition.related_discussion_title = 'Discussion Forum'
       edition.related_discussion_href = 'http://someforum.gov.uk'
-      expect(presenter.exportable_attributes[:details][:related_discussion]).to eq(
+      expect(presenter.content_payload[:details][:related_discussion]).to eq(
         title: "Discussion Forum",
         href: "http://someforum.gov.uk"
       )
@@ -54,18 +54,18 @@ RSpec.describe GuidePresenter do
     it "omits related_discusion when it's not provided" do
       edition.related_discussion_title = ''
       edition.related_discussion_href = ''
-      expect(presenter.exportable_attributes[:details][:related_discussion]).to be_blank
+      expect(presenter.content_payload[:details][:related_discussion]).to be_blank
     end
 
     it "omits the content owner if the edition doesn't have one" do
       edition.content_owner = nil
 
-      expect(presenter.exportable_attributes[:details][:content_owner]).to be_blank
+      expect(presenter.content_payload[:details][:content_owner]).to be_blank
     end
 
     it "includes h2 links for the sidebar" do
       edition.body = "## Header 1 \n\n### Subheader \n\n## Header 2\n\ntext"
-      expect(presenter.exportable_attributes[:details][:header_links]).to match_array([
+      expect(presenter.content_payload[:details][:header_links]).to match_array([
         { title: "Header 1", href: "#header-1" },
         { title: "Header 2", href: "#header-2" }
       ])
@@ -73,12 +73,12 @@ RSpec.describe GuidePresenter do
 
     it "renders body to HTML" do
       edition.body = "__look at me__"
-      expect(presenter.exportable_attributes[:details][:body]).to include("<strong>look at me</strong>")
+      expect(presenter.content_payload[:details][:body]).to include("<strong>look at me</strong>")
     end
 
     it "exports the title" do
       edition.title = "Agile Process"
-      expect(presenter.exportable_attributes[:title]).to eq("Agile Process")
+      expect(presenter.content_payload[:title]).to eq("Agile Process")
     end
   end
 

--- a/spec/presenters/guide_presenter_spec.rb
+++ b/spec/presenters/guide_presenter_spec.rb
@@ -58,6 +58,12 @@ RSpec.describe GuidePresenter do
       expect(presenter.exportable_attributes[:details][:related_discussion]).to be_blank
     end
 
+    it "omits the content owner if the edition doesn't have one" do
+      edition.content_owner = nil
+
+      expect(presenter.exportable_attributes[:details][:content_owner]).to be_blank
+    end
+
     it "includes h2 links for the sidebar" do
       edition.body = "## Header 1 \n\n### Subheader \n\n## Header 2\n\ntext"
       expect(presenter.exportable_attributes[:details][:header_links]).to match_array([

--- a/spec/presenters/guide_presenter_spec.rb
+++ b/spec/presenters/guide_presenter_spec.rb
@@ -81,4 +81,22 @@ RSpec.describe GuidePresenter do
       expect(presenter.exportable_attributes[:title]).to eq("Agile Process")
     end
   end
+
+  describe '#links_payload' do
+    it 'returns an empty hash without a content owner' do
+      expect(presenter.links_payload).to eq({links: {}})
+    end
+
+    it 'returns the content owner if present' do
+      edition.content_owner = Generators.valid_guide_community(
+        latest_edition: Generators.valid_edition(content_owner: nil, title: 'Technology Community')
+        ).tap(&:save!)
+
+      expect(presenter.links_payload).to eq({
+        links: {
+          content_owners: [edition.content_owner.content_id]
+        }
+      })
+    end
+  end
 end

--- a/spec/presenters/guide_presenter_spec.rb
+++ b/spec/presenters/guide_presenter_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe GuidePresenter do
       description:         "Description",
       update_type:         "major",
       body:                "# Heading",
-      content_owner:       ContentOwner.new(title: "Publisher Name", href: "http://gov.uk"),
       updated_at:          Time.now
     )
   end

--- a/spec/presenters/search_header_presenter_spec.rb
+++ b/spec/presenters/search_header_presenter_spec.rb
@@ -44,7 +44,10 @@ RSpec.describe SearchHeaderPresenter do
     end
 
     it "appends the selected content owner" do
-      agile_community = ContentOwner.create!(title: "Agile Community", href: 'example.com')
+      agile_community = Generators.valid_guide_community(
+        latest_edition: Generators.valid_edition(content_owner: nil, title: 'Agile Community')
+        ).tap(&:save!)
+
       header = described_class.new({ content_owner: agile_community.id }, User.new).to_s
       expect(header).to end_with "published by Agile Community"
     end

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -54,9 +54,9 @@ RSpec.describe TopicPresenter do
     end
   end
 
-  describe "#links" do
+  describe "#links_payload" do
     it "references all content_ids that appear in groups" do
-      linked_items = presented_topic.links[:links][:linked_items]
+      linked_items = presented_topic.links_payload[:links][:linked_items]
       [edition_1, edition_2, edition_3].each do |edition|
         expect(edition.guide.content_id).to be_in(linked_items)
       end

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -20,11 +20,7 @@ RSpec.describe TopicPresenter do
           guides: [edition_3.guide.to_param],
           description: "Berries",
         }
-      ].to_json,
-      content_owners: [
-        ContentOwner.new(title: "Content Owner 1", href: "/service-manual/content-owner-1"),
-        ContentOwner.new(title: "Content Owner 2", href: "/service-manual/content-owner-2"),
-      ]
+      ].to_json
     )
   end
 
@@ -64,17 +60,6 @@ RSpec.describe TopicPresenter do
       [edition_1, edition_2, edition_3].each do |edition|
         expect(edition.guide.content_id).to be_in(linked_items)
       end
-    end
-
-    it "references all content owners" do
-      expected = 1.upto(2).map do |i|
-       {
-         "title"     => "Content Owner #{i}",
-         "base_path" => "/service-manual/content-owner-#{i}"
-       }
-      end
-      content_owners = presented_topic.links[:links][:content_owners]
-      expect(content_owners).to eq expected
     end
   end
 end

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -26,13 +26,13 @@ RSpec.describe TopicPresenter do
 
   let(:presented_topic) { described_class.new(topic) }
 
-  describe "#exportable_attributes" do
+  describe "#content_payload" do
     it "conforms to the schema" do
-      expect(presented_topic.exportable_attributes).to be_valid_against_schema('service_manual_topic')
+      expect(presented_topic.content_payload).to be_valid_against_schema('service_manual_topic')
     end
 
     it "exports all necessary metadata" do
-      expect(presented_topic.exportable_attributes).to include(
+      expect(presented_topic.content_payload).to include(
         description: "Topic description",
         update_type: "minor",
         phase: "beta",
@@ -45,7 +45,7 @@ RSpec.describe TopicPresenter do
     end
 
     it "transforms nested guides into the groups format" do
-      groups = presented_topic.exportable_attributes[:details][:groups]
+      groups = presented_topic.content_payload[:details][:groups]
       expect(groups.size).to eq 2
       expect(groups.first).to include(name: "Group 1", description: "Fruits")
       expect(groups.first[:contents]).to eq [edition_1.guide.slug, edition_2.guide.slug]

--- a/spec/support/capybara_helpers.rb
+++ b/spec/support/capybara_helpers.rb
@@ -2,6 +2,10 @@ module CapybaraHelpers
   def click_first_button(value)
     click_button value, match: :first
   end
+
+  def within_guide_index_row(name, &block)
+    within(:xpath, %{//a[.="#{name}"]/ancestor::tr}, &block)
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/support/generators.rb
+++ b/spec/support/generators.rb
@@ -1,8 +1,7 @@
 class Generators
   def self.valid_edition(attributes = {})
-    default_content_owner = ContentOwner.first || ContentOwner.create(title: "content owner title", href: "content_owner_href")
+    default_content_owner = GuideCommunity.first || ContentOwner.create(title: "content owner title", href: "content_owner_href")
     content_owner = attributes.fetch(:content_owner, default_content_owner)
-
 
     attributes = {
       title:          "The Title",
@@ -37,6 +36,11 @@ class Generators
   def self.valid_guide(attributes = {})
     default_attributes = { slug: "/service-manual/test-guide#{SecureRandom.hex}" }
     Guide.new(default_attributes.merge(attributes))
+  end
+
+  def self.valid_guide_community(attributes = {})
+    default_attributes = { slug: "/service-manual/test-guide#{SecureRandom.hex}" }
+    GuideCommunity.new(default_attributes.merge(attributes))
   end
 
   def self.valid_user(attributes = {})

--- a/spec/support/generators.rb
+++ b/spec/support/generators.rb
@@ -1,7 +1,13 @@
 class Generators
   def self.valid_edition(attributes = {})
-    default_content_owner = GuideCommunity.first || ContentOwner.create(title: "content owner title", href: "content_owner_href")
-    content_owner = attributes.fetch(:content_owner, default_content_owner)
+    if attributes.has_key?(:content_owner)
+      content_owner = attributes.fetch(:content_owner)
+    else
+      content_owner = GuideCommunity.first ||
+                      Generators.valid_guide_community(
+                        latest_edition: valid_edition(content_owner: nil)
+                        )
+    end
 
     attributes = {
       title:          "The Title",

--- a/spec/support/generators.rb
+++ b/spec/support/generators.rb
@@ -1,6 +1,8 @@
 class Generators
   def self.valid_edition(attributes = {})
-    content_owner = ContentOwner.first || ContentOwner.create(title: "content owner title", href: "content_owner_href")
+    default_content_owner = ContentOwner.first || ContentOwner.create(title: "content owner title", href: "content_owner_href")
+    content_owner = attributes.fetch(:content_owner, default_content_owner)
+
 
     attributes = {
       title:          "The Title",


### PR DESCRIPTION
A guide's community was represented by a ContentOwner was a hardcoded thing. We only had two ContentOwners to choose from.

Here we change the way we reference the guide's community. Because the a guide and a guide community are so similar we introduce an STI to give use Guide and GuideCommunity where a Guide has a (self referential relation) to GuideCommunity.

This is a reincarnation of https://github.com/alphagov/service-manual-publisher/pull/146 where there is a little discussion. A fair few of the commits are the same.