### PR TITLE
[do-not-merge] validate links when publishing guides

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'select2-rails', '~> 4.0.0'
 gem 'diffy', '~> 3.0', '>= 3.0.7'
 gem 'redcarpet', '~> 3.3.3'
 gem 'rummageable', '1.2.0'
+gem 'httparty', '~> 0.13.7'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,9 @@ GEM
     htmlentities (4.3.4)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
+    httparty (0.13.7)
+      json (~> 1.8)
+      multi_xml (>= 0.5.2)
     i18n (0.7.0)
     jasmine (2.4.0)
       jasmine-core (~> 2.4)
@@ -321,6 +324,7 @@ DEPENDENCIES
   govspeak (~> 3.4.0)
   govuk-content-schema-test-helpers (~> 1.3.0)
   govuk_admin_template (~> 3.5.0)
+  httparty (~> 0.13.7)
   jasmine
   kaminari (~> 0.16.3)
   launchy

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -48,6 +48,8 @@ class GuidesController < ApplicationController
       send_for_review
     elsif params[:approve_for_publication].present?
       approve_for_publication
+    elsif params[:publish_with_broken_links]
+      publish(true)
     elsif params[:publish].present?
       publish
     else
@@ -69,7 +71,7 @@ private
     redirect_to back_or_default, notice: "Thanks for approving this guide"
   end
 
-  def publish
+  def publish(skip_broken_link_validation=false)
     unless @guide.included_in_a_topic?
       @edition = @guide.latest_edition
       flash[:error] = "This guide could not be published because it is not included in a topic page."
@@ -78,6 +80,10 @@ private
     end
 
     @guide.latest_edition.assign_attributes(state: 'published')
+
+    if skip_broken_link_validation
+      @guide.latest_edition.skip_broken_link_validation = true
+    end
 
     publication = Publisher.new(content_model: @guide).publish
     if publication.success?

--- a/app/models/checked_url.rb
+++ b/app/models/checked_url.rb
@@ -1,0 +1,2 @@
+class CheckedUrl < ActiveRecord::Base
+end

--- a/app/models/govspeak_url_checker.rb
+++ b/app/models/govspeak_url_checker.rb
@@ -1,0 +1,31 @@
+class GovspeakUrlChecker
+  def initialize govspeak
+    @govspeak = govspeak
+  end
+
+  def find_broken_links
+    govspeak_document = Govspeak::Document.new(@govspeak)
+
+    nokogiri_document = Nokogiri::HTML::Document.new
+    nokogiri_document.encoding = "UTF-8"
+    nokogiri_fragment = nokogiri_document.fragment(govspeak_document.to_html)
+    links = nokogiri_fragment
+      .css('a:not([href^="mailto"])')
+      .css('a:not([href^="#"])')
+      .map { |link| link['href'] }
+    links.select do |link|
+      checked_url = CheckedUrl.find_or_initialize_by(url: link)
+      if checked_url.persisted? == false || checked_url.created_at < 5.minutes.ago
+        response = HTTParty.get(
+          link,
+          follow_redirects: true,
+          timeout: 5,
+        )
+        checked_url.code = response.code
+        checked_url.save!
+      end
+
+      checked_url.code != 200
+    end
+  end
+end

--- a/app/views/editions/_actions.html.erb
+++ b/app/views/editions/_actions.html.erb
@@ -25,6 +25,9 @@
 
         <% if edition.can_be_published? %>
           <%= form.submit "Publish", class: 'btn btn-success add-right-margin', name: :publish %>
+          <% if form.object.errors["latest_edition.body"].any? %>
+            <%= form.submit "Publish with broken links", class: 'btn btn-danger add-right-margin', name: :publish_with_broken_links %>
+          <% end %>
         <% end %>
       <% else %>
         <%= form.submit "Send for review", name: :send_for_review, class: 'btn btn-success', disabled: true %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,10 +4,16 @@ Rails.application.routes.draw do
 
   root 'guides#index'
 
-  resources :guides
+  resources :guides do
+    resources :drafts
+    resources :publications, only: :create
+  end
 
-  resources :editions, only: [:show]
+  resources :editions, only: [:show] do
+    resources :review_requests
+  end
 
+  resources :approvals
   resources :comments
   resources :uploads, only: [:create]
   resources :topics

--- a/db/migrate/20160301111323_create_checked_urls.rb
+++ b/db/migrate/20160301111323_create_checked_urls.rb
@@ -1,0 +1,9 @@
+class CreateCheckedUrls < ActiveRecord::Migration
+  def change
+    create_table :checked_urls do |t|
+      t.string :url, null: false
+      t.integer :code, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -78,6 +78,38 @@ ALTER SEQUENCE approvals_id_seq OWNED BY approvals.id;
 
 
 --
+-- Name: checked_urls; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE checked_urls (
+    id integer NOT NULL,
+    url character varying NOT NULL,
+    code integer NOT NULL,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
+);
+
+
+--
+-- Name: checked_urls_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE checked_urls_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: checked_urls_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE checked_urls_id_seq OWNED BY checked_urls.id;
+
+
+--
 -- Name: comments; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -316,6 +348,13 @@ ALTER TABLE ONLY approvals ALTER COLUMN id SET DEFAULT nextval('approvals_id_seq
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY checked_urls ALTER COLUMN id SET DEFAULT nextval('checked_urls_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY comments ALTER COLUMN id SET DEFAULT nextval('comments_id_seq'::regclass);
 
 
@@ -360,6 +399,14 @@ ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regcl
 
 ALTER TABLE ONLY approvals
     ADD CONSTRAINT approvals_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: checked_urls_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY checked_urls
+    ADD CONSTRAINT checked_urls_pkey PRIMARY KEY (id);
 
 
 --
@@ -558,4 +605,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160225101236');
 INSERT INTO schema_migrations (version) VALUES ('20160225113207');
 
 INSERT INTO schema_migrations (version) VALUES ('20160225130400');
+
+INSERT INTO schema_migrations (version) VALUES ('20160301111323');
 

--- a/spec/models/govspeak_url_checker_spec.rb
+++ b/spec/models/govspeak_url_checker_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+RSpec.describe GovspeakUrlChecker do
+  describe "#find_broken_links" do
+    let :success do
+      OpenStruct.new(code: 200)
+    end
+
+    let :fail do
+      OpenStruct.new(code: 500)
+    end
+
+    it "lists broken links" do
+      expect(HTTParty).to receive(:get)
+        .with("http://example.org/one", follow_redirects: true, timeout: 5)
+        .and_return success
+      expect(HTTParty).to receive(:get)
+        .with("http://example.org/two", follow_redirects: true, timeout: 5)
+        .and_return fail
+
+      govspeak = <<-GOVSPEAK
+[link 1](http://example.org/one)
+[link 2](http://example.org/two)
+      GOVSPEAK
+      broken_links = GovspeakUrlChecker.new(govspeak).find_broken_links
+      expect(broken_links).to eq ["http://example.org/two"]
+    end
+
+    it "caches already checked urls" do
+      expect(HTTParty).to receive(:get)
+        .with("http://some-url.com/url", follow_redirects: true, timeout: 5)
+        .once
+        .and_return success
+
+      govspeak = "[link](http://some-url.com/url)"
+      GovspeakUrlChecker.new(govspeak).find_broken_links
+      GovspeakUrlChecker.new(govspeak).find_broken_links
+    end
+
+    it "ignores mailto: links" do
+      expect(HTTParty).to receive(:get)
+        .with("http://example.org", follow_redirects: true, timeout: 5)
+        .and_return success
+
+      govspeak = <<-GOVSPEAK
+[link 1](http://example.org)
+[link 2](mailto:email@example.org)
+      GOVSPEAK
+      GovspeakUrlChecker.new(govspeak).find_broken_links
+    end
+
+    it "ignores anchor links" do
+      expect(HTTParty).to receive(:get)
+        .with("http://example.org", follow_redirects: true, timeout: 5)
+        .and_return success
+
+      govspeak = <<-GOVSPEAK
+[link 1](http://example.org)
+[link 2](#some-heading)
+      GOVSPEAK
+      GovspeakUrlChecker.new(govspeak).find_broken_links
+    end
+
+    it "expires cached urls after 5 minutes" do
+      CheckedUrl.create!(
+        url: "http://old-url.com",
+        code: 500,
+        created_at: 6.minutes.ago,
+      )
+      CheckedUrl.create!(
+        url: "http://new-url.com",
+        code: 500,
+        created_at: 3.minutes.ago,
+      )
+
+      expect(HTTParty).to receive(:get)
+        .with("http://old-url.com", follow_redirects: true, timeout: 5)
+        .once
+        .and_return success
+
+      govspeak = <<-GOVSPEAK
+[link 1](http://old-url.com)
+[link 2](http://new-url.com)
+      GOVSPEAK
+      GovspeakUrlChecker.new(govspeak).find_broken_links
+    end
+  end
+end


### PR DESCRIPTION
For discussion only at this point.

This is incomplete. I plan on allowing users to force publish even if link validation fails.

Quote from Elena (asked if guides should not be published if they have broken links):

```
Not for the 1st edition, otherwise we could never publish a interlinked topic at the same time.
(Our current publishing approach)
After that, sure.
Right now, we're publishing completely new guides together within a 15 min window.
So when the first one is published, it usually contains links to other guides that will be published in the next 10 min, but aren't yet.
```