### PR TITLE
Republish all guides

### DIFF
--- a/app/models/guide_republisher.rb
+++ b/app/models/guide_republisher.rb
@@ -6,11 +6,14 @@ class GuideRepublisher
 
   def republish
     live_edition = guide.live_edition
-    guide_for_publication = GuidePresenter.new(guide, live_edition)
 
-    publishing_api.put_content(guide.content_id, guide_for_publication.content_payload)
-    publishing_api.patch_links(guide.content_id, guide_for_publication.links_payload)
-    publishing_api.publish(guide.content_id, live_edition.update_type)
+    if live_edition
+      guide_for_publication = GuidePresenter.new(guide, live_edition)
+
+      publishing_api.put_content(guide.content_id, guide_for_publication.content_payload)
+      publishing_api.patch_links(guide.content_id, guide_for_publication.links_payload)
+      publishing_api.publish(guide.content_id, live_edition.update_type)
+    end
   end
 
   private

--- a/app/models/guide_republisher.rb
+++ b/app/models/guide_republisher.rb
@@ -1,0 +1,19 @@
+class GuideRepublisher
+  def initialize(guide, publishing_api: PUBLISHING_API)
+    @guide = guide
+    @publishing_api = publishing_api
+  end
+
+  def republish
+    live_edition = guide.live_edition
+    guide_for_publication = GuidePresenter.new(guide, live_edition)
+
+    publishing_api.put_content(guide.content_id, guide_for_publication.content_payload)
+    publishing_api.patch_links(guide.content_id, guide_for_publication.links_payload)
+    publishing_api.publish(guide.content_id, live_edition.update_type)
+  end
+
+  private
+
+  attr_reader :guide, :publishing_api
+end

--- a/lib/republish.rake
+++ b/lib/republish.rake
@@ -1,0 +1,8 @@
+namespace :republish do
+  desc "republish all guides"
+  task guides: :environment do
+    Guide.find_each do |guide|
+      GuideRepublisher.new(guide).republish
+    end
+  end
+end

--- a/lib/republish.rake
+++ b/lib/republish.rake
@@ -1,8 +1,0 @@
-namespace :republish do
-  desc "republish all guides"
-  task guides: :environment do
-    Guide.find_each do |guide|
-      GuideRepublisher.new(guide).republish
-    end
-  end
-end

--- a/lib/tasks/republish.rake
+++ b/lib/tasks/republish.rake
@@ -1,0 +1,8 @@
+namespace :republish do
+  desc "republish all guides"
+  task guides: :environment do
+    Guide.find_each do |guide|
+      GuideRepublisher.new(guide).republish
+    end
+  end
+end

--- a/spec/models/guide_republisher_spec.rb
+++ b/spec/models/guide_republisher_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe GuideRepublisher, "#republish" do
+  it "saves the content, links and publishes" do
+    publishing_api = double(:publishing_api)
+    guide = create(:published_guide, slug: "/service-manual/topic/guide")
+
+    expect(publishing_api).to receive(:put_content)
+                                .with(guide.content_id, hash_including(base_path: "/service-manual/topic/guide"))
+    expect(publishing_api).to receive(:patch_links)
+                                .with(guide.content_id, hash_including(links: kind_of(Hash)))
+    expect(publishing_api).to receive(:publish).with(guide.content_id, "major")
+
+    described_class.new(guide, publishing_api: publishing_api).republish
+  end
+end

--- a/spec/models/guide_republisher_spec.rb
+++ b/spec/models/guide_republisher_spec.rb
@@ -13,4 +13,15 @@ RSpec.describe GuideRepublisher, "#republish" do
 
     described_class.new(guide, publishing_api: publishing_api).republish
   end
+
+  it "does not attempt to publish anything if there isn't a live editon" do
+    publishing_api = double(:publishing_api)
+    guide = create(:guide)
+
+    expect(publishing_api).to_not receive(:put_content)
+    expect(publishing_api).to_not receive(:put_links)
+    expect(publishing_api).to_not receive(:publish)
+
+    described_class.new(guide, publishing_api: publishing_api).republish
+  end
 end


### PR DESCRIPTION
We need to be able to republish all of our content. We will soon be changing frontend which requires us to republish all content to change the rendering_app.

It is not possible to republish old editions from the UI and we don't want to make our content designers finish all of their work at the same time to facilitate clicking the publish button. We therefore need a script that can republish the correct live edition.