### PR TITLE
Fix issue where Guide Communities could not be created

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -57,7 +57,7 @@ if Rails.env.development? || ENV["GOVUK_APP_DOMAIN"] == "preview.alphagov.co.uk"
       )
     GuideCommunity.create!(
       latest_edition: community_guide_edition,
-      slug: "/service-manual/design-community"
+      slug: "/service-manual/communities/design-community"
     )
   end
 

--- a/spec/features/guide_community_spec.rb
+++ b/spec/features/guide_community_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Create a guide community', type: :feature do
     expect(publishing_api).to receive(:put_content)
     expect(publishing_api).to receive(:patch_links)
 
-    fill_in 'Slug', with: '/service-manual/topic-name/design-community'
+    fill_in 'Slug', with: '/service-manual/communities/design-community'
     fill_in "Description", with: "This acts as a test case"
     fill_in "Title", with: "First Edition Title"
     fill_in "Body", with: "## First Edition Title"
@@ -24,7 +24,7 @@ RSpec.describe 'Create a guide community', type: :feature do
     # the content of the fields
     visit current_path
 
-    expect(page).to have_field('Slug', with: '/service-manual/topic-name/design-community')
+    expect(page).to have_field('Slug', with: '/service-manual/communities/design-community')
     expect(page).to have_field('Description', with: 'This acts as a test case')
     expect(page).to have_field('Title', with: 'First Edition Title')
     expect(page).to have_field('Body', with: '## First Edition Title')


### PR DESCRIPTION
Allow url paths without a topic name in them