### PR TITLE
Remove duplicate guides from the topic admin dropdown

### DIFF
--- a/app/helpers/topic_helper.rb
+++ b/app/helpers/topic_helper.rb
@@ -5,8 +5,8 @@ module TopicHelper
 
   def all_guides_container_for_select
     @_all_guides_container_for_select ||=
-      Guide.includes(:latest_edition).
-            order('editions.title').
-            pluck('editions.title', 'guides.id')
+      Guide.includes(:latest_edition).sort_by(&:title).map do |guide|
+        [guide.title, guide.id]
+      end
   end
 end

--- a/spec/helpers/topic_helper_spec.rb
+++ b/spec/helpers/topic_helper_spec.rb
@@ -15,9 +15,11 @@ RSpec.describe TopicHelper, "#all_guides_container_for_select" do
                                                    content_owner: nil,
                                                    title: 'Agile Community'))
     agile = create(:guide,
-                   latest_edition: build(:edition,
-                                         title: 'Agile',
-                                         content_owner: agile_community))
+                   latest_edition: nil,
+                   editions: [
+                     build(:edition, title: 'Agile', content_owner: agile_community, created_at: 1.week.ago),
+                     build(:edition, title: 'Agile old', content_owner: agile_community, created_at: 1.month.ago),
+                     ])
 
     expected = [
       ['Agile', agile.id],


### PR DESCRIPTION
The joined editions were causing duplicate guides. Rails's two queries generated by #includes was pretty neat in the first place. A subquery would be required to make a single database query which really isn't worth it.