### PR TITLE
Use /service-manual instead of service-manual for search index

### DIFF
--- a/app/models/guide_search_indexer.rb
+++ b/app/models/guide_search_indexer.rb
@@ -15,7 +15,7 @@ class GuideSearchIndexer
         "indexable_content": live_edition.body,
         "title":             live_edition.title,
         "link":              guide.slug,
-        "manual":            "service-manual",
+        "manual":            "/service-manual",
         "organisations":     ["government-digital-service"],
       }])
     end

--- a/app/models/topic_search_indexer.rb
+++ b/app/models/topic_search_indexer.rb
@@ -12,7 +12,7 @@ class TopicSearchIndexer
       "indexable_content": topic.title + "\n\n" + topic.description,
       "title":             topic.title,
       "link":              topic.path,
-      "manual":            "service-manual",
+      "manual":            "/service-manual",
       "organisations":     ["government-digital-service"],
     }])
   end

--- a/spec/models/guide_search_indexer_spec.rb
+++ b/spec/models/guide_search_indexer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe GuideSearchIndexer, "#index" do
       indexable_content: "It's my published guide content",
       title:             "My guide",
       link:              "/service-manual/topic/some-slug",
-      manual:            "service-manual",
+      manual:            "/service-manual",
       organisations:     ["government-digital-service"]
     }])
 

--- a/spec/models/topic_search_indexer_spec.rb
+++ b/spec/models/topic_search_indexer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe TopicSearchIndexer do
       indexable_content: topic.title + "\n\n" + topic.description,
       title:             topic.title,
       link:              topic.path,
-      manual:            "service-manual",
+      manual:            "/service-manual",
       organisations:     ["government-digital-service"]
     }])
 


### PR DESCRIPTION
This ensures that we don't have to pass both values through to rummager
to get consistent search results.

This needs to be deployed alongside https://github.com/alphagov/design-principles/pull/260
Also, after that PR is deployed, we need to reindex content in elasticsearch.