### PR TITLE
A boolean for whether topics should be visually collapsed

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -85,7 +85,7 @@ private
   end
 
   def updatable_topic_attributes
-    [:title, :description, content_owner_ids: []]
+    [:title, :description, :visually_collapsed, content_owner_ids: []]
   end
 
   def store_topic_sections_in_topic

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -23,6 +23,7 @@ class TopicPresenter
         { type: "exact", path: topic.path }
       ],
       details: {
+        visually_collapsed: topic.visually_collapsed,
         groups: groups
       }
     }

--- a/app/views/topics/_form.html.erb
+++ b/app/views/topics/_form.html.erb
@@ -21,6 +21,13 @@
           <%= f.label :description %>
           <%= f.text_field :description, class: "form-control" %>
         </div>
+        <div class="form-group">
+          <%= f.label :visually_collapsed, "Collapsed" %>
+          <div class="help-block">
+            By default the sections of a topic will be expanded. Setting this option will show all the sections collapsed, but expandable, when the user visits the page.
+          </div>
+          <%= f.check_box :visually_collapsed, class: "form-control" %>
+        </div>
       </div>
 
       <div class="well">

--- a/db/migrate/20160504064153_add_topics_visually_collapsed.rb
+++ b/db/migrate/20160504064153_add_topics_visually_collapsed.rb
@@ -1,0 +1,5 @@
+class AddTopicsVisuallyCollapsed < ActiveRecord::Migration
+  def change
+    add_column :topics, :visually_collapsed, :boolean, default: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -343,7 +343,8 @@ CREATE TABLE topics (
     path character varying NOT NULL,
     title character varying NOT NULL,
     description character varying NOT NULL,
-    content_id character varying
+    content_id character varying,
+    visually_collapsed boolean DEFAULT false
 );
 
 
@@ -746,4 +747,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160428124015');
 INSERT INTO schema_migrations (version) VALUES ('20160428190215');
 
 INSERT INTO schema_migrations (version) VALUES ('20160429134835');
+
+INSERT INTO schema_migrations (version) VALUES ('20160504064153');
 

--- a/spec/features/topic_spec.rb
+++ b/spec/features/topic_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe "Topics", type: :feature do
     fill_in "Path", with: "/service-manual/something"
     fill_in "Title", with: "The title"
     fill_in "Description", with: "The description"
+    check "Collapsed"
     click_button "Add Heading"
     fill_in "Heading Title", with: "The heading title"
     fill_in "Heading Description", with: "The heading description"
@@ -44,6 +45,7 @@ RSpec.describe "Topics", type: :feature do
 
     expect(page).to have_field('Title', with: 'The title')
     expect(page).to have_field('Description', with: 'The description')
+    expect(page).to have_checked_field('Collapsed')
 
     expect(find('.js-topic-title').value).to eq('The heading title')
     expect(find('.js-topic-description').value).to eq('The heading description')

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -56,6 +56,14 @@ RSpec.describe TopicPresenter do
       expect(groups.first[:content_ids]).to eq [guide_1.content_id, guide_2.content_id]
       expect(groups.last).to include(name: "Group 2", description: "Berries")
     end
+
+    it "sets visually_expanded" do
+      topic.update_attribute(:visually_collapsed, true)
+
+      expect(
+        presented_topic.content_payload[:details][:visually_collapsed]
+        ).to eq(true)
+    end
   end
 end
 


### PR DESCRIPTION
By default it is false. Topics sections are expanded by default. This is considered safer than collapsing by default even though it is more likely it will be collapsed eventually.

The topic has multiple sections which are normally collapsed. Sometimes there aren't enough sections or items within a section to justify to collapsing and it appears there aren't a set of rules that can be applied which will let the frontend decide for itself. Instead we are adding this boolean which the publisher will set so a pair of human eyes can decide whether it should be collapsed or expanded.

![screen shot 2016-05-04 at 17 00 16](https://cloud.githubusercontent.com/assets/78311/15020374/b8dfb350-1219-11e6-9681-3e082ac17de8.png)
