### PR TITLE
Stop redirecting back to root after modifying a guide

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,16 +10,4 @@ class ApplicationController < ActionController::Base
     [Plek.find('draft-origin'), content_model.slug].join('')
   end
   helper_method :preview_content_model_url
-
-  def back_or_default(fallback_uri = root_url, anchor: nil)
-    uri = if request.referrer.present? && request.referrer != request.url
-      request.referrer
-    else
-      fallback_uri
-    end
-    if anchor && uri.exclude?("#")
-      uri += "##{anchor}"
-    end
-    uri
-  end
 end

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -60,13 +60,13 @@ private
   def send_for_review
     ApprovalProcess.new(content_model: @guide).request_review
 
-    redirect_to back_or_default, notice: "A review has been requested"
+    redirect_to edit_guide_path(@guide), notice: "A review has been requested"
   end
 
   def approve_for_publication
     ApprovalProcess.new(content_model: @guide).give_approval(approver: current_user)
 
-    redirect_to back_or_default, notice: "Thanks for approving this guide"
+    redirect_to edit_guide_path(@guide), notice: "Thanks for approving this guide"
   end
 
   def publish
@@ -87,7 +87,7 @@ private
         NotificationMailer.published(@guide, current_user).deliver_later
       end
 
-      redirect_to back_or_default, notice: "Guide has been published"
+      redirect_to edit_guide_path(@guide), notice: "Guide has been published"
     else
       @guide = @guide.reload
 
@@ -103,7 +103,7 @@ private
     publication = Publisher.new(content_model: @guide).
                             save_draft(GuidePresenter.new(@guide, @guide.latest_edition))
     if publication.success?
-      redirect_to back_or_default, notice: "Guide has been updated"
+      redirect_to edit_guide_path(@guide), notice: "Guide has been updated"
     else
       flash.now[:error] = publication.errors
       render 'edit'

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -13,32 +13,4 @@ RSpec.describe ApplicationController do
       get :index
     end
   end
-
-  describe "back_or_default" do
-    it "returns referer if there's one" do
-      request.env['HTTP_REFERER'] = 'referer_url'
-      expect(controller.back_or_default('default')).to eq 'referer_url'
-    end
-
-    it "returns root_url if there's no referer nor fallback path" do
-      request.env['HTTP_REFERER'] = nil
-      expect(controller.back_or_default).to eq root_url
-    end
-
-    it "returns fallback uri if there's no referer" do
-      request.env['HTTP_REFERER'] = nil
-      expect(controller.back_or_default('fallback_url')).to eq 'fallback_url'
-    end
-
-    it "returns fallback uri if referer is the same as current url to avoid infinite loops" do
-      request.env['HTTP_REFERER'] = 'infinite_loop_url'
-      allow(request).to receive(:url).and_return('infinite_loop_url')
-      expect(controller.back_or_default('fallback_url')).to eq 'fallback_url'
-    end
-
-    it "adds an anchor if provided" do
-      request.env['HTTP_REFERER'] = 'referer_url'
-      expect(controller.back_or_default('default', anchor: 'anchovy')).to eq 'referer_url#anchovy'
-    end
-  end
 end

--- a/spec/controllers/guides_controller_spec.rb
+++ b/spec/controllers/guides_controller_spec.rb
@@ -32,12 +32,12 @@ RSpec.describe GuidesController, type: :controller do
       it 'notifies about search indexing errors but does not fail the transaction' do
         expect_any_instance_of(Rummageable::Index).to receive(:add_batch).and_raise("Something went wrong")
         edition = build(:edition, state: 'approved')
-        Guide.create!(slug: "/service-manual/topic-name/test", editions: [edition])
+        guide = Guide.create!(slug: "/service-manual/topic-name/test", editions: [edition])
         expect(controller).to receive(:notify_airbrake)
 
         put :update, id: edition.guide_id, publish: true
 
-        expect(response).to redirect_to(root_url)
+        expect(response).to redirect_to(edit_guide_path(guide))
         expect(flash[:notice]).to eq "Guide has been published"
       end
 


### PR DESCRIPTION
https://trello.com/c/ZYB8fHOV/288-save-from-publisher-should-keep-user-on-the-edit-guide-page-instead-of-dashboard