### PR TITLE
Remove 'Save and preview' button

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -103,18 +103,10 @@ private
     publication = Publisher.new(content_model: @guide).
                             save_draft(GuidePresenter.new(@guide, @guide.latest_edition))
     if publication.success?
-      redirect_to success_url(@guide), notice: "Guide has been updated"
+      redirect_to back_or_default, notice: "Guide has been updated"
     else
       flash.now[:error] = publication.errors
       render 'edit'
-    end
-  end
-
-  def success_url(guide)
-    if params[:save_and_preview]
-      preview_content_model_url(guide)
-    else
-      back_or_default
     end
   end
 

--- a/app/views/editions/_actions.html.erb
+++ b/app/views/editions/_actions.html.erb
@@ -7,7 +7,6 @@
       <% end %>
       <% if !publish_controls_only %>
         <%= form.submit "Save", class: 'btn btn-default add-right-margin js-ok-to-navigate-away', name: :save, data: disable_if_new_record(guide) %>
-        <%= form.submit "Save and preview", class: 'btn btn-default add-right-margin js-ok-to-navigate-away', name: :save_and_preview, data: disable_if_new_record(guide) %>
         <% if !edition.persisted? %>
           <%= link_to "Discard new guide", guides_path, class: "btn btn-danger add-right-margin" %>
         <% end %>

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -161,18 +161,17 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     end
   end
 
-  it "should save a draft locally, sent it to Publishing API, then redirect to the front end when previewing" do
+  it "should save a draft locally and send it to Publishing API" do
     guide = create(:guide, slug: '/service-manual/topic-name/preview-test')
     visit edit_guide_path(guide)
     fill_in "Title", with: "Changed Title"
 
     expect(fake_publishing_api).to receive(:put_content)
 
-    expect_external_redirect_to "http://draft-origin.dev.gov.uk/service-manual/topic-name/preview-test" do
-      click_first_button "Save and preview"
-    end
+    click_first_button "Save"
 
     expect(guide.editions.map(&:title)).to match_array ["Changed Title"]
+    expect(page).to have_link "Preview", href: "http://draft-origin.dev.gov.uk/service-manual/topic-name/preview-test"
   end
 
   context "with a review requested" do
@@ -287,14 +286,6 @@ private
 
   def the_form_should_be_prepopulated_with_title(title)
     expect(find_field('Title').value).to eq title
-  end
-
-  def expect_external_redirect_to(external_url)
-    yield
-  rescue ActionController::RoutingError # Rack::Test raises when redirected to external urls
-    expect(current_url).to eq external_url
-  else
-    raise "Missing external redirect"
   end
 
   class FakePublishingApi


### PR DESCRIPTION
Because nobody actually uses it.

https://trello.com/c/BtidAaIX/271-remove-save-and-preview-button-and-add-a-dialog-if-previewing-when-the-current-draft-has-not-been-saved