### PR TITLE
Show more information about guide editions in "comments and history"

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,3 +5,4 @@
 @import 'text-area-auto-size';
 @import 'edition-actions';
 @import 'topics';
+@import 'guide-history';

--- a/app/assets/stylesheets/guide-history.scss
+++ b/app/assets/stylesheets/guide-history.scss
@@ -1,0 +1,5 @@
+.panel-edition {
+  .panel-heading-part {
+    padding-right: 30px;
+  }
+}

--- a/app/views/editions/comments.html.erb
+++ b/app/views/editions/comments.html.erb
@@ -7,10 +7,27 @@
 
 <% @latest_edition_per_edition_group.each do |latest_edition_of_group| %>
   <% if latest_edition_of_group == @edition %>
-    <div class="open-edition panel panel-default">
+    <div class="panel-edition open-edition panel panel-default">
       <div class="panel-heading">
         <span class="glyphicon glyphicon-chevron-down"></span>
-        Version #<%= latest_edition_of_group.version %>
+        <span class="panel-heading-part">
+          Edition #<%= latest_edition_of_group.version %>
+        </span>
+        <span class="panel-heading-part">
+          <%= latest_edition_of_group.update_type.titlecase %> update
+        </span>
+        <span class="panel-heading-part">
+          <% if latest_edition_of_group.published? %>
+            Published on <%= l latest_edition_of_group.updated_at, format: :date_without_time %>
+          <% else %>
+            Not yet published
+          <% end %>
+        </span>
+        <span class="panel-heading-part">
+          <% if latest_edition_of_group.major? %>
+            "<%=latest_edition_of_group.change_summary%>"
+          <% end %>
+        </span>
         <div class="pull-right">
           <%= link_to "View changes", edition_changes_path(latest_edition_of_group) %>
         </div>
@@ -24,10 +41,27 @@
       </div>
     </div>
   <% else %>
-    <div class="panel panel-default">
+    <div class="panel-edition panel panel-default">
       <div class="panel-heading">
         <span class="glyphicon glyphicon-chevron-right"></span>
-        <%= link_to "Version ##{latest_edition_of_group.version}", edition_comments_path(latest_edition_of_group) %>
+        <span class="panel-heading-part">
+          <%= link_to "Edition ##{latest_edition_of_group.version}", edition_comments_path(latest_edition_of_group) %>
+        </span>
+        <span class="panel-heading-part">
+          <%= latest_edition_of_group.update_type.titlecase %> update
+        </span>
+        <span class="panel-heading-part">
+          <% if latest_edition_of_group.published? %>
+            Published on <%= l latest_edition_of_group.updated_at, format: :date_without_time %>
+          <% else %>
+            Not yet published
+          <% end %>
+        </span>
+        <span class="panel-heading-part">
+          <% if latest_edition_of_group.major? %>
+            "<%=latest_edition_of_group.change_summary%>"
+          <% end %>
+        </span>
         <div class="pull-right">
           <%= link_to "View changes", edition_changes_path(latest_edition_of_group) %>
         </div>


### PR DESCRIPTION
Very simple CSS for now:

I should probably extract a partial, but I would prefer to rename the whole comments thing to comments_and_history or something like that first.

![image](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-20-04-2016-11-15-29-sohlonib.png)