### PR TITLE
Test against V2 of the publishing API

### DIFF
--- a/app/models/slug_migration_publisher.rb
+++ b/app/models/slug_migration_publisher.rb
@@ -3,10 +3,9 @@ require "gds_api/publishing_api_v2"
 class SlugMigrationPublisher
   def process(slug_migration)
     data = {
-      content_id: slug_migration.content_id,
       format: "redirect",
-      publishing_app: "service-manual-publisher",
       base_path: slug_migration.slug,
+      publishing_app: "service-manual-publisher",
       redirects: [
         {
           path: slug_migration.slug,

--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -8,7 +8,6 @@ class GuidePresenter
 
   def content_payload
     {
-      content_id: guide.content_id,
       publishing_app: "service-manual-publisher",
       rendering_app: "government-frontend",
       format: "service_manual_guide",

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -5,7 +5,6 @@ class TopicPresenter
 
   def content_payload
     {
-      content_id: topic.content_id,
       publishing_app: "service-manual-publisher",
       rendering_app: "government-frontend",
       format: "service_manual_topic",

--- a/spec/models/publisher_spec.rb
+++ b/spec/models/publisher_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Publisher, '#save_draft' do
     publishing_api = double(:publishing_api)
 
     expect(publishing_api).to receive(:put_content).
-                              with(guide.content_id, a_hash_including(content_id: guide.content_id))
+                              with(guide.content_id, a_hash_including(base_path: guide.slug))
     expect(publishing_api).to receive(:put_links).
                               with(guide.content_id, a_kind_of(Hash))
 

--- a/spec/models/slug_migration_publisher_spec.rb
+++ b/spec/models/slug_migration_publisher_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe SlugMigrationPublisher, type: :model do
     )
 
     expected_redirect = {
-      content_id: slug_migration.content_id,
       format: "redirect",
       publishing_app: "service-manual-publisher",
       base_path: slug_migration.slug,
@@ -27,7 +26,7 @@ RSpec.describe SlugMigrationPublisher, type: :model do
     api_double = double(:publishing_api)
     expect(GdsApi::PublishingApiV2).to receive(:new).and_return(api_double)
     expect(api_double).to receive(:put_content)
-      .with(an_instance_of(String), expected_redirect)
+      .with(slug_migration.content_id, expected_redirect)
     expect(api_double).to receive(:publish)
       .once.with(slug_migration.content_id, 'minor')
 

--- a/spec/presenters/guide_presenter_spec.rb
+++ b/spec/presenters/guide_presenter_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe GuidePresenter do
 
     it "exports all necessary metadata" do
       expect(presenter.content_payload).to include(
-        content_id: "220169e2-ae6f-44f5-8459-5a79e0a78537",
         description: "Description",
         update_type: "major",
         phase: "beta",

--- a/spec/support/govuk_content_schemas.rb
+++ b/spec/support/govuk_content_schemas.rb
@@ -4,6 +4,6 @@ require 'govuk-content-schema-test-helpers/rspec_matchers'
 RSpec.configuration.include GovukContentSchemaTestHelpers::RSpecMatchers
 
 GovukContentSchemaTestHelpers.configure do |config|
-  config.schema_type = 'publisher'
+  config.schema_type = 'publisher_v2'
   config.project_root = Rails.root
 end


### PR DESCRIPTION
Our tests were configured to validate that we are sending correct
payloads for the V1 of the publishing-api, when in reality we were using
V2 of the publishing API.