### PR TITLE
Save the guide change summary and note

### DIFF
--- a/app/forms/guide_form.rb
+++ b/app/forms/guide_form.rb
@@ -38,6 +38,8 @@ class GuideForm
     guide.slug = slug
     edition.author_id = author_id
     edition.body = body
+    edition.change_note = change_note
+    edition.change_summary = change_summary
     edition.content_owner_id = content_owner_id
     edition.description = description
     edition.state = Edition::STATES.first

--- a/spec/forms/guide_form_spec.rb
+++ b/spec/forms/guide_form_spec.rb
@@ -194,6 +194,21 @@ RSpec.describe GuideForm, "#save" do
 
       expect(edition.author_id).to eq(5)
     end
+
+    it "assigns the changed note and summary to the edition" do
+      guide = Guide.new
+      edition = guide.editions.build
+      user = User.new
+      guide_form = described_class.new(guide: guide, edition: edition, user: user)
+      guide_form.assign_attributes(
+        change_summary: "X happened",
+        change_note: "This happened because of X.",
+        )
+      guide_form.save
+
+      expect(edition.change_summary).to eq("X happened")
+      expect(edition.change_note).to eq("This happened because of X.")
+    end
   end
 
   context "for a published guide" do


### PR DESCRIPTION
A bug appeared with the GuideForm that we weren't saving the change summary or change note.