### PR TITLE
Fix bug where we were not sending topics to the correct content items

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -38,10 +38,7 @@ private
                             publish
 
     if publication.success?
-      GuideTaggerJob.batch_perform_later(
-        guide_ids: @topic.guide_ids,
-        topic_id: @topic.content_id
-      )
+      GuideTaggerJob.batch_perform_later(@topic)
       TopicSearchIndexer.new(@topic).index
 
       redirect_to edit_topic_path(@topic), notice: "Topic has been published"

--- a/app/models/guide_tagger_job.rb
+++ b/app/models/guide_tagger_job.rb
@@ -1,14 +1,14 @@
 class GuideTaggerJob < ActiveJob::Base
   queue_as :default
 
-  def self.batch_perform_later(guide_ids:, topic_id:)
-    guide_ids.each do |guide_id|
-      perform_later(guide_id: guide_id, topic_id: topic_id)
+  def self.batch_perform_later(topic)
+    topic.guide_content_ids.each do |guide_content_id|
+      perform_later(guide_content_id: guide_content_id, topic_content_id: topic.content_id)
     end
   end
 
-  def perform(guide_id:, topic_id:)
-    publishing_api.patch_links(guide_id, links: { topics: [topic_id] })
+  def perform(guide_content_id:, topic_content_id:)
+    publishing_api.patch_links(guide_content_id, links: { topics: [topic_content_id] })
   end
 
 private

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -21,12 +21,15 @@ class Topic < ActiveRecord::Base
     path
   end
 
-  def guide_ids
-    tree.map do |grouping|
+  def guide_content_ids
+    ids = tree.map do |grouping|
       grouping['guides'].map do |guide_id|
         Integer(guide_id)
       end
     end.flatten.uniq
+    Guide
+      .where(id: ids)
+      .pluck(:content_id)
   end
 
   private

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -50,6 +50,25 @@ FactoryGirl.define do
     title "Agile Delivery"
     path "/service-manual/agile-delivery"
     description "Agile description"
+
+    trait :with_some_guides do
+      tree do
+        guide1 = create(:published_guide)
+        guide2 = create(:published_guide)
+        [
+          {
+            title: "Group 1 title",
+            guides: [guide1.to_param],
+            description: "Group 1 description",
+          },
+          {
+            title: "Group 2",
+            guides: [guide2.to_param],
+            description: "Group 2 description",
+          }
+        ]
+      end
+    end
   end
 
   factory :published_edition, parent: :edition do

--- a/spec/features/topic_spec.rb
+++ b/spec/features/topic_spec.rb
@@ -98,14 +98,14 @@ RSpec.describe "Topics", type: :feature do
     stub_const("PUBLISHING_API", api_double)
     expect(api_double).to receive(:publish).
                           once
-    topic = create(:topic, title: 'Agile Delivery')
+    topic = create(:topic, :with_some_guides)
 
     # When publishing a topic we also need to update the links for all the relevant
     # guides so that they can display which topic they're in.
     #
     # Expect that the batch operation to patch the links is called
-    expect(GuideTaggerJob).to receive(:batch_perform_later).
-                              with(guide_ids: [], topic_id: topic.content_id)
+    expect(GuideTaggerJob).to receive(:batch_perform_later)
+      .with(topic)
 
     # Expect that the topic is attempted to be indexed for search
     topic_search_indexer = double(:topic_search_indexer)
@@ -114,7 +114,7 @@ RSpec.describe "Topics", type: :feature do
 
     visit root_path
     click_link "Manage Topics"
-    click_link "Agile Delivery"
+    click_link topic.title
 
     click_on 'Publish'
 

--- a/spec/models/guide_tagger_job_spec.rb
+++ b/spec/models/guide_tagger_job_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe GuideTaggerJob do
+  let(:api_double) { double(:publishing_api) }
+
+  before do
+    stub_const("PUBLISHING_API", api_double)
+  end
+
+  describe "#batch_perform_later" do
+    it "adds the topic to all guides" do
+      topic = create(:topic, :with_some_guides)
+      guide_ids = topic.tree.map {|t| t["guides"]}.flatten
+      guide_content_ids = Guide.where(id: guide_ids).pluck(:content_id)
+      guide_content_ids.each do |guide_content_id|
+        expect(api_double).to receive(:patch_links)
+          .with(
+            guide_content_id,
+            links: { topics: [topic.content_id] },
+          )
+      end
+
+      GuideTaggerJob.batch_perform_later(topic)
+    end
+  end
+end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -49,11 +49,14 @@ RSpec.describe Topic do
     end
   end
 
-  describe "#guide_ids" do
-    it "returns the associated guide ids" do
-      topic = create(:topic, tree: [{'guides' => ['2', '5']}, {'guides' => ['3']}])
+  describe "#guide_content_ids" do
+    it "returns the associated guide content ids" do
+      topic = create(:topic, :with_some_guides)
+      guide_ids = topic.tree.map {|t| t["guides"]}.flatten
+      guide_content_ids = Guide.where(id: guide_ids).pluck(:content_id)
 
-      expect(topic.guide_ids).to match_array([2, 3, 5])
+      expect(topic.guide_content_ids).to match_array(guide_content_ids)
+      expect(topic.guide_content_ids).to_not be_empty
     end
   end
 end


### PR DESCRIPTION
~~Don't merge, because this needs tests and need to fix the bug in the `publishing-api` if possible.~~
Also, turns out if you pass an incorrect ID through to `patch_links`,
you get a 200.