### PR TITLE
Remove the word Community from the guide index community titles

### DIFF
--- a/app/helpers/guide_helper.rb
+++ b/app/helpers/guide_helper.rb
@@ -30,4 +30,8 @@ module GuideHelper
 
     form_for(guide, *args << options.merge(as: :guide, url: url), &block)
   end
+
+  def guide_community_title(guide_community)
+    guide_community.title.gsub(/ [cC]ommunity$/, "")
+  end
 end

--- a/app/views/guides/index.html.erb
+++ b/app/views/guides/index.html.erb
@@ -32,7 +32,7 @@
         <h2><%= search_header.to_s %></h2>
       <% end %>
     <% end %>
-    <table class='table table-bordered'>
+    <table class='guide-table table table-bordered'>
       <thead>
         <tr class='table-header'>
           <th>Guide</th>
@@ -51,7 +51,7 @@
             </td>
             <td>
               <% if guide.latest_edition.content_owner %>
-                <%= guide.latest_edition.content_owner.title %>
+                <%= guide_community_title(guide.latest_edition.content_owner) %>
               <% end %>
             </td>
             <td class='last-edited-by'>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :guide_community do
-    latest_edition { build(:edition, content_owner: nil) }
+    latest_edition { build(:community_edition, content_owner: nil) }
     slug "/service-manual/topic-name/test-guide#{SecureRandom.hex}"
   end
 
@@ -22,6 +22,12 @@ FactoryGirl.define do
     body "Heading"
     content_owner { build(:guide_community) }
     user { build(:user) }
+  end
+
+  factory :community_edition, parent: :edition do
+    sequence :title do |n|
+      "#{n} Community"
+    end
   end
 
   factory :draft_guide, parent: :guide do

--- a/spec/features/guide_index_spec.rb
+++ b/spec/features/guide_index_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe 'Guide index', type: :feature do
+  it "removes the Community part from guide community titles" do
+    guide = create(:guide)
+
+    visit root_path
+
+    content_owner_title =
+      guide.latest_edition.content_owner.title
+    content_owner_title_without_community =
+      guide.latest_edition.content_owner.title.gsub(" Community", "")
+
+    within_guide_index_row guide.title do
+      expect(page).to_not have_content content_owner_title
+      expect(page).to have_content content_owner_title_without_community
+    end
+  end
+end

--- a/spec/support/capybara_helpers.rb
+++ b/spec/support/capybara_helpers.rb
@@ -3,8 +3,8 @@ module CapybaraHelpers
     click_button value, match: :first
   end
 
-  def within_guide_index_row(name, &block)
-    within(:xpath, %{//a[.="#{name}"]/ancestor::tr}, &block)
+  def within_guide_index_row(title, &block)
+    within(:xpath, %{//a[.="#{title}"]/ancestor::tr}, &block)
   end
 end
 


### PR DESCRIPTION
https://trello.com/c/EjzqwXL6/293-quick-fixes-to-lables-and-inputs-on-the-guide-list-table