### PR TITLE
Disable summary field for an unpublished point

### DIFF
--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -50,7 +50,7 @@
           <%= f.label :summary %>
           <%= f.error_list :summary %>
           <span class="help-block">The summary beneath the title which does not support formatting.</span>
-          <%= f.text_area :summary, rows: 5, class: 'input-md-12 form-control text-area-auto-size js-text-area-auto-size' %>
+          <%= f.text_area :summary, disabled: disable_inputs, rows: 5, class: 'input-md-12 form-control text-area-auto-size js-text-area-auto-size' %>
         </div>
       <% end %>
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -87,6 +87,8 @@ FactoryGirl.define do
       ] }
   end
 
+  factory :published_guide_community, parent: :published_guide, class: 'GuideCommunity'
+
   factory :unpublished_guide, parent: :guide do
     transient do
       title "An Unpublished Guide"
@@ -102,7 +104,21 @@ FactoryGirl.define do
     }
   end
 
-  factory :published_guide_community, parent: :published_guide, class: 'GuideCommunity'
+  factory :unpublished_point, parent: :guide, class: 'Point' do
+    transient do
+      title "An Unpublished Point"
+      body "Some Body Text"
+      summary "A summary"
+    end
+
+    editions {
+      [
+        build(:edition, state: "draft", title: title, body: body, summary: summary),
+        build(:edition, state: "published", title: title, body: body, summary: summary),
+        build(:edition, state: "unpublished", title: title, body: body, summary: summary),
+      ]
+    }
+  end
 
   factory :user do
     name "Test User"

--- a/spec/features/unpublish_spec.rb
+++ b/spec/features/unpublish_spec.rb
@@ -112,5 +112,13 @@ RSpec.describe "unpublishing guides", type: :feature do
 
       expect(page).to_not have_field("Author")
     end
+
+    it "disables the summary field for a points page" do
+      guide = create(:unpublished_point)
+
+      visit edit_guide_path(guide)
+
+      expect(page).to_not have_field("Summary")
+    end
   end
 end


### PR DESCRIPTION
Like the rest of the fields for an unpublished guide/point, the summary field should be disabled.