### PR TITLE
A rake task to index topics

### DIFF
--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -1,7 +1,7 @@
 namespace :rummager do
   desc "Index all live guides in rummager"
   task index_guides: :environment do
-    Guide.all.each do |guide|
+    Guide.find_each do |guide|
       puts "Indexing #{guide.title}..."
 
       GuideSearchIndexer.new(guide).index
@@ -14,7 +14,7 @@ namespace :rummager do
   # each topic manually.
   desc "Index published AND unpublished topics in rummager"
   task index_topics: :environment do
-    Topic.all.each do |guide|
+    Topic.find_each do |topic|
       puts "Indexing #{topic.title}..."
 
       TopicSearchIndexer.new(topic).index

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -1,10 +1,26 @@
 namespace :rummager do
-  desc "index all published documents in rummager"
-  task index: :environment do
+  desc "Index all live guides in rummager"
+  task index_guides: :environment do
     Guide.all.each do |guide|
       puts "Indexing #{guide.title}..."
 
       GuideSearchIndexer.new(guide).index
     end
   end
+
+  # WARNING: This indexes topics whether they have been published or not.
+  # We don't currently store the state of a Topic so this is best we can do
+  # at the moment. Rather than using this rake task it is safer to republish
+  # each topic manually.
+  desc "Index published AND unpublished topics in rummager"
+  task index_topics: :environment do
+    Topic.all.each do |guide|
+      puts "Indexing #{topic.title}..."
+
+      TopicSearchIndexer.new(topic).index
+    end
+  end
+
+  desc "Index all content"
+  task index_all: [:index_guides, :index_topics]
 end


### PR DESCRIPTION
Because we currently don't store state for the topics using this rake task is a little dangerous. We might end up indexing a topic that hasn't actually be published yet.