### PR TITLE
Republish all content

### DIFF
--- a/app/models/guide_republisher.rb
+++ b/app/models/guide_republisher.rb
@@ -1,0 +1,17 @@
+class GuideRepublisher
+  def initialize(guides, publishing_api: PUBLISHING_API)
+    @guides = guides
+    @publishing_api = publishing_api
+  end
+
+  def republish
+    guides.each do |guide|
+      publisher = Publisher.new(content_model: guide, publishing_api: publishing_api)
+      publisher.save_draft(GuidePresenter.new(guide, guide.latest_edition))
+      publisher.publish
+    end
+  end
+
+private
+  attr_reader :guides, :publishing_api
+end

--- a/app/models/guide_republisher.rb
+++ b/app/models/guide_republisher.rb
@@ -1,11 +1,14 @@
 class GuideRepublisher
-  def initialize(guides, publishing_api: PUBLISHING_API)
+  def initialize(guides, publishing_api: PUBLISHING_API, logger: Rails.logger)
     @guides = guides
     @publishing_api = publishing_api
+    @logger = logger
   end
 
   def republish
     guides.each do |guide|
+      log("Republishing: #{guide.title}")
+
       publisher = Publisher.new(content_model: guide, publishing_api: publishing_api)
       publisher.save_draft(GuidePresenter.new(guide, guide.latest_edition))
       publisher.publish
@@ -14,4 +17,8 @@ class GuideRepublisher
 
 private
   attr_reader :guides, :publishing_api
+
+  def log(str)
+    @logger << str + "\n"
+  end
 end

--- a/lib/tasks/republish_all_guides.rake
+++ b/lib/tasks/republish_all_guides.rake
@@ -1,5 +1,5 @@
 desc "Republish all guides"
 task republish_all_guides: :environment do
-  GuideRepublisher.new(Guide.with_published_editions).
+  GuideRepublisher.new(Guide.with_published_editions, logger: $stdout).
                    republish
 end

--- a/lib/tasks/republish_all_guides.rake
+++ b/lib/tasks/republish_all_guides.rake
@@ -1,0 +1,5 @@
+desc "Republish all guides"
+task republish_all_guides: :environment do
+  GuideRepublisher.new(Guide.with_published_editions).
+                   republish
+end

--- a/spec/models/guide_republisher_spec.rb
+++ b/spec/models/guide_republisher_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe GuideRepublisher, '#republish' do
+  it 'republishes all guides' do
+    publishing_api = double(:publishing_api)
+    guide1 = create(:guide)
+    guide2 = create(:guide)
+
+    expect_guide_to_be_republished(guide1, publishing_api)
+    expect_guide_to_be_republished(guide2, publishing_api)
+
+    republisher = described_class.new([guide1, guide2], publishing_api: publishing_api)
+    republisher.republish
+  end
+
+  def expect_guide_to_be_republished(guide, publishing_api)
+    expect(publishing_api).to receive(:put_content).
+                              with(guide.content_id, a_hash_including(base_path: guide.slug))
+    expect(publishing_api).to receive(:patch_links).
+                              with(guide.content_id, a_kind_of(Hash))
+    expect(publishing_api).to receive(:publish).
+                              with(guide.content_id, guide.latest_edition.update_type)
+  end
+end

--- a/spec/models/guide_republisher_spec.rb
+++ b/spec/models/guide_republisher_spec.rb
@@ -13,6 +13,19 @@ RSpec.describe GuideRepublisher, '#republish' do
     republisher.republish
   end
 
+  it 'writes to the supplied logger' do
+    log = Tempfile.new('simulated-log')
+    publishing_api = double(:publishing_api)
+    guide1 = create(:guide)
+
+    expect_guide_to_be_republished(guide1, publishing_api)
+
+    republisher = described_class.new([guide1], publishing_api: publishing_api, logger: log)
+    republisher.republish
+
+    expect_log_contains(log, "Republishing: #{guide1.title}\n")
+  end
+
   def expect_guide_to_be_republished(guide, publishing_api)
     expect(publishing_api).to receive(:put_content).
                               with(guide.content_id, a_hash_including(base_path: guide.slug))
@@ -20,5 +33,10 @@ RSpec.describe GuideRepublisher, '#republish' do
                               with(guide.content_id, a_kind_of(Hash))
     expect(publishing_api).to receive(:publish).
                               with(guide.content_id, guide.latest_edition.update_type)
+  end
+
+  def expect_log_contains(log, string)
+    log.rewind
+    expect(log.readlines).to include(string)
   end
 end


### PR DESCRIPTION
When there are structural changes to our content we will sometimes need to republishing everything.

This will be useful when we change rendering app.