### PR TITLE
[REVERT] Store change history for each published guide with update_type=major

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -147,8 +147,8 @@ private
         :related_discussion_href,
         :related_discussion_title,
         :update_type,
-        :reason_for_change,
         :change_note,
+        :change_summary,
       ]).deep_merge(with)
   end
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -12,14 +12,13 @@ class Edition < ActiveRecord::Base
 
   scope :draft, -> { where(state: 'draft') }
   scope :published, -> { where(state: 'published') }
-  scope :major_published_editions, -> { published.where(update_type: 'major')}
   scope :review_requested, -> { where(state: 'review_requested') }
   scope :most_recent_first, -> { order('created_at DESC, id DESC') }
 
   validates_presence_of [:state, :phase, :description, :title, :update_type, :body, :user]
   validates_inclusion_of :state, in: STATES
-  validates :reason_for_change, presence: true, if: :major?
   validates :change_note, presence: true, if: :major?
+  validates :change_summary, presence: true, if: :major?
 
   auto_strip_attributes(
     :title,
@@ -89,7 +88,6 @@ class Edition < ActiveRecord::Base
   def draft_copy
     dup.tap do |e|
       e.change_note = nil
-      e.reason_for_change = nil
       e.update_type = "minor"
       e.state = "draft"
     end

--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -21,7 +21,7 @@ class GuidePresenter
       routes: [
         { type: "exact", path: guide.slug }
       ],
-      details: details,
+      details: details
     }
   end
 
@@ -49,15 +49,6 @@ private
       details[:related_discussion] = {
         title: edition.related_discussion_title,
         href: edition.related_discussion_href
-      }
-    end
-
-    major_published_editions = guide.editions.major_published_editions
-    details[:change_history] = major_published_editions.map do |edition|
-      {
-        public_timestamp: edition.updated_at.iso8601,
-        note: edition.change_note,
-        reason_for_change: edition.reason_for_change,
       }
     end
 

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -88,15 +88,15 @@
           </div>
 
           <div class="form-group change-note-form-group">
-            <%= editions_form.label :change_note, "Summary of change" %>
+            <%= editions_form.label :change_summary, "Summary of change" %>
             <div class="help-block">What is being changed in this update</div>
-            <%= editions_form.text_field :change_note, class: 'input-md-12 form-control', rows: 5 %>
+            <%= editions_form.text_field :change_summary, class: 'input-md-12 form-control', rows: 5 %>
           </div>
 
           <div class="form-group change-note-form-group">
-            <%= editions_form.label :reason_for_change, "Why the change is being made" %>
+            <%= editions_form.label :change_note, "Why the change is being made" %>
             <div class="help-block">Include any evidence from research and links to any related discussions</div>
-            <%= editions_form.text_area :reason_for_change, class: 'input-md-12 form-control text-area-auto-size js-text-area-auto-size', rows: 5 %>
+            <%= editions_form.text_area :change_note, class: 'input-md-12 form-control text-area-auto-size js-text-area-auto-size', rows: 5 %>
           </div>
 
           <p class="text-strong change-note-form-group">

--- a/db/migrate/20160407115651_rename_editions_change_note_and_change_summary.rb
+++ b/db/migrate/20160407115651_rename_editions_change_note_and_change_summary.rb
@@ -1,6 +1,0 @@
-class RenameEditionsChangeNoteAndChangeSummary < ActiveRecord::Migration
-  def change
-    rename_column :editions, :change_note, :reason_for_change
-    rename_column :editions, :change_summary, :change_note
-  end
-end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -130,8 +130,8 @@ CREATE TABLE editions (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     state text,
-    reason_for_change text,
     change_note text,
+    change_summary text,
     content_owner_id integer,
     version integer
 );
@@ -569,6 +569,4 @@ INSERT INTO schema_migrations (version) VALUES ('20160404123940');
 INSERT INTO schema_migrations (version) VALUES ('20160405103708');
 
 INSERT INTO schema_migrations (version) VALUES ('20160405145315');
-
-INSERT INTO schema_migrations (version) VALUES ('20160407115651');
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -28,7 +28,7 @@ FactoryGirl.define do
     description "Description"
     update_type "major"
     change_note "change note"
-    reason_for_change "change reason"
+    change_summary "change summary"
     body "Heading"
     version 1
     content_owner { build(:guide_community) }
@@ -107,17 +107,6 @@ FactoryGirl.define do
 
   factory :review_requested_edition, parent: :edition do
     state "review_requested"
-  end
-
-  factory :published_major_edition, parent: :edition do
-    state "published"
-    update_type "major"
-    sequence :change_note do |n|
-      "Change Note ##{n}"
-    end
-    sequence :reason_for_change do |n|
-      "Change Reason ##{n}"
-    end
   end
 
   factory :slug_migration do

--- a/spec/features/guide_compare_changes_spec.rb
+++ b/spec/features/guide_compare_changes_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe "Guide compare changes", type: :feature do
       visit edit_guide_path(guide)
       fill_in "Title", with: "Second version"
       fill_in "Body", with: "## Hi"
-      fill_in "Summary of change", with: "Change note"
       fill_in "Why the change is being made", with: "Better greeting"
       click_first_button 'Save'
       click_link "Compare changes"

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       end
 
       fill_in "Title", with: "Agile"
-      fill_in "Summary of change", with: "Change note"
       fill_in "Why the change is being made", with: "Update Title"
 
       click_first_button 'Save'
@@ -33,14 +32,13 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       expect(guide.editions.order(:created_at).last.version).to eq(2)
     end
 
-    it "defaults to a major update and the new change note and reason is empty" do
-      create(:published_guide, title: "A guide to agile")
+    it "defaults to a major update and the new change note is empty" do
+      guide = create(:published_guide, title: "A guide to agile")
       visit guides_path
 
       within_guide_index_row("A guide to agile") do
         click_link "A guide to agile"
       end
-      expect(find_field("Summary of change").value).to be_blank
       expect(find_field("Why the change is being made").value).to be_blank
 
       expect(find_field("Major update")).to be_checked
@@ -74,7 +72,6 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
 
       visit edit_guide_path(guide)
       fill_in "Title", with: "Updated Title"
-      fill_in "Summary of change", with: "Change note"
       fill_in "Why the change is being made", with: "Update Title"
       click_first_button 'Save'
 
@@ -93,7 +90,6 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       within_guide_index_row("Scrum") do
         click_link "Scrum"
       end
-      fill_in "Summary of change", with: "Change note"
       fill_in "Why the change is being made", with: "Fix a typo"
       click_first_button 'Save'
 
@@ -211,7 +207,6 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
 
       visit edit_guide_path(guide)
       fill_in "Title", with: "Current Draft Edition"
-      fill_in "Summary of change", with: "Change note"
       fill_in "Why the change is being made", with: "Update Title"
 
       expect(fake_publishing_api).to receive(:put_content)

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe Guide do
         description:    "Description",
         update_type:    "major",
         change_note:    "change note",
-        reason_for_change: "change reason",
+        change_summary: "change summary",
         body:           "# Heading",
         content_owner:  build(:guide_community),
         user:           build(:user),

--- a/spec/presenters/guide_presenter_spec.rb
+++ b/spec/presenters/guide_presenter_spec.rb
@@ -79,35 +79,6 @@ RSpec.describe GuidePresenter do
       edition.title = "Agile Process"
       expect(presenter.content_payload[:title]).to eq("Agile Process")
     end
-
-    it "has all change history for the edition" do
-      edition1 = build(:published_major_edition)
-      edition2 = build(:published_major_edition)
-      guide = create(
-        :guide,
-        editions: [
-          edition1,
-          edition2,
-          build(:edition),
-          build(:edition),
-        ],
-      )
-
-      presenter = described_class.new(guide, guide.latest_edition)
-      change_history = presenter.content_payload[:details][:change_history]
-      expect(change_history).to eq [
-        {
-          public_timestamp: edition1.updated_at.iso8601,
-          note: edition1.change_note,
-          reason_for_change: edition1.reason_for_change,
-        },
-        {
-          public_timestamp: edition2.updated_at.iso8601,
-          note: edition2.change_note,
-          reason_for_change: edition2.reason_for_change,
-        },
-      ]
-    end
   end
 
   describe '#links_payload' do


### PR DESCRIPTION
Turns out that the latest published item can never get added to this change
history, because it is never published when we're presenting this data in
`put_content`.

We need to do one of these:

1. Store `note` and `reason_for_change` on the guide content, and add it to change history in the frontend.
2. Redo `put_content` every time we publish.
3. ???