### PR TITLE
Notification mailer links

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -86,7 +86,7 @@ private
       TopicPublisher.new(@guide.topic).publish_immediately
 
       unless @guide.latest_edition.notification_subscribers == [current_user]
-        NotificationMailer.published(@guide.latest_edition, current_user).deliver_later
+        NotificationMailer.published(@guide, current_user).deliver_later
       end
 
       redirect_to back_or_default, notice: "Guide has been published"

--- a/app/helpers/guide_route_helper.rb
+++ b/app/helpers/guide_route_helper.rb
@@ -1,0 +1,5 @@
+module GuideRouteHelper
+  def guide_frontend_published_url(guide)
+    "#{Plek.find('www')}#{guide.slug}"
+  end
+end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,4 +1,6 @@
 class NotificationMailer < ApplicationMailer
+  helper GuideRouteHelper
+
   def comment_added(comment)
     @comment = comment
     @edition = comment.commentable
@@ -18,8 +20,9 @@ class NotificationMailer < ApplicationMailer
     )
   end
 
-  def published(edition, user)
-    @edition = edition
+  def published(guide, user)
+    @guide = guide
+    @edition = @guide.latest_edition
     @user = user
     mail(
       to: @edition.notification_subscribers.map { |recipient| user_email(recipient) },

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -8,9 +8,10 @@ class NotificationMailer < ApplicationMailer
     )
   end
 
-  def approved_for_publishing(edition)
-    @edition = edition
-    @approval = edition.approval
+  def approved_for_publishing(guide)
+    @guide = guide
+    @edition = @guide.latest_edition
+    @approval = @edition.approval
     mail(
       to: @edition.notification_subscribers.map { |recipient| user_email(recipient) },
       subject: "\"#{@edition.title}\" approved for publishing"

--- a/app/models/approval_process.rb
+++ b/app/models/approval_process.rb
@@ -16,6 +16,6 @@ class ApprovalProcess
     edition.state = "approved"
     edition.save!
 
-    NotificationMailer.approved_for_publishing(edition).deliver_later
+    NotificationMailer.approved_for_publishing(content_model).deliver_later
   end
 end

--- a/app/views/notification_mailer/approved_for_publishing.html.erb
+++ b/app/views/notification_mailer/approved_for_publishing.html.erb
@@ -9,5 +9,5 @@
 </p>
 
 <p>
-  <%= link_to "See \"#{@edition.title}\" in Service Manual Publisher", edition_url(@edition) %>
+  <%= link_to "See \"#{@edition.title}\" in Service Manual Publisher", guide_url(@guide) %>
 </p>

--- a/app/views/notification_mailer/approved_for_publishing.text.erb
+++ b/app/views/notification_mailer/approved_for_publishing.text.erb
@@ -4,5 +4,5 @@ Hello,
 
 In order for the changes to be visible publically the guide needs to be published.
 
-See "<%= @edition.title %>" in Service Manual Publisher on <%= edition_url(@edition) %>
+See "<%= @edition.title %>" in Service Manual Publisher on <%= guide_url(@guide) %>
 

--- a/app/views/notification_mailer/published.html.erb
+++ b/app/views/notification_mailer/published.html.erb
@@ -5,5 +5,5 @@
 </p>
 
 <p>
-  <%= link_to "See \"#{@edition.title}\" in Service Manual Publisher", edition_url(@edition) %>.
+  <%= link_to "See published \"#{@edition.title}\"", guide_frontend_published_url(@guide) %>.
 </p>

--- a/app/views/notification_mailer/published.text.erb
+++ b/app/views/notification_mailer/published.text.erb
@@ -2,5 +2,5 @@ Hello,
 
 <%= @user.name %> has published "<%= @edition.title %>".
 
-See "<%= @edition.title %>" in Service Manual Publisher via <%= edition_url(@edition) %>.
+See published "<%= @edition.title %>" via <%= guide_frontend_published_url(@guide) %>.
 

--- a/spec/helpers/guide_route_helper_spec.rb
+++ b/spec/helpers/guide_route_helper_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe GuideRouteHelper, '#guide_frontend_published_url' do
+  it 'returns the URL a guide should be published at' do
+    guide = Guide.new(slug: '/service-manual/technology')
+
+    expect(
+      helper.guide_frontend_published_url(guide)
+      ).to eq("#{Plek.find('www')}/service-manual/technology")
+  end
+end
+

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe NotificationMailer, type: :mailer do
 
   describe "#published" do
     it "contains the edition title, publisher's name and a link" do
-      email = NotificationMailer.published(edition, luke).deliver_now
+      email = NotificationMailer.published(guide, luke).deliver_now
 
       expect(ActionMailer::Base.deliveries.size).to eq 1
       expect(email.to).to eq ["gary@example.com"]
@@ -61,7 +61,7 @@ RSpec.describe NotificationMailer, type: :mailer do
       email.parts.each do |part|
         expect(part.body.to_s).to include "Luke"
         expect(part.body.to_s).to include "\"Agile\""
-        expect(part.body.to_s).to include "/editions/#{edition.id}"
+        expect(part.body.to_s).to include "#{Plek.find('www')}/service-manual/agile-delivery"
       end
     end
   end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -3,11 +3,12 @@ require "rails_helper"
 RSpec.describe NotificationMailer, type: :mailer do
   let(:gary) { Generators.valid_user(name: "Gary", email: "gary@example.com") }
   let(:luke) { Generators.valid_user(name: "Luke") }
+  let(:guide) { Generators.valid_guide(slug: '/service-manual/agile-delivery', latest_edition: edition) }
   let(:edition) { Generators.valid_edition(title: "Agile", user: gary) }
 
   before do
     ActionMailer::Base.deliveries.clear
-    edition.save!
+    guide.save!
     allow_any_instance_of(Edition).to receive(:notification_subscribers).and_return([gary])
   end
 
@@ -35,7 +36,7 @@ RSpec.describe NotificationMailer, type: :mailer do
     end
 
     it "contains the edition title, approver's name and a link" do
-      email = NotificationMailer.approved_for_publishing(edition).deliver_now
+      email = NotificationMailer.approved_for_publishing(guide).deliver_now
 
       expect(ActionMailer::Base.deliveries.size).to eq 1
       expect(email.to).to eq ["gary@example.com"]
@@ -44,7 +45,7 @@ RSpec.describe NotificationMailer, type: :mailer do
       email.parts.each do |part|
         expect(part.body.to_s).to include "Luke"
         expect(part.body.to_s).to include "\"Agile\""
-        expect(part.body.to_s).to include "/editions/#{edition.id}"
+        expect(part.body.to_s).to include guide_path(guide)
       end
     end
   end


### PR DESCRIPTION
The links in the approved and published notifications were broken.

We fix the approved email to link to the guide in the publisher. We fix the published email to link to the published guide on the frontend.