### PR TITLE
Fix comments form URL for a guide community

### DIFF
--- a/app/helpers/guide_helper.rb
+++ b/app/helpers/guide_helper.rb
@@ -31,4 +31,11 @@ module GuideHelper
           sort_by{ |guide| guide.title }.
           map{ |g| [g.title, g.id] }
   end
+
+  def guide_form_for(guide, *args, &block)
+    options = args.extract_options!
+    url = url_for(guide.becomes(Guide))
+
+    form_for(guide, *args << options.merge(as: :guide, url: url), &block)
+  end
 end

--- a/app/views/editions/comments.html.erb
+++ b/app/views/editions/comments.html.erb
@@ -1,7 +1,7 @@
 <%= render 'editions/header_with_navigation', edition: @edition, guide: @guide %>
 <%= render 'editions/old_edition_alert', edition: @edition, guide: @guide %>
 
-<%= form_for @guide do |f| %>
+<%= guide_form_for @guide do |f| %>
   <%= render 'editions/actions', publish_controls_only: true, form: f, guide: @guide, edition: @edition %>
 <% end %>
 
@@ -23,6 +23,6 @@
   </div>
 <% end %>
 
-<%= form_for @guide do |f| %>
+<%= guide_form_for @guide do |f| %>
   <%= render 'editions/actions', publish_controls_only: true, form: f, guide: @guide, edition: @edition %>
 <% end %>

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for guide, as: :guide, url: url_for(guide.becomes(Guide)), html: { class: "js-protect-data" } do |f| %>
+<%= guide_form_for guide, html: { class: "js-protect-data" } do |f| %>
 
   <%= f.hidden_field :type %>
 

--- a/spec/features/comments_spec.rb
+++ b/spec/features/comments_spec.rb
@@ -2,17 +2,31 @@ require 'rails_helper'
 require 'capybara/rails'
 
 RSpec.describe "Commenting", type: :feature do
-  let!(:guide) do
-    edition = Generators.valid_edition(title: 'Lean Startup')
-    Guide.create!(
-      latest_edition: edition,
-      slug: "/service-manual/test/comment"
-    )
+  describe 'for a normal guide' do
+    it 'write a comment successfully' do
+      edition = Generators.valid_edition(title: 'Lean Startup')
+      guide = Guide.create!(
+                latest_edition: edition,
+                slug: "/service-manual/test/comment"
+              )
+
+      write_a_comment_successfully(guide: guide)
+    end
   end
 
-  it "allows discourse" do
+  describe 'for a guide community' do
+    it 'write a comment successfully' do
+      edition = Generators.valid_edition(title: 'Agile Community', content_owner: nil)
+      guide = Generators.valid_guide_community(latest_edition: edition)
+      guide.save!
+
+      write_a_comment_successfully(guide: guide)
+    end
+  end
+
+  def write_a_comment_successfully(guide:)
     visit root_path
-    within_guide_index_row('Lean Startup') do
+    within_guide_index_row(guide.latest_edition.title) do
       click_link "Edit"
     end
     click_link "Comments and history"


### PR DESCRIPTION
Because Guide is a now an STI the polymorphic URL generation is based of the model_name whereas we specifically want it to use the same route and controller.