### PR TITLE
Users can discard draft editions

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -121,21 +121,13 @@ private
   end
 
   def discard
-    loop do
-      break if @guide.latest_edition.nil?
-      break if @guide.latest_edition.published?
-
-      @guide.latest_edition.destroy
-      @guide.reload
-    end
-
-    publication = Publisher.new(content_model: @guide).discard_draft
-
-    if @guide.latest_edition.present?
-      redirect_to edit_guide_path(@guide), notice: "Draft has been discarded"
+    discard_draft = Publisher.new(content_model: @guide)
+      .discard_draft
+    if discard_draft.success?
+      redirect_to root_path, notice: "Draft has been discarded"
     else
-      @guide.destroy
-      redirect_to root_path, notice: "Guide has been discarded"
+      flash.now[:error] = discard_draft.errors
+      render 'edit'
     end
   end
 

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -72,6 +72,8 @@ class GuidesController < ApplicationController
       approve_for_publication
     elsif params[:publish].present?
       publish
+    elsif params[:discard].present?
+      discard
     else
       save_draft
     end
@@ -115,6 +117,25 @@ private
 
       flash.now[:error] = publication.errors
       render 'edit'
+    end
+  end
+
+  def discard
+    loop do
+      break if @guide.latest_edition.nil?
+      break if @guide.latest_edition.published?
+
+      @guide.latest_edition.destroy
+      @guide.reload
+    end
+
+    publication = Publisher.new(content_model: @guide).discard_draft
+
+    if @guide.latest_edition.present?
+      redirect_to edit_guide_path(@guide), notice: "Draft has been discarded"
+    else
+      @guide.destroy
+      redirect_to root_path, notice: "Guide has been discarded"
     end
   end
 

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -33,7 +33,7 @@ class GuidesController < ApplicationController
     if publication.success?
       redirect_to edit_guide_path(@guide), notice: 'Guide has been created'
     else
-      flash.now[:error] = publication.errors
+      flash.now[:error] = publication.error
       render 'new'
     end
   end
@@ -115,7 +115,7 @@ private
     else
       @guide = @guide.reload
 
-      flash.now[:error] = publication.errors
+      flash.now[:error] = publication.error
       render 'edit'
     end
   end
@@ -126,7 +126,7 @@ private
     if discard_draft.success?
       redirect_to root_path, notice: "Draft has been discarded"
     else
-      flash.now[:error] = discard_draft.errors
+      flash.now[:error] = discard_draft.error
       render 'edit'
     end
   end
@@ -139,7 +139,7 @@ private
     if publication.success?
       redirect_to edit_guide_path(@guide), notice: "Guide has been updated"
     else
-      flash.now[:error] = publication.errors
+      flash.now[:error] = publication.error
       render 'edit'
     end
   end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -43,7 +43,7 @@ private
 
       redirect_to edit_topic_path(@topic), notice: "Topic has been published"
     else
-      flash.now[:error] = publication.errors
+      flash.now[:error] = publication.error
       render 'edit'
     end
   end
@@ -61,7 +61,7 @@ private
     if publication.success?
       redirect_to edit_topic_path(@topic), notice: success_notice
     else
-      flash.now[:error] = publication.errors
+      flash.now[:error] = publication.error
       render @topic.persisted? ? 'edit' : 'new'
     end
   end

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -55,6 +55,7 @@ class Guide < ActiveRecord::Base
 
   def editions_since_last_published
     latest_published_edition = editions.published.last
+    return [] unless latest_published_edition.present?
     editions
       .where("created_at > ?", latest_published_edition.created_at)
   end

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -53,6 +53,12 @@ class Guide < ActiveRecord::Base
     editions.where(state: "published").any?
   end
 
+  def editions_since_last_published
+    latest_published_edition = editions.published.last
+    editions
+      .where("created_at > ?", latest_published_edition.created_at)
+  end
+
   def work_in_progress_edition?
     latest_edition.try(:published?) == false
   end

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -4,7 +4,7 @@ class Guide < ActiveRecord::Base
   validate :slug_cant_be_changed_if_an_edition_has_been_published
   validate :latest_edition_has_content_owner, if: :requires_content_owner?
 
-  has_many :editions
+  has_many :editions, dependent: :destroy
   has_one :latest_edition, -> { order(created_at: :desc) }, class_name: "Edition", inverse_of: :guide
 
   accepts_nested_attributes_for :latest_edition

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -24,11 +24,9 @@ class Publisher
       ActiveRecord::Base.transaction do
         publishing_api.discard_draft(content_model.content_id)
 
-        latest_published_edition = content_model.editions.published.last
-        if latest_published_edition.present?
+        if content_model.has_published_edition?
           content_model
-            .editions
-            .where("created_at > ?", latest_published_edition.created_at)
+            .editions_since_last_published
             .destroy_all
         else
           content_model.destroy!

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -19,6 +19,9 @@ class Publisher
     end
   end
 
+  def discard_draft
+  end
+
 private
 
   def save_catching_gds_api_errors(&block)

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -55,9 +55,9 @@ private
   end
 
   class Response
-    def initialize(opts = {})
-      @success = opts.fetch(:success)
-      @error = opts.fetch(:error, nil)
+    def initialize(options = {})
+      @success = options.fetch(:success)
+      @error = options[:error]
     end
 
     def success?

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -34,9 +34,9 @@ class Publisher
           content_model.destroy!
         end
       end
-      DiscardDraftResponse.new(success: true)
+      Response.new(success: true)
     rescue GdsApi::HTTPErrorResponse => e
-      DiscardDraftResponse.new(success: false, errors: e.error_details['error']['message'])
+      Response.new(success: false, error: e.error_details['error']['message'])
     end
   end
 
@@ -48,39 +48,28 @@ private
         if content_model.save
           block.call
 
-          PublicationResponse.new(success: true)
+          Response.new(success: true)
         else
-          PublicationResponse.new(success: false)
+          Response.new(success: false)
         end
       end
     rescue GdsApi::HTTPErrorResponse => e
-      PublicationResponse.new(success: false, errors: e.error_details['error']['message'])
+      Response.new(success: false, error: e.error_details['error']['message'])
     end
   end
 
-  class DiscardDraftResponse
+  class Response
     def initialize(opts = {})
       @success = opts.fetch(:success)
-      @errors = opts.fetch(:errors, [])
+      @error = opts.fetch(:error, nil)
     end
 
     def success?
       @success
     end
 
-    def errors
-      @errors
-    end
-  end
-
-  class PublicationResponse
-    attr_reader :success, :errors
-
-    alias_method :success?, :success
-
-    def initialize(opts = {})
-      @success = opts.fetch(:success)
-      @errors = opts.fetch(:errors, [])
+    def error
+      @error
     end
   end
 end

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -20,22 +20,20 @@ class Publisher
   end
 
   def discard_draft
-    begin
-      ActiveRecord::Base.transaction do
-        publishing_api.discard_draft(content_model.content_id)
+    ActiveRecord::Base.transaction do
+      publishing_api.discard_draft(content_model.content_id)
 
-        if content_model.has_published_edition?
-          content_model
-            .editions_since_last_published
-            .destroy_all
-        else
-          content_model.destroy!
-        end
+      if content_model.has_published_edition?
+        content_model
+          .editions_since_last_published
+          .destroy_all
+      else
+        content_model.destroy!
       end
-      Response.new(success: true)
-    rescue GdsApi::HTTPErrorResponse => e
-      Response.new(success: false, error: e.error_details['error']['message'])
     end
+    Response.new(success: true)
+  rescue GdsApi::HTTPErrorResponse => e
+    Response.new(success: false, error: e.error_details['error']['message'])
   end
 
 private

--- a/app/views/editions/_actions.html.erb
+++ b/app/views/editions/_actions.html.erb
@@ -10,6 +10,7 @@
         <% if !edition.persisted? %>
           <%= link_to "Discard new guide", guides_path, class: "btn btn-danger add-right-margin" %>
         <% end %>
+        <%= form.submit "Discard draft", class: 'btn btn-default add-right-margin js-ok-to-navigate-away', name: :discard %>
       <% end %>
 
         <% if edition.persisted? %>

--- a/app/views/editions/_actions.html.erb
+++ b/app/views/editions/_actions.html.erb
@@ -11,7 +11,12 @@
           <%= link_to "Discard new guide", guides_path, class: "btn btn-danger add-right-margin" %>
         <% end %>
         <% if !guide.latest_edition.published? %>
-          <%= form.submit "Discard draft", class: 'btn btn-default add-right-margin js-ok-to-navigate-away', name: :discard %>
+          <%=
+            form.submit "Discard draft",
+              class: 'btn btn-default add-right-margin js-ok-to-navigate-away',
+              name: :discard,
+              :"data-confirm"=> "Are you sure you want to discard this draft?"
+            %>
         <% end %>
       <% end %>
 

--- a/app/views/editions/_actions.html.erb
+++ b/app/views/editions/_actions.html.erb
@@ -10,7 +10,9 @@
         <% if !edition.persisted? %>
           <%= link_to "Discard new guide", guides_path, class: "btn btn-danger add-right-margin" %>
         <% end %>
-        <%= form.submit "Discard draft", class: 'btn btn-default add-right-margin js-ok-to-navigate-away', name: :discard %>
+        <% if !guide.latest_edition.published? %>
+          <%= form.submit "Discard draft", class: 'btn btn-default add-right-margin js-ok-to-navigate-away', name: :discard %>
+        <% end %>
       <% end %>
 
         <% if edition.persisted? %>

--- a/app/views/editions/_actions.html.erb
+++ b/app/views/editions/_actions.html.erb
@@ -13,7 +13,7 @@
         <% if !guide.latest_edition.published? %>
           <%=
             form.submit "Discard draft",
-              class: 'btn btn-default add-right-margin js-ok-to-navigate-away',
+              class: 'btn btn-danger add-right-margin js-ok-to-navigate-away',
               name: :discard,
               :"data-confirm"=> "Are you sure you want to discard this draft?"
             %>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -96,6 +96,9 @@ FactoryGirl.define do
     end
   end
 
+  factory :draft_edition, parent: :edition do
+  end
+
   factory :published_edition, parent: :edition do
     state "published"
   end

--- a/spec/features/discard_guide_spec.rb
+++ b/spec/features/discard_guide_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "discarding guides", type: :feature do
   end
 
   it "makes the user confirm discarding the draft", js: true do
-    guide = create(:guide)
+    guide = create(:guide, :with_draft_edition)
     visit edit_guide_path(guide)
     click_first_button "Discard draft"
     expect(page.driver.browser.modal_message).to include "Are you sure you want to discard this draft?"
@@ -24,7 +24,7 @@ RSpec.describe "discarding guides", type: :feature do
 
   context "with a successful discard_draft" do
     it "discards the draft in the publishing api" do
-      guide = create(:guide)
+      guide = create(:guide, :with_draft_edition)
       publisher = double(:publisher)
       expect(Publisher).to receive(:new).with(content_model: guide).and_return publisher
       expect(publisher).to receive(:discard_draft)
@@ -40,7 +40,7 @@ RSpec.describe "discarding guides", type: :feature do
 
   context "with an unsuccessful discard_draft" do
     it "does not discard the draft" do
-      guide = create(:guide)
+      guide = create(:guide, :with_draft_edition)
       discard_draft_response = Publisher::Response.new(
         success: false,
         error: "An error occurred",

--- a/spec/features/discard_guide_spec.rb
+++ b/spec/features/discard_guide_spec.rb
@@ -2,6 +2,13 @@ require 'rails_helper'
 require 'capybara/rails'
 
 RSpec.describe "discarding guides", type: :feature do
+  it "makes the user confirm discarding the draft", js: true do
+    guide = create(:guide)
+    visit edit_guide_path(guide)
+    click_first_button "Discard draft"
+    expect(page.driver.browser.modal_message).to include "Are you sure you want to discard this draft?"
+  end
+
   context "when the latest edition is published" do
     it "does not allow discarding" do
       guide = create(:published_guide)

--- a/spec/features/discard_guide_spec.rb
+++ b/spec/features/discard_guide_spec.rb
@@ -4,7 +4,7 @@ require 'capybara/rails'
 RSpec.describe "discarding guides", type: :feature do
   before do
     allow_any_instance_of(Publisher).to receive(:discard_draft)
-      .and_return(Publisher::DiscardDraftResponse.new(success: true))
+      .and_return(Publisher::Response.new(success: true))
   end
 
   it "makes the user confirm discarding the draft", js: true do
@@ -28,7 +28,7 @@ RSpec.describe "discarding guides", type: :feature do
       publisher = double(:publisher)
       expect(Publisher).to receive(:new).with(content_model: guide).and_return publisher
       expect(publisher).to receive(:discard_draft)
-        .and_return(Publisher::DiscardDraftResponse.new(success: true))
+        .and_return(Publisher::Response.new(success: true))
 
       visit edit_guide_path(guide)
       click_first_button "Discard draft"
@@ -41,9 +41,9 @@ RSpec.describe "discarding guides", type: :feature do
   context "with an unsuccessful discard_draft" do
     it "does not discard the draft" do
       guide = create(:guide)
-      discard_draft_response = Publisher::DiscardDraftResponse.new(
+      discard_draft_response = Publisher::Response.new(
         success: false,
-        errors: "An error occurred",
+        error: "An error occurred",
       )
       expect_any_instance_of(Publisher).to receive(:discard_draft)
         .and_return(discard_draft_response)

--- a/spec/features/discard_guide_spec.rb
+++ b/spec/features/discard_guide_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+require 'capybara/rails'
+
+RSpec.describe "discarding guides", type: :feature do
+  let :publisher do
+    double(:publisher)
+  end
+
+  context "guide that has been published" do
+    let :guide do
+      create(
+        :guide,
+        editions: [
+          build(:draft_edition, body: "This is the first draft edition"),
+          build(:published_edition, body: "This is the published edition"),
+          build(:draft_edition, body: "This is the latest draft edition"),
+        ],
+      )
+    end
+
+    it "restores it to the latest published edition" do
+      visit edit_guide_path(guide)
+      click_first_button "Discard draft"
+      within ".alert" do
+        expect(page).to have_content "Draft has been discarded"
+      end
+      expect(guide.reload.latest_edition.body).to eq "This is the published edition"
+    end
+
+    it "discards the draft in the publishing api" do
+      expect(Publisher).to receive(:new).with(content_model: guide).and_return publisher
+      expect(publisher).to receive(:discard_draft)
+
+      visit edit_guide_path(guide)
+      click_first_button "Discard draft"
+    end
+  end
+
+  context "guide that has never been published" do
+    let :guide do
+      create(
+        :guide,
+        editions: [
+          build(:draft_edition, body: "This is the first draft edition"),
+        ],
+      )
+    end
+
+    it "completely destroys it" do
+      visit edit_guide_path(guide)
+      click_first_button "Discard draft"
+      within ".alert" do
+        expect(page).to have_content "Guide has been discarded"
+      end
+
+      expect(Guide.where(id: guide.id).count).to be 0
+    end
+
+    it "discards the draft in the publishing api" do
+      expect(Publisher).to receive(:new).with(content_model: guide).and_return publisher
+      expect(publisher).to receive(:discard_draft)
+
+      visit edit_guide_path(guide)
+      click_first_button "Discard draft"
+    end
+  end
+end

--- a/spec/features/discard_guide_spec.rb
+++ b/spec/features/discard_guide_spec.rb
@@ -2,6 +2,11 @@ require 'rails_helper'
 require 'capybara/rails'
 
 RSpec.describe "discarding guides", type: :feature do
+  before do
+    allow_any_instance_of(Publisher).to receive(:discard_draft)
+      .and_return(Publisher::DiscardDraftResponse.new(success: true))
+  end
+
   it "makes the user confirm discarding the draft", js: true do
     guide = create(:guide)
     visit edit_guide_path(guide)

--- a/spec/features/discard_guide_spec.rb
+++ b/spec/features/discard_guide_spec.rb
@@ -2,19 +2,17 @@ require 'rails_helper'
 require 'capybara/rails'
 
 RSpec.describe "discarding guides", type: :feature do
-  let :guide do
-    create(
-      :guide,
-      editions: [
-        build(:draft_edition, body: "This is the first draft edition"),
-        build(:published_edition, body: "This is the published edition"),
-        build(:draft_edition, body: "This is the latest draft edition"),
-      ],
-    )
+  context "when the latest edition is published" do
+    it "does not allow discarding" do
+      guide = create(:published_guide)
+      visit edit_guide_path(guide)
+      expect(page).to_not have_button "Discard draft"
+    end
   end
 
   context "with a successful discard_draft" do
     it "discards the draft in the publishing api" do
+      guide = create(:guide)
       publisher = double(:publisher)
       expect(Publisher).to receive(:new).with(content_model: guide).and_return publisher
       expect(publisher).to receive(:discard_draft)
@@ -30,6 +28,7 @@ RSpec.describe "discarding guides", type: :feature do
 
   context "with an unsuccessful discard_draft" do
     it "does not discard the draft" do
+      guide = create(:guide)
       discard_draft_response = Publisher::DiscardDraftResponse.new(
         success: false,
         errors: "An error occurred",

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe "creating guides", type: :feature do
 
   context "when creating a new guide" do
     it 'displays an alert if it fails' do
-      publication = Publisher::PublicationResponse.new(success: false, errors: ['trouble'])
+      publication = Publisher::Response.new(success: false, error: 'trouble')
       allow_any_instance_of(Publisher).to receive(:save_draft).and_return(publication)
 
       fill_in_guide_form
@@ -169,7 +169,7 @@ RSpec.describe "creating guides", type: :feature do
     end
 
     it 'displays an alert if it fails' do
-      publication = Publisher::PublicationResponse.new(success: false, errors: ['trouble'])
+      publication = Publisher::Response.new(success: false, error: 'trouble')
       allow_any_instance_of(Publisher).to receive(:save_draft).and_return(publication)
 
       guide = create(:guide, :with_draft_edition, slug: "/service-manual/topic-name/something")

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -231,3 +231,16 @@ RSpec.describe Guide, "#latest_edition_per_edition_group" do
       ).to eq([second_version_second_edition, first_version_second_edition])
   end
 end
+
+RSpec.describe Guide, "#editions_since_last_published" do
+  it "returns editions since last published" do
+    guide = create(:published_guide)
+    edition1 = build(:edition)
+    edition2 = build(:edition)
+    guide.editions << edition1
+    guide.editions << edition2
+
+    expect(guide.editions_since_last_published.to_a).to eq [edition1, edition2]
+  end
+end
+

--- a/spec/models/publisher_spec.rb
+++ b/spec/models/publisher_spec.rb
@@ -90,7 +90,9 @@ end
 
 RSpec.describe Publisher, "#discard_draft" do
   let :publishing_api do
-    double(:publishing_api)
+    publishing_api = double(:publishing_api)
+    allow(publishing_api).to receive(:discard_draft)
+    publishing_api
   end
 
   let(:publishing_api_which_always_fails) do
@@ -104,10 +106,6 @@ RSpec.describe Publisher, "#discard_draft" do
 
   let :subject do
     Publisher.new(content_model: guide, publishing_api: publishing_api)
-  end
-
-  before do
-    allow(publishing_api).to receive(:discard_draft)
   end
 
   context "guide that has published editions" do

--- a/spec/models/publisher_spec.rb
+++ b/spec/models/publisher_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Publisher, "#discard_draft" do
 
   context "guide that does not have published editions" do
     let :guide do
-      create(:guide)
+      create(:guide, :with_draft_edition)
     end
 
     it "is successful" do

--- a/spec/models/publisher_spec.rb
+++ b/spec/models/publisher_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Publisher, '#save_draft' do
         Publisher.new(content_model: guide, publishing_api: publishing_api_which_always_fails).
                   save_draft(GuidePresenter.new(guide, guide.latest_edition))
 
-      expect(publication_response.errors).to include('trouble')
+      expect(publication_response.error).to include('trouble')
     end
   end
 end

--- a/spec/models/publisher_spec.rb
+++ b/spec/models/publisher_spec.rb
@@ -143,23 +143,18 @@ RSpec.describe Publisher, "#discard_draft" do
     context "when the publishing api call fails" do
       it "does not destroy anything" do
         subject = Publisher.new(content_model: guide, publishing_api: publishing_api_which_always_fails)
+        edition_count = guide.editions.count
         subject.discard_draft
 
-        ids = guide.editions.map(&:id)
         expect(Guide.where(id: guide.id).count).to eq 1
-        expect(Edition.where(id: ids).count).to eq 4
+        expect(guide.editions.count).to eq edition_count
       end
     end
   end
 
   context "guide that does not have published editions" do
     let :guide do
-      create(
-        :guide,
-        editions: [
-          build(:draft_edition, title: "This is the first draft edition"),
-        ],
-      )
+      create(:guide)
     end
 
     it "is successful" do
@@ -179,9 +174,8 @@ RSpec.describe Publisher, "#discard_draft" do
         subject = Publisher.new(content_model: guide, publishing_api: publishing_api_which_always_fails)
         subject.discard_draft
 
-        ids = guide.editions.map(&:id)
         expect(Guide.where(id: guide.id).count).to eq 1
-        expect(Edition.where(id: ids).count).to eq 1
+        expect(guide.editions.count).to eq 1
       end
     end
   end


### PR DESCRIPTION
If the guide has never been published then the whole guide is destroyed,
otherwise only the latest drafts are destroyed.

Note that the dialog will pop up twice, because of https://github.com/alphagov/service-manual-publisher/pull/225