### PR TITLE
Reindex published guides

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -147,7 +147,7 @@ private
   end
 
   def index_for_search(guide)
-    SearchIndexer.new(guide).index
+    GuideSearchIndexer.new(guide).index
   rescue => e
     notify_airbrake(e)
     Rails.logger.error(e.message)

--- a/app/controllers/unpublishes_controller.rb
+++ b/app/controllers/unpublishes_controller.rb
@@ -22,7 +22,7 @@ class UnpublishesController < ApplicationController
         old_path:   @redirect.old_path,
         new_path: @redirect.new_path,
       )
-      SearchIndexer.new(@guide).delete
+      GuideSearchIndexer.new(@guide).delete
       redirect_to root_path
     else
       @select_options = select_options

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -1,5 +1,6 @@
 class Edition < ActiveRecord::Base
   STATES = %w(draft published review_requested ready unpublished).freeze
+  STATES_THAT_UPDATE_THE_FRONTEND = %w(published unpublished).freeze
 
   acts_as_commentable
 
@@ -14,6 +15,7 @@ class Edition < ActiveRecord::Base
   scope :published, -> { where(state: 'published') }
   scope :review_requested, -> { where(state: 'review_requested') }
   scope :most_recent_first, -> { order('created_at DESC, id DESC') }
+  scope :which_update_the_frontend, -> { where(state: STATES_THAT_UPDATE_THE_FRONTEND) }
 
   validates_presence_of [:state, :phase, :description, :title, :update_type, :body, :author]
   validates_inclusion_of :state, in: STATES

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -34,8 +34,14 @@ class Guide < ActiveRecord::Base
     editions.most_recent_first.first
   end
 
-  def latest_published_edition
-    editions.published.most_recent_first.first
+  def live_edition
+    latest_edition_to_update_the_frontend =
+      editions.which_update_the_frontend.most_recent_first.first
+
+    return nil if latest_edition_to_update_the_frontend.nil?
+    return nil if latest_edition_to_update_the_frontend.unpublished?
+
+    latest_edition_to_update_the_frontend
   end
 
   def topic

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -34,6 +34,9 @@ class Guide < ActiveRecord::Base
     editions.most_recent_first.first
   end
 
+  def latest_published_edition
+    editions.published.most_recent_first.first
+  end
 
   def topic
     Topic.includes(topic_sections: :guides)

--- a/app/models/guide_search_indexer.rb
+++ b/app/models/guide_search_indexer.rb
@@ -1,4 +1,4 @@
-class SearchIndexer
+class GuideSearchIndexer
   def initialize(guide, rummager_index: RUMMAGER_INDEX)
     @guide = guide
     @rummager_index = rummager_index

--- a/app/models/guide_search_indexer.rb
+++ b/app/models/guide_search_indexer.rb
@@ -5,18 +5,20 @@ class GuideSearchIndexer
   end
 
   def index
-    edition = guide.live_edition
+    live_edition = guide.live_edition
 
-    rummager_index.add_batch([{
-      "format":            "service_manual_guide",
-      "_type":             "service_manual_guide",
-      "description":       edition.description,
-      "indexable_content": edition.body,
-      "title":             edition.title,
-      "link":              guide.slug,
-      "manual":            "service-manual",
-      "organisations":     ["government-digital-service"],
-    }])
+    if live_edition
+      rummager_index.add_batch([{
+        "format":            "service_manual_guide",
+        "_type":             "service_manual_guide",
+        "description":       live_edition.description,
+        "indexable_content": live_edition.body,
+        "title":             live_edition.title,
+        "link":              guide.slug,
+        "manual":            "service-manual",
+        "organisations":     ["government-digital-service"],
+      }])
+    end
   end
 
   def delete

--- a/app/models/guide_search_indexer.rb
+++ b/app/models/guide_search_indexer.rb
@@ -5,7 +5,7 @@ class GuideSearchIndexer
   end
 
   def index
-    edition = guide.latest_published_edition
+    edition = guide.live_edition
 
     rummager_index.add_batch([{
       "format":            "service_manual_guide",

--- a/app/models/search_indexer.rb
+++ b/app/models/search_indexer.rb
@@ -1,29 +1,30 @@
 class SearchIndexer
   def initialize(guide, rummager_index: RUMMAGER_INDEX)
     @guide = guide
-    @edition = guide.latest_published_edition
     @rummager_index = rummager_index
   end
 
   def index
+    edition = guide.latest_published_edition
+
     rummager_index.add_batch([{
       "format":            "service_manual_guide",
       "_type":             "service_manual_guide",
-      "description":       @edition.description,
-      "indexable_content": @edition.body,
-      "title":             @edition.title,
-      "link":              @guide.slug,
+      "description":       edition.description,
+      "indexable_content": edition.body,
+      "title":             edition.title,
+      "link":              guide.slug,
       "manual":            "service-manual",
       "organisations":     ["government-digital-service"],
     }])
   end
 
   def delete
-    rummager_index.delete(@guide.slug)
+    rummager_index.delete(guide.slug)
   end
 
 private
 
-  attr_reader :rummager_index
+  attr_reader :guide, :rummager_index
 
 end

--- a/app/models/search_indexer.rb
+++ b/app/models/search_indexer.rb
@@ -1,14 +1,12 @@
 class SearchIndexer
-  def initialize(guide)
+  def initialize(guide, rummager_index: RUMMAGER_INDEX)
     @guide = guide
     @edition = guide.latest_published_edition
+    @rummager_index = rummager_index
   end
 
   def index
-    index = Rummageable::Index.new(
-      Plek.current.find('rummager'), '/mainstream'
-    )
-    index.add_batch([{
+    rummager_index.add_batch([{
       "format":            "service_manual_guide",
       "_type":             "service_manual_guide",
       "description":       @edition.description,
@@ -21,9 +19,11 @@ class SearchIndexer
   end
 
   def delete
-    index = Rummageable::Index.new(
-      Plek.current.find('rummager'), '/mainstream'
-    )
-    index.delete(@guide.slug)
+    rummager_index.delete(@guide.slug)
   end
+
+private
+
+  attr_reader :rummager_index
+
 end

--- a/app/models/search_indexer.rb
+++ b/app/models/search_indexer.rb
@@ -1,7 +1,7 @@
 class SearchIndexer
   def initialize(guide)
     @guide = guide
-    @edition = guide.latest_edition
+    @edition = guide.latest_published_edition
   end
 
   def index

--- a/app/models/topic_search_indexer.rb
+++ b/app/models/topic_search_indexer.rb
@@ -1,26 +1,24 @@
 class TopicSearchIndexer
-  def initialize(topic)
+  def initialize(topic, rummager_index: RUMMAGER_INDEX)
     @topic = topic
+    @rummager_index = rummager_index
   end
 
   def index
     rummager_index.add_batch([{
       "format":            "service_manual_topic",
       "_type":             "service_manual_topic",
-      "description":       @topic.description,
-      "indexable_content": @topic.title + "\n\n" + @topic.description,
-      "title":             @topic.title,
-      "link":              @topic.path,
+      "description":       topic.description,
+      "indexable_content": topic.title + "\n\n" + topic.description,
+      "title":             topic.title,
+      "link":              topic.path,
       "manual":            "service-manual",
       "organisations":     ["government-digital-service"],
     }])
   end
 
-  private
+private
 
-    def rummager_index
-      Rummageable::Index.new(
-        Plek.current.find('rummager'), '/mainstream'
-      )
-    end
+  attr_reader :topic, :rummager_index
+
 end

--- a/config/initializers/rummager.rb
+++ b/config/initializers/rummager.rb
@@ -1,0 +1,2 @@
+RUMMAGER_INDEX =
+  Rummageable::Index.new(Plek.current.find('rummager'), '/mainstream')

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -4,7 +4,7 @@ namespace :rummager do
     Guide.all.each do |guide|
       puts "Indexing #{guide.title}..."
 
-      SearchIndexer.new(guide).index
+      GuideSearchIndexer.new(guide).index
     end
   end
 end

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
 
   before do
     stub_const('PUBLISHING_API', fake_publishing_api)
-    allow_any_instance_of(SearchIndexer).to receive(:index)
+    allow_any_instance_of(GuideSearchIndexer).to receive(:index)
     allow_any_instance_of(Guide).to receive(:topic).and_return build(:topic)
   end
 
@@ -55,7 +55,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       guide = create(:guide, :with_draft_edition)
 
       indexer = double(:indexer)
-      expect(SearchIndexer).to receive(:new).with(guide).and_return(indexer)
+      expect(GuideSearchIndexer).to receive(:new).with(guide).and_return(indexer)
       expect(indexer).to receive(:index)
       visit guides_path
       within_guide_index_row(guide.title) do

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "creating guides", type: :feature do
     visit root_path
     click_link "Create a Guide"
 
-    allow_any_instance_of(SearchIndexer).to receive(:index)
+    allow_any_instance_of(GuideSearchIndexer).to receive(:index)
     allow_any_instance_of(Guide).to receive(:topic).and_return topic
   end
 

--- a/spec/features/preventing_loss_of_changes_spec.rb
+++ b/spec/features/preventing_loss_of_changes_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Preventing users from losing unsaved changes in the form", type:
     publishing_api = double(:publishing_api)
     allow(publishing_api).to receive(:put_content)
     stub_const('PUBLISHING_API', publishing_api)
-    allow_any_instance_of(SearchIndexer).to receive(:index)
+    allow_any_instance_of(GuideSearchIndexer).to receive(:index)
   end
 
   it "asks the user for confirmation when navigating away via 'Request review'", js: true do

--- a/spec/features/unpublish_spec.rb
+++ b/spec/features/unpublish_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "unpublishing guides", type: :feature do
   context "with a published guide" do
     before do
       allow_any_instance_of(RedirectPublisher).to receive(:process)
-      allow_any_instance_of(SearchIndexer).to receive(:delete)
+      allow_any_instance_of(GuideSearchIndexer).to receive(:delete)
     end
 
     it "redirects to topics" do
@@ -86,7 +86,7 @@ RSpec.describe "unpublishing guides", type: :feature do
       allow_any_instance_of(RedirectPublisher).to receive(:process)
 
       indexer = double(:indexer)
-      expect(SearchIndexer).to receive(:new).with(guide).and_return(indexer)
+      expect(GuideSearchIndexer).to receive(:new).with(guide).and_return(indexer)
       expect(indexer).to receive(:delete)
 
       visit edit_guide_path(guide)

--- a/spec/models/guide_search_indexer_spec.rb
+++ b/spec/models/guide_search_indexer_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe SearchIndexer, "#index" do
+RSpec.describe GuideSearchIndexer, "#index" do
   it "indexes a document in rummager for the most recently published edition" do
     rummager_index = double(:rummageable_index)
     guide = create(:published_guide,
@@ -21,17 +21,17 @@ RSpec.describe SearchIndexer, "#index" do
       organisations:     ["government-digital-service"]
     }])
 
-    SearchIndexer.new(guide, rummager_index: rummager_index).index
+    described_class.new(guide, rummager_index: rummager_index).index
   end
 end
 
-RSpec.describe SearchIndexer, "#delete" do
+RSpec.describe GuideSearchIndexer, "#delete" do
   it "deletes documents from rummager" do
     rummager_index = double(:rummageable_index)
     guide = create(:guide, :with_draft_edition, slug: "/service-manual/topic/some-slug")
 
     expect(rummager_index).to receive(:delete).with("/service-manual/topic/some-slug")
 
-    SearchIndexer.new(guide, rummager_index: rummager_index).delete
+    described_class.new(guide, rummager_index: rummager_index).delete
   end
 end

--- a/spec/models/guide_search_indexer_spec.rb
+++ b/spec/models/guide_search_indexer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe GuideSearchIndexer, "#index" do
-  it "indexes a document in rummager for the most recently published edition" do
+  it "indexes a document in rummager for the live edition" do
     rummager_index = double(:rummageable_index)
     guide = create(:published_guide,
                     title: "My guide",

--- a/spec/models/guide_search_indexer_spec.rb
+++ b/spec/models/guide_search_indexer_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe GuideSearchIndexer, "#index" do
 
     described_class.new(guide, rummager_index: rummager_index).index
   end
+
+  it "does not attempt to index a guide if it has no live editons" do
+    rummager_index = double(:rummageable_index)
+    guide = create(:guide)
+
+    expect(rummager_index).to_not receive(:add_batch)
+
+    described_class.new(guide, rummager_index: rummager_index).index
+  end
 end
 
 RSpec.describe GuideSearchIndexer, "#delete" do

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -234,19 +234,37 @@ RSpec.describe Guide, "#can_be_unpublished?" do
   end
 end
 
-RSpec.describe Guide, "#latest_published_edition" do
+RSpec.describe Guide, "#live_edition" do
   it "returns the most recently published edition" do
     guide = create(:guide, created_at: 5.days.ago)
     latest_published_edition = build(:published_edition, created_at: 3.days.ago)
     guide.editions << latest_published_edition
     guide.editions << create(:published_edition, created_at: 4.days.ago)
 
-    expect(guide.latest_published_edition).to eq(latest_published_edition)
+    expect(guide.live_edition).to eq(latest_published_edition)
+  end
+
+  it "returns the most recently published edition since unpublication" do
+    guide = create(:guide, created_at: 5.days.ago)
+    guide.editions << build(:published_edition, created_at: 4.days.ago)
+    guide.editions << build(:unpublished_edition, created_at: 3.days.ago)
+    latest_published_edition = build(:published_edition, created_at: 2.days.ago)
+    guide.editions << latest_published_edition
+
+    expect(guide.live_edition).to eq(latest_published_edition)
+  end
+
+  it "returns nil if it has been unpublished since publication" do
+    guide = create(:guide, created_at: 5.days.ago)
+    guide.editions << create(:published_edition, created_at: 4.days.ago)
+    guide.editions << create(:unpublished_edition, created_at: 3.days.ago)
+
+    expect(guide.live_edition).to eq(nil)
   end
 
   it "is nil if an edition hasn't been published yet" do
     guide = create(:guide)
 
-    expect(guide.latest_published_edition).to eq(nil)
+    expect(guide.live_edition).to eq(nil)
   end
 end

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -233,3 +233,20 @@ RSpec.describe Guide, "#can_be_unpublished?" do
     expect(guide.can_be_unpublished?).to be false
   end
 end
+
+RSpec.describe Guide, "#latest_published_edition" do
+  it "returns the most recently published edition" do
+    guide = create(:guide, created_at: 5.days.ago)
+    latest_published_edition = build(:published_edition, created_at: 3.days.ago)
+    guide.editions << latest_published_edition
+    guide.editions << create(:published_edition, created_at: 4.days.ago)
+
+    expect(guide.latest_published_edition).to eq(latest_published_edition)
+  end
+
+  it "is nil if an edition hasn't been published yet" do
+    guide = create(:guide)
+
+    expect(guide.latest_published_edition).to eq(nil)
+  end
+end

--- a/spec/models/search_indexer_spec.rb
+++ b/spec/models/search_indexer_spec.rb
@@ -1,24 +1,34 @@
 require 'rails_helper'
 
-RSpec.describe SearchIndexer do
-  it "indexes documents in rummager" do
+RSpec.describe SearchIndexer, "#index" do
+  it "indexes a document in rummager for the most recently published edition" do
     index = double(:rummageable_index)
     plek = Plek.current.find('rummager')
+
+    guide = create(:published_guide,
+                    title: "My guide",
+                    body: "It's my published guide content",
+                    slug: "/service-manual/topic/some-slug"
+                    )
+    guide.editions << build(:edition, body: "I'm reconsidering this draft..")
+
     expect(Rummageable::Index).to receive(:new).with(plek, "/mainstream").and_return index
-    guide = create(:guide, :with_draft_edition, slug: "/service-manual/topic/some-slug")
     expect(index).to receive(:add_batch).with([{
       format:            "service_manual_guide",
       _type:             "service_manual_guide",
-      description:       guide.latest_edition.description,
-      indexable_content: guide.latest_edition.body,
-      title:             guide.latest_edition.title,
-      link:              guide.slug,
+      description:       "Description",
+      indexable_content: "It's my published guide content",
+      title:             "My guide",
+      link:              "/service-manual/topic/some-slug",
       manual:            "service-manual",
       organisations:     ["government-digital-service"]
     }])
+
     SearchIndexer.new(guide).index
   end
+end
 
+RSpec.describe SearchIndexer, "#delete" do
   it "deletes documents from rummager" do
     index = double(:rummageable_index)
     plek = Plek.current.find('rummager')

--- a/spec/models/search_indexer_spec.rb
+++ b/spec/models/search_indexer_spec.rb
@@ -2,9 +2,7 @@ require 'rails_helper'
 
 RSpec.describe SearchIndexer, "#index" do
   it "indexes a document in rummager for the most recently published edition" do
-    index = double(:rummageable_index)
-    plek = Plek.current.find('rummager')
-
+    rummager_index = double(:rummageable_index)
     guide = create(:published_guide,
                     title: "My guide",
                     body: "It's my published guide content",
@@ -12,8 +10,7 @@ RSpec.describe SearchIndexer, "#index" do
                     )
     guide.editions << build(:edition, body: "I'm reconsidering this draft..")
 
-    expect(Rummageable::Index).to receive(:new).with(plek, "/mainstream").and_return index
-    expect(index).to receive(:add_batch).with([{
+    expect(rummager_index).to receive(:add_batch).with([{
       format:            "service_manual_guide",
       _type:             "service_manual_guide",
       description:       "Description",
@@ -24,17 +21,17 @@ RSpec.describe SearchIndexer, "#index" do
       organisations:     ["government-digital-service"]
     }])
 
-    SearchIndexer.new(guide).index
+    SearchIndexer.new(guide, rummager_index: rummager_index).index
   end
 end
 
 RSpec.describe SearchIndexer, "#delete" do
   it "deletes documents from rummager" do
-    index = double(:rummageable_index)
-    plek = Plek.current.find('rummager')
-    expect(Rummageable::Index).to receive(:new).with(plek, "/mainstream").and_return index
+    rummager_index = double(:rummageable_index)
     guide = create(:guide, :with_draft_edition, slug: "/service-manual/topic/some-slug")
-    expect(index).to receive(:delete).with(guide.slug)
-    SearchIndexer.new(guide).delete
+
+    expect(rummager_index).to receive(:delete).with("/service-manual/topic/some-slug")
+
+    SearchIndexer.new(guide, rummager_index: rummager_index).delete
   end
 end

--- a/spec/models/topic_search_indexer_spec.rb
+++ b/spec/models/topic_search_indexer_spec.rb
@@ -2,15 +2,14 @@ require 'rails_helper'
 
 RSpec.describe TopicSearchIndexer do
   it "indexes topics in rummager" do
-    index = double(:rummageable_index)
-    plek = Plek.current.find('rummager')
-    expect(Rummageable::Index).to receive(:new).with(plek, "/mainstream").and_return index
+    rummager_index = double(:rummager_index)
     topic = Topic.create!(
       path: "/service-manual/topic1",
       title: "The Topic Title",
       description: "The Topic Description",
     )
-    expect(index).to receive(:add_batch).with([{
+
+    expect(rummager_index).to receive(:add_batch).with([{
       format:            "service_manual_topic",
       _type:             "service_manual_topic",
       description:       topic.description,
@@ -20,6 +19,7 @@ RSpec.describe TopicSearchIndexer do
       manual:            "service-manual",
       organisations:     ["government-digital-service"]
     }])
-    described_class.new(topic).index
+
+    described_class.new(topic, rummager_index: rummager_index).index
   end
 end

--- a/spec/models/topic_search_indexer_spec.rb
+++ b/spec/models/topic_search_indexer_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe SearchIndexer do
+RSpec.describe TopicSearchIndexer do
   it "indexes topics in rummager" do
     index = double(:rummageable_index)
     plek = Plek.current.find('rummager')
@@ -20,6 +20,6 @@ RSpec.describe SearchIndexer do
       manual:            "service-manual",
       organisations:     ["government-digital-service"]
     }])
-    TopicSearchIndexer.new(topic).index
+    described_class.new(topic).index
   end
 end


### PR DESCRIPTION
We had a rake task `rummager:index` that indexed guides but it didn't suit our current needs. This PR:

1) Only indexes published guides
2) Avoids indexing unpublished guides
3) Paves the way for reindexing withdrawn guides

There's a little bit of housekeeping in here too.

https://trello.com/c/5zi6bvwH