### PR TITLE
Expand previous editions on history tab

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -57,10 +57,13 @@ class GuidesController < ApplicationController
     # We hack around the problem by reassigning the foreign key (guide_id) after
     # building the new latest edition. The latest_edition association is causing
     # confusion across the app so this hack can be removed if/when it is
-    # replaced.
+    # replaced. We also reset the updated_at column because this isn't a valid
+    # reason to update it.
     previous_latest_edition = @guide.latest_edition
+    guide_id = previous_latest_edition.guide_id
+    updated_at = previous_latest_edition.updated_at
     @guide.build_latest_edition(@guide.latest_edition.dup.attributes)
-    previous_latest_edition.update_attribute(:guide_id, @guide.id)
+    previous_latest_edition.update_columns(guide_id: guide_id, updated_at: updated_at)
 
     if previous_latest_edition.published?
       @guide.latest_edition.version += 1

--- a/app/views/editions/_old_edition_alert.html.erb
+++ b/app/views/editions/_old_edition_alert.html.erb
@@ -1,6 +1,5 @@
 <% if !edition.latest_edition? %>
   <div class="alert alert-info">
     You're looking at a past edition of this guide published at <%= edition.updated_at %>.
-    <%= link_to "See the latest edition", guide.latest_edition %>
   </div>
 <% end %>

--- a/app/views/editions/comments.html.erb
+++ b/app/views/editions/comments.html.erb
@@ -5,10 +5,8 @@
   <%= render 'editions/actions', publish_controls_only: true, form: f, guide: @guide, edition: @edition %>
 <% end %>
 
-<% latest_edition_for_open_edition_group = @latest_edition_per_edition_group.first %>
-
 <% @latest_edition_per_edition_group.each do |latest_edition_of_group| %>
-  <% if latest_edition_of_group == latest_edition_for_open_edition_group %>
+  <% if latest_edition_of_group == @edition %>
     <div class="open-edition panel panel-default">
       <div class="panel-heading">
         Version #<%= latest_edition_of_group.version %>
@@ -25,7 +23,7 @@
   <% else %>
     <div class="panel panel-default">
       <div class="panel-heading">
-        Version #<%= latest_edition_of_group.version %>
+        <%= link_to "Version ##{latest_edition_of_group.version}", edition_comments_path(latest_edition_of_group) %>
         <%= link_to "View changes", edition_changes_path(latest_edition_of_group) %>
       </div>
     </div>

--- a/app/views/editions/comments.html.erb
+++ b/app/views/editions/comments.html.erb
@@ -9,6 +9,7 @@
   <% if latest_edition_of_group == @edition %>
     <div class="open-edition panel panel-default">
       <div class="panel-heading">
+        <span class="glyphicon glyphicon-chevron-down"></span>
         Version #<%= latest_edition_of_group.version %>
         <%= link_to "View changes", edition_changes_path(latest_edition_of_group) %>
       </div>
@@ -23,6 +24,7 @@
   <% else %>
     <div class="panel panel-default">
       <div class="panel-heading">
+        <span class="glyphicon glyphicon-chevron-right"></span>
         <%= link_to "Version ##{latest_edition_of_group.version}", edition_comments_path(latest_edition_of_group) %>
         <%= link_to "View changes", edition_changes_path(latest_edition_of_group) %>
       </div>

--- a/app/views/editions/comments.html.erb
+++ b/app/views/editions/comments.html.erb
@@ -11,7 +11,9 @@
       <div class="panel-heading">
         <span class="glyphicon glyphicon-chevron-down"></span>
         Version #<%= latest_edition_of_group.version %>
-        <%= link_to "View changes", edition_changes_path(latest_edition_of_group) %>
+        <div class="pull-right">
+          <%= link_to "View changes", edition_changes_path(latest_edition_of_group) %>
+        </div>
       </div>
       <div class="panel-body">
         <%= render 'comment_form', comment: @comment, edition: latest_edition_of_group %>
@@ -26,7 +28,9 @@
       <div class="panel-heading">
         <span class="glyphicon glyphicon-chevron-right"></span>
         <%= link_to "Version ##{latest_edition_of_group.version}", edition_comments_path(latest_edition_of_group) %>
-        <%= link_to "View changes", edition_changes_path(latest_edition_of_group) %>
+        <div class="pull-right">
+          <%= link_to "View changes", edition_changes_path(latest_edition_of_group) %>
+        </div>
       </div>
     </div>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,6 @@ Rails.application.routes.draw do
 
   resources :guides
 
-  resources :editions, only: [:show]
-
   resources :comments
   resources :uploads, only: [:create]
   resources :topics

--- a/spec/features/guide_history_spec.rb
+++ b/spec/features/guide_history_spec.rb
@@ -59,3 +59,23 @@ RSpec.describe "Guide history", type: :feature do
       .reverse
   end
 end
+
+
+RSpec.describe "Guide history", type: :feature do
+  scenario "viewing previous editions" do
+    guide = create(:published_guide)
+    guide.editions << build(:edition, version: 2)
+
+    visit edition_comments_path(guide.reload.latest_edition)
+
+    expect_edition_to_be_open("Version #2")
+
+    click_link "Version #1"
+
+    expect_edition_to_be_open("Version #1")
+  end
+
+  def expect_edition_to_be_open(title)
+    expect(page).to have_css(".open-edition .panel-heading", text: title)
+  end
+end

--- a/spec/features/guide_history_spec.rb
+++ b/spec/features/guide_history_spec.rb
@@ -7,19 +7,23 @@ RSpec.describe "Guide history", type: :feature do
     stub_publisher
     create_guide_community
 
-    travel_to "2004-11-24 01:04:44".to_time do
+    travel_to "2004-11-24".to_time do
       visit root_path
       click_on "Create a Guide"
       fill_out_new_guide_fields
       click_first_button "Save"
+    end
 
+    travel_to "2004-11-25".to_time do
       click_on "Comments and history"
 
       within ".open-edition" do
         fill_in "Add new comment", with: "What a great piece of writing"
         click_button "Save comment"
       end
+    end
 
+    travel_to "2004-11-26".to_time do
       click_first_button "Send for review"
     end
 
@@ -27,8 +31,8 @@ RSpec.describe "Guide history", type: :feature do
 
     expect(events.first).to eq "24 November 2004 New draft created by Stub User"
     expect(events.second).to eq "24 November 2004 Assigned to Stub User"
-    expect(events.third).to include "24 November 2004 Stub User What a great piece of writing"
-    expect(events.fourth).to eq "24 November 2004 Review requested by Stub User"
+    expect(events.third).to include "25 November 2004 Stub User What a great piece of writing"
+    expect(events.fourth).to eq "26 November 2004 Review requested by Stub User"
   end
 
   def stub_publisher

--- a/spec/features/guide_history_spec.rb
+++ b/spec/features/guide_history_spec.rb
@@ -72,14 +72,28 @@ RSpec.describe "Guide history", type: :feature do
 
     visit edition_comments_path(guide.reload.latest_edition)
 
-    expect_edition_to_be_open("Version #2")
+    within_edition(1) do
+      expect(events_visible).to be_empty
+    end
+    within_edition(2) do
+      expect(page).to have_css(".event", text: "New draft created")
+    end
 
     click_link "Version #1"
 
-    expect_edition_to_be_open("Version #1")
+    within_edition(1) do
+      expect(page).to have_css(".event", text: "New draft created")
+    end
+    within_edition(2) do
+      expect(events_visible).to be_empty
+    end
   end
 
-  def expect_edition_to_be_open(title)
-    expect(page).to have_css(".open-edition .panel-heading", text: title)
+  def within_edition(number, &block)
+    within(:xpath, "//div[contains(@class, 'panel') and div[contains(@class, 'panel-heading') and contains(., 'Version ##{number}')]]", &block)
+  end
+
+  def events_visible
+    all(".event")
   end
 end


### PR DESCRIPTION
So we can browse the history of a guide we need to be able to open up the previous editions. Previously only the latest edition panel was accessible.

This is part of https://trello.com/c/h4JkfGfP but got missed off.