### PR TITLE
Fix saving topics which contain communities

### DIFF
--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -54,9 +54,13 @@ private
 
   def content_owner_content_ids
     content_ids = eagerloaded_guides.map do |guide|
-      guide.latest_edition.content_owner.content_id
+      edition = guide.latest_edition
+
+      if edition.content_owner
+        edition.content_owner.content_id
+      end
     end
-    content_ids.uniq
+    content_ids.compact.uniq
   end
 
   def eagerloaded_guides

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -99,6 +99,17 @@ RSpec.describe TopicPresenter, "#links_payload" do
     expect(content_owner_content_ids).to eq([guide_community.content_id])
   end
 
+  it "doesn't contain community content_owners because communities don't have them" do
+    guide_community = create(:guide_community)
+    topic = create_topic_in_groups([[guide_community]])
+
+    presented_topic = TopicPresenter.new(topic)
+
+    expect(
+      presented_topic.links_payload[:links][:content_owners]
+      ).to eq([])
+  end
+
   def create_topic_in_groups(groups)
     tree = groups.map.with_index do |group_guides, index|
       {


### PR DESCRIPTION
Communities do not have content owners so we need a condition to stop us trying to link to the content_id of their related content_owners.