### PR TITLE
Use search index mainstream with document type service_manual

### DIFF
--- a/app/models/search_indexer.rb
+++ b/app/models/search_indexer.rb
@@ -6,10 +6,10 @@ class SearchIndexer
 
   def index
     index = Rummageable::Index.new(
-      Plek.current.find('rummager'), '/service-manual'
+      Plek.current.find('rummager'), '/mainstream'
     )
     index.add_batch([{
-      "_type":             "manual_section",
+      "_type":             "service_manual",
       "description":       @edition.description,
       "indexable_content": @edition.body,
       "title":             @edition.title,

--- a/app/models/search_indexer.rb
+++ b/app/models/search_indexer.rb
@@ -9,6 +9,7 @@ class SearchIndexer
       Plek.current.find('rummager'), '/mainstream'
     )
     index.add_batch([{
+      "format":            "service_manual",
       "_type":             "service_manual",
       "description":       @edition.description,
       "indexable_content": @edition.body,

--- a/app/models/topic_search_indexer.rb
+++ b/app/models/topic_search_indexer.rb
@@ -5,6 +5,7 @@ class TopicSearchIndexer
 
   def index
     rummager_index.add_batch([{
+      "format":            "service_manual",
       "_type":             "service_manual",
       "description":       @topic.description,
       "indexable_content": @topic.title + "\n\n" + @topic.description,

--- a/app/models/topic_search_indexer.rb
+++ b/app/models/topic_search_indexer.rb
@@ -5,7 +5,7 @@ class TopicSearchIndexer
 
   def index
     rummager_index.add_batch([{
-      "_type":             "edition",
+      "_type":             "service_manual",
       "description":       @topic.description,
       "indexable_content": @topic.title + "\n\n" + @topic.description,
       "title":             @topic.title,
@@ -18,7 +18,7 @@ class TopicSearchIndexer
 
     def rummager_index
       Rummageable::Index.new(
-        Plek.current.find('rummager'), '/service-manual'
+        Plek.current.find('rummager'), '/mainstream'
       )
     end
 end

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -18,6 +18,7 @@ namespace :rummager do
       if edition.published?
         puts "Indexing #{edition.title}..."
         index_document({
+          "format": "service_manual",
           "_type": "service_manual",
           "description": edition.description,
           "indexable_content": edition.body,

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -5,7 +5,7 @@ namespace :rummager do
     require 'rummageable'
 
     root_document = {
-      format: "manual",
+      format: "service_manual",
       title: "Government Service Design Manual",
       description: "All new digital services from the government must meet the Digital by Default Service Standard",
       link: "/service-manual",
@@ -18,7 +18,7 @@ namespace :rummager do
       if edition.published?
         puts "Indexing #{edition.title}..."
         index_document({
-          "_type": "manual_section",
+          "_type": "service_manual",
           "description": edition.description,
           "indexable_content": edition.body,
           "title": edition.title,
@@ -32,7 +32,7 @@ namespace :rummager do
 
   def index_document document
     @rummageable_index ||= Rummageable::Index.new(
-      Plek.current.find('rummager'), '/service-manual'
+      Plek.current.find('rummager'), '/mainstream'
     )
     @rummageable_index.add_batch([document])
   end

--- a/spec/models/search_indexer_spec.rb
+++ b/spec/models/search_indexer_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe SearchIndexer do
   it "indexes documents in rummager" do
     index = double(:rummageable_index)
     plek = Plek.current.find('rummager')
-    expect(Rummageable::Index).to receive(:new).with(plek, "/service-manual").and_return index
+    expect(Rummageable::Index).to receive(:new).with(plek, "/mainstream").and_return index
     guide = build_stubbed(:guide, slug: "/service-manual/some-slug")
     expect(index).to receive(:add_batch).with([{
-      _type:             "manual_section",
+      _type:             "service_manual",
       description:       guide.latest_edition.description,
       indexable_content: guide.latest_edition.body,
       title:             guide.latest_edition.title,

--- a/spec/models/search_indexer_spec.rb
+++ b/spec/models/search_indexer_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe SearchIndexer do
     expect(Rummageable::Index).to receive(:new).with(plek, "/mainstream").and_return index
     guide = build_stubbed(:guide, slug: "/service-manual/some-slug")
     expect(index).to receive(:add_batch).with([{
+      format:            "service_manual",
       _type:             "service_manual",
       description:       guide.latest_edition.description,
       indexable_content: guide.latest_edition.body,

--- a/spec/models/topic_search_indexer_spec.rb
+++ b/spec/models/topic_search_indexer_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe SearchIndexer do
   it "indexes topics in rummager" do
     index = double(:rummageable_index)
     plek = Plek.current.find('rummager')
-    expect(Rummageable::Index).to receive(:new).with(plek, "/service-manual").and_return index
+    expect(Rummageable::Index).to receive(:new).with(plek, "/mainstream").and_return index
     topic = Topic.create!(
       path: "/service-manual/topic1",
       title: "The Topic Title",
       description: "The Topic Description",
     )
     expect(index).to receive(:add_batch).with([{
-      _type:             "edition",
+      _type:             "service_manual",
       description:       topic.description,
       indexable_content: topic.title + "\n\n" + topic.description,
       title:             topic.title,

--- a/spec/models/topic_search_indexer_spec.rb
+++ b/spec/models/topic_search_indexer_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe SearchIndexer do
       description: "The Topic Description",
     )
     expect(index).to receive(:add_batch).with([{
+      format:            "service_manual",
       _type:             "service_manual",
       description:       topic.description,
       indexable_content: topic.title + "\n\n" + topic.description,


### PR DESCRIPTION
So that we don't share the same index as the original service manual, which is purged upon each deploy, we are going to use the mainstream index and a specific document type so that search queries can downgrade service manual results (as per current functionality).

Here is the related PR in rummager for the new document type and the downgrading bit: https://github.com/alphagov/rummager/pull/586