### PR TITLE
Fix notification mailer links

### DIFF
--- a/app/helpers/guide_route_helper.rb
+++ b/app/helpers/guide_route_helper.rb
@@ -1,5 +1,5 @@
 module GuideRouteHelper
   def guide_frontend_published_url(guide)
-    "#{Plek.find('www')}#{guide.slug}"
+    "#{Plek.new.website_root}#{guide.slug}"
   end
 end

--- a/app/views/notification_mailer/approved_for_publishing.html.erb
+++ b/app/views/notification_mailer/approved_for_publishing.html.erb
@@ -9,5 +9,5 @@
 </p>
 
 <p>
-  <%= link_to "See \"#{@edition.title}\" in Service Manual Publisher", guide_url(@guide) %>
+  <%= link_to "See \"#{@edition.title}\" in Service Manual Publisher", edit_guide_url(@guide) %>
 </p>

--- a/app/views/notification_mailer/approved_for_publishing.text.erb
+++ b/app/views/notification_mailer/approved_for_publishing.text.erb
@@ -4,5 +4,5 @@ Hello,
 
 In order for the changes to be visible publically the guide needs to be published.
 
-See "<%= @edition.title %>" in Service Manual Publisher on <%= guide_url(@guide) %>
+See "<%= @edition.title %>" in Service Manual Publisher on <%= edit_guide_url(@guide) %>
 

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe NotificationMailer, type: :mailer do
       email.parts.each do |part|
         expect(part.body.to_s).to include "Luke"
         expect(part.body.to_s).to include "\"Agile\""
-        expect(part.body.to_s).to include guide_path(guide)
+        expect(part.body.to_s).to include edit_guide_path(guide)
       end
     end
   end


### PR DESCRIPTION
The approved for publishing link was just going to the wrong path and the published link wasn't being built correctly in integration.