### PR TITLE
Use mainstream search index

### DIFF
--- a/app/controllers/slug_migrations_controller.rb
+++ b/app/controllers/slug_migrations_controller.rb
@@ -56,11 +56,4 @@ class SlugMigrationsController < ApplicationController
   def show
     @slug_migration = SlugMigration.find(params[:id])
   end
-
-  def delete_search_index
-    @slug_migration = SlugMigration.find(params[:slug_migration_id])
-    @slug_migration.delete_search_document!
-
-    redirect_to edit_slug_migration_path(@slug_migration), notice: "Document has been removed from search"
-  end
 end

--- a/app/models/search_indexer.rb
+++ b/app/models/search_indexer.rb
@@ -6,7 +6,7 @@ class SearchIndexer
 
   def index
     index = Rummageable::Index.new(
-      Plek.current.find('rummager'), '/service-manual'
+      Plek.current.find('rummager'), '/mainstream'
     )
     index.add_batch([{
       "_type":             "manual_section",

--- a/app/models/search_indexer.rb
+++ b/app/models/search_indexer.rb
@@ -9,7 +9,8 @@ class SearchIndexer
       Plek.current.find('rummager'), '/mainstream'
     )
     index.add_batch([{
-      "_type":             "manual_section",
+      "format":            "service_manual_guide",
+      "_type":             "service_manual_guide",
       "description":       @edition.description,
       "indexable_content": @edition.body,
       "title":             @edition.title,

--- a/app/models/slug_migration.rb
+++ b/app/models/slug_migration.rb
@@ -10,20 +10,6 @@ class SlugMigration < ActiveRecord::Base
     object.content_id = SecureRandom.uuid
   end
 
-  def has_search_document?
-    @search_client ||= GdsApi::Rummager.new(Plek.current.find('rummager'), disable_cache: true)
-    begin
-      @search_client.get_content!(slug)
-    rescue GdsApi::HTTPErrorResponse => e
-      false
-    end
-  end
-
-  def delete_search_document!
-    @search_client ||= GdsApi::Rummager.new(Plek.current.find('rummager'), disable_cache: true)
-    @search_client.delete_content!(slug)
-  end
-
   private
 
     def is_not_already_completed

--- a/app/models/topic_search_indexer.rb
+++ b/app/models/topic_search_indexer.rb
@@ -18,7 +18,7 @@ class TopicSearchIndexer
 
     def rummager_index
       Rummageable::Index.new(
-        Plek.current.find('rummager'), '/service-manual'
+        Plek.current.find('rummager'), '/mainstream'
       )
     end
 end

--- a/app/models/topic_search_indexer.rb
+++ b/app/models/topic_search_indexer.rb
@@ -5,11 +5,13 @@ class TopicSearchIndexer
 
   def index
     rummager_index.add_batch([{
-      "_type":             "edition",
+      "format":            "service_manual_topic",
+      "_type":             "service_manual_topic",
       "description":       @topic.description,
       "indexable_content": @topic.title + "\n\n" + @topic.description,
       "title":             @topic.title,
       "link":              @topic.path,
+      "manual":            "service-manual",
       "organisations":     ["government-digital-service"],
     }])
   end

--- a/app/views/slug_migrations/edit.html.erb
+++ b/app/views/slug_migrations/edit.html.erb
@@ -20,16 +20,3 @@
     </div>
   <% end %>
 </div>
-
-<div class='well'>
-  <h2>Search index</h2>
-  <% if @slug_migration.has_search_document? %>
-    <%= form_tag slug_migration_delete_search_index_path(slug_migration_id: @slug_migration.id) do |f| %>
-      <%= submit_tag "Delete from search index", class: "btn btn-danger" %>
-    <% end %>
-  <% else %>
-    <p>
-      This url has nothing indexed in search
-    </p>
-  <% end %>
-</div>

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -18,7 +18,8 @@ namespace :rummager do
       if edition.published?
         puts "Indexing #{edition.title}..."
         index_document({
-          "_type": "manual_section",
+          "format": "service_manual_guide",
+          "_type": "service_manual_guide",
           "description": edition.description,
           "indexable_content": edition.body,
           "title": edition.title,

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -1,40 +1,10 @@
 namespace :rummager do
   desc "index all published documents in rummager"
   task index: :environment do
-    require 'plek'
-    require 'rummageable'
-
-    root_document = {
-      format: "manual",
-      title: "Government Service Design Manual",
-      description: "All new digital services from the government must meet the Digital by Default Service Standard",
-      link: "/service-manual",
-      organisations: "government-digital-service",
-    }
-    index_document root_document
-
     Guide.all.each do |guide|
-      edition = guide.latest_edition
-      if edition.published?
-        puts "Indexing #{edition.title}..."
-        index_document({
-          "format": "service_manual_guide",
-          "_type": "service_manual_guide",
-          "description": edition.description,
-          "indexable_content": edition.body,
-          "title": edition.title,
-          "link": guide.slug,
-          "manual": "/service-manual",
-          "organisations": [ "government-digital-service" ],
-        })
-      end
-    end
-  end
+      puts "Indexing #{guide.title}..."
 
-  def index_document document
-    @rummageable_index ||= Rummageable::Index.new(
-      Plek.current.find('rummager'), '/mainstream'
-    )
-    @rummageable_index.add_batch([document])
+      SearchIndexer.new(guide).index
+    end
   end
 end

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -32,7 +32,7 @@ namespace :rummager do
 
   def index_document document
     @rummageable_index ||= Rummageable::Index.new(
-      Plek.current.find('rummager'), '/service-manual'
+      Plek.current.find('rummager'), '/mainstream'
     )
     @rummageable_index.add_batch([document])
   end

--- a/spec/features/slug_migration_spec.rb
+++ b/spec/features/slug_migration_spec.rb
@@ -220,40 +220,4 @@ RSpec.describe "Slug migration", type: :feature do
       end
     end
   end
-
-  context "with a slug migration" do
-    before do
-      guide = create(:published_guide)
-      @slug_migration = SlugMigration.create!(
-        completed: false,
-        slug: "/service-manual/path.html",
-        redirect_to: guide.slug,
-      )
-    end
-
-    context "that has a search index" do
-      it "allows the search index to be deleted" do
-        expect(@rummager_double).to receive(:get_content!).with(@slug_migration.slug).twice.and_return(true)
-        expect(@rummager_double).to receive(:delete_content!).with(@slug_migration.slug)
-
-        visit root_path
-        click_link "Manage Migrations"
-        click_link "Manage"
-        click_button "Delete from search index"
-        expect(page).to have_content "Document has been removed from search"
-      end
-    end
-
-    context "that does not have a search index" do
-      it "does not allow the search index to be deleted" do
-        not_found_error = GdsApi::HTTPNotFound.new(404, "error", "error")
-        expect(@rummager_double).to receive(:get_content!).with(@slug_migration.slug).and_raise(not_found_error)
-
-        visit root_path
-        click_link "Manage Migrations"
-        click_link "Manage"
-        expect(page).to_not have_button "Delete from search index"
-      end
-    end
-  end
 end

--- a/spec/models/search_indexer_spec.rb
+++ b/spec/models/search_indexer_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe SearchIndexer do
     expect(Rummageable::Index).to receive(:new).with(plek, "/mainstream").and_return index
     guide = build_stubbed(:guide, slug: "/service-manual/some-slug")
     expect(index).to receive(:add_batch).with([{
-      _type:             "manual_section",
+      format:            "service_manual_guide",
+      _type:             "service_manual_guide",
       description:       guide.latest_edition.description,
       indexable_content: guide.latest_edition.body,
       title:             guide.latest_edition.title,

--- a/spec/models/search_indexer_spec.rb
+++ b/spec/models/search_indexer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SearchIndexer do
   it "indexes documents in rummager" do
     index = double(:rummageable_index)
     plek = Plek.current.find('rummager')
-    expect(Rummageable::Index).to receive(:new).with(plek, "/service-manual").and_return index
+    expect(Rummageable::Index).to receive(:new).with(plek, "/mainstream").and_return index
     guide = build_stubbed(:guide, slug: "/service-manual/some-slug")
     expect(index).to receive(:add_batch).with([{
       _type:             "manual_section",

--- a/spec/models/topic_search_indexer_spec.rb
+++ b/spec/models/topic_search_indexer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SearchIndexer do
   it "indexes topics in rummager" do
     index = double(:rummageable_index)
     plek = Plek.current.find('rummager')
-    expect(Rummageable::Index).to receive(:new).with(plek, "/service-manual").and_return index
+    expect(Rummageable::Index).to receive(:new).with(plek, "/mainstream").and_return index
     topic = Topic.create!(
       path: "/service-manual/topic1",
       title: "The Topic Title",

--- a/spec/models/topic_search_indexer_spec.rb
+++ b/spec/models/topic_search_indexer_spec.rb
@@ -11,11 +11,13 @@ RSpec.describe SearchIndexer do
       description: "The Topic Description",
     )
     expect(index).to receive(:add_batch).with([{
-      _type:             "edition",
+      format:            "service_manual_topic",
+      _type:             "service_manual_topic",
       description:       topic.description,
       indexable_content: topic.title + "\n\n" + topic.description,
       title:             topic.title,
       link:              topic.path,
+      manual:            "service-manual",
       organisations:     ["government-digital-service"]
     }])
     TopicSearchIndexer.new(topic).index


### PR DESCRIPTION
So that we don't share the same index as the original service manual, which is purged upon each deploy, we are going to use the mainstream index and a specific document type so that search queries can downgrade service manual results (as per current functionality).

Here is the related PR in rummager for the new document type and the downgrading bit: alphagov/rummager#589

This is a reincarnation of https://github.com/alphagov/service-manual-publisher/pull/190