### PR TITLE
Add require for addressable in url checker

### DIFF
--- a/app/models/govspeak_url_checker.rb
+++ b/app/models/govspeak_url_checker.rb
@@ -1,3 +1,5 @@
+require "addressable/uri"
+
 class GovspeakUrlChecker
   def initialize govspeak
     @govspeak = govspeak


### PR DESCRIPTION
It appears to not be loading properly in production, so attempt to
require it manually.

http://stackoverflow.com/questions/12497138/addressable-gem-is-not-found