### PR TITLE
Switch to "major" for "update_type" when creating redirects.

### DIFF
--- a/app/models/slug_migration_publisher.rb
+++ b/app/models/slug_migration_publisher.rb
@@ -19,6 +19,6 @@ class SlugMigrationPublisher
       bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
     )
     publishing_api.put_content(slug_migration.content_id, data)
-    publishing_api.publish(slug_migration.content_id, "minor")
+    publishing_api.publish(slug_migration.content_id, "major")
   end
 end

--- a/spec/models/slug_migration_publisher_spec.rb
+++ b/spec/models/slug_migration_publisher_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe SlugMigrationPublisher, type: :model do
     expect(api_double).to receive(:put_content)
       .with(slug_migration.content_id, expected_redirect)
     expect(api_double).to receive(:publish)
-      .once.with(slug_migration.content_id, 'minor')
+      .once.with(slug_migration.content_id, 'major')
 
     SlugMigrationPublisher.new.process(slug_migration)
   end
@@ -47,7 +47,7 @@ RSpec.describe SlugMigrationPublisher, type: :model do
     expect(api_double).to receive(:put_content)
       .with(an_instance_of(String), be_valid_against_schema('redirect'))
     expect(api_double).to receive(:publish)
-      .once.with(slug_migration.content_id, 'minor')
+      .once.with(slug_migration.content_id, 'major')
 
     SlugMigrationPublisher.new.process(slug_migration)
   end


### PR DESCRIPTION
Content items in publishing-api expect to have an "update_type" of "major"
when they're first created. If it's set to "minor" then publishing-api
fails to create the item, because it requires a "public_updated_at"
field for some reason. For now, this will fix slug migrations
temporarily. Later on, we can think about moving back to "minor", if
need be.