### PR TITLE
Add content owners to topic links

### DIFF
--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -28,6 +28,7 @@ class TopicPresenter
     {
       links: {
         linked_items: eagerloaded_guides.map(&:content_id),
+        content_owners: content_owner_content_ids,
       }
     }
   end
@@ -48,6 +49,12 @@ private
         contents: guides.map {|g| g.slug},
         content_ids: guides.map {|g| g.content_id},
       }
+    end
+  end
+
+  def content_owner_content_ids
+    eagerloaded_guides.map do |guide|
+      guide.latest_edition.content_owner.content_id
     end
   end
 

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -53,9 +53,10 @@ private
   end
 
   def content_owner_content_ids
-    eagerloaded_guides.map do |guide|
+    content_ids = eagerloaded_guides.map do |guide|
       guide.latest_edition.content_owner.content_id
     end
+    content_ids.uniq
   end
 
   def eagerloaded_guides

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -62,5 +62,15 @@ RSpec.describe TopicPresenter do
         expect(guide.content_id).to be_in(linked_items)
       end
     end
+
+    it "contains content_owners content ids" do
+      guide_community_content_ids = [guide_1, guide_2, guide_3].map do |guide|
+        guide.latest_edition.content_owner.content_id
+      end
+
+      content_owner_content_ids = presented_topic.links_payload[:links][:content_owners]
+
+      expect(content_owner_content_ids).to match_array(guide_community_content_ids)
+    end
   end
 end


### PR DESCRIPTION
Including refactored a test a little to avoid the `let`s.

https://trello.com/c/rZlsL4Am/152-add-communities-sidebar-to-the-topic-pages

Related content schemas PR: https://github.com/alphagov/govuk-content-schemas/pull/277