### PR TITLE
Don't include jquery twice

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,8 +10,6 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery
-//= require jquery_ujs
 //= require select2
 //= require protect_form_data
 //= require jquery.textarea_autosize

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -11,6 +11,7 @@
 #   - dist/**/*.js
 #
 src_files:
+  - assets/govuk-admin-template.js
   - assets/application.js
   - spec/javascripts/helpers/mock-ajax.js
 


### PR DESCRIPTION
This was causing data-confirm to fire off two dialogs.

Jquery is already included by `govuk_admin_template`.

Also, we need jquery in jasmine, so import all govuk_admin_template javascript.