### PR TITLE
Replace rummageable with gds api adapters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem 'active_link_to', '~> 1.0.3'
 gem 'select2-rails', '~> 4.0.0'
 gem 'diffy', '~> 3.0', '>= 3.0.7'
 gem 'redcarpet', '~> 3.3.3'
-gem 'rummageable', '1.2.0'
 gem 'auto_strip_attributes', '~> 2.0', '>= 2.0.6'
 gem 'rinku', '~> 1.7', '>= 1.7.3', require: "rails_rinku"
 gem 'acts_as_list', '~> 0.7.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,10 +258,6 @@ GEM
       rspec-mocks (~> 3.4.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
-    rummageable (1.2.0)
-      multi_json
-      null_logger
-      rest-client
     safe_yaml (1.0.4)
     sanitize (2.1.0)
       nokogiri (>= 1.4.4)
@@ -354,7 +350,6 @@ DEPENDENCIES
   redcarpet (~> 3.3.3)
   rinku (~> 1.7, >= 1.7.3)
   rspec-rails (~> 3.3)
-  rummageable (= 1.2.0)
   sass-rails (~> 5.0)
   select2-rails (~> 4.0.0)
   simplecov (= 0.10.0)

--- a/app/models/guide_search_indexer.rb
+++ b/app/models/guide_search_indexer.rb
@@ -8,16 +8,21 @@ class GuideSearchIndexer
     live_edition = guide.live_edition
 
     if live_edition
-      rummager_api.add_batch([{
-        "format":            "service_manual_guide",
-        "_type":             "service_manual_guide",
-        "description":       live_edition.description,
-        "indexable_content": live_edition.body,
-        "title":             live_edition.title,
-        "link":              guide.slug,
-        "manual":            "/service-manual",
-        "organisations":     ["government-digital-service"],
-      }])
+      type = "service_manual_guide"
+      id = guide.slug
+
+      rummager_api.add_document(
+        type,
+        id,
+        {
+          "format":            "service_manual_guide",
+          "description":       live_edition.description,
+          "indexable_content": live_edition.body,
+          "title":             live_edition.title,
+          "link":              guide.slug,
+          "manual":            "/service-manual",
+          "organisations":     ["government-digital-service"],
+        })
     end
   end
 

--- a/app/models/guide_search_indexer.rb
+++ b/app/models/guide_search_indexer.rb
@@ -1,14 +1,14 @@
 class GuideSearchIndexer
-  def initialize(guide, rummager_index: RUMMAGER_INDEX)
+  def initialize(guide, rummager_api: RUMMAGER_API)
     @guide = guide
-    @rummager_index = rummager_index
+    @rummager_api = rummager_api
   end
 
   def index
     live_edition = guide.live_edition
 
     if live_edition
-      rummager_index.add_batch([{
+      rummager_api.add_batch([{
         "format":            "service_manual_guide",
         "_type":             "service_manual_guide",
         "description":       live_edition.description,
@@ -22,11 +22,11 @@ class GuideSearchIndexer
   end
 
   def delete
-    rummager_index.delete(guide.slug)
+    rummager_api.delete_content!(guide.slug)
   end
 
 private
 
-  attr_reader :guide, :rummager_index
+  attr_reader :guide, :rummager_api
 
 end

--- a/app/models/topic_search_indexer.rb
+++ b/app/models/topic_search_indexer.rb
@@ -1,11 +1,11 @@
 class TopicSearchIndexer
-  def initialize(topic, rummager_index: RUMMAGER_INDEX)
+  def initialize(topic, rummager_api: RUMMAGER_API)
     @topic = topic
-    @rummager_index = rummager_index
+    @rummager_api = rummager_api
   end
 
   def index
-    rummager_index.add_batch([{
+    rummager_api.add_batch([{
       "format":            "service_manual_topic",
       "_type":             "service_manual_topic",
       "description":       topic.description,
@@ -19,6 +19,6 @@ class TopicSearchIndexer
 
 private
 
-  attr_reader :topic, :rummager_index
+  attr_reader :topic, :rummager_api
 
 end

--- a/app/models/topic_search_indexer.rb
+++ b/app/models/topic_search_indexer.rb
@@ -5,16 +5,22 @@ class TopicSearchIndexer
   end
 
   def index
-    rummager_api.add_batch([{
-      "format":            "service_manual_topic",
-      "_type":             "service_manual_topic",
-      "description":       topic.description,
-      "indexable_content": topic.title + "\n\n" + topic.description,
-      "title":             topic.title,
-      "link":              topic.path,
-      "manual":            "/service-manual",
-      "organisations":     ["government-digital-service"],
-    }])
+    type = "service_manual_topic"
+    id = topic.path
+
+    rummager_api.add_batch(
+      type,
+      id,
+      {
+        "format":            "service_manual_topic",
+        "description":       topic.description,
+        "indexable_content": topic.title + "\n\n" + topic.description,
+        "title":             topic.title,
+        "link":              topic.path,
+        "manual":            "/service-manual",
+        "organisations":     ["government-digital-service"],
+      }
+    )
   end
 
 private

--- a/config/initializers/rummager.rb
+++ b/config/initializers/rummager.rb
@@ -1,2 +1,4 @@
-RUMMAGER_INDEX =
-  Rummageable::Index.new(Plek.current.find('rummager'), '/mainstream')
+require 'gds_api/rummager'
+
+RUMMAGER_API =
+  GdsApi::Rummager.new(Plek.new.find("rummager"))

--- a/spec/controllers/guides_controller_spec.rb
+++ b/spec/controllers/guides_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe GuidesController, type: :controller do
 
     describe "#publish" do
       it 'notifies about search indexing errors but does not fail the transaction' do
-        expect_any_instance_of(Rummageable::Index).to receive(:add_batch).and_raise("Something went wrong")
+        expect_any_instance_of(GdsApi::Rummager).to receive(:add_document).and_raise("Something went wrong")
         edition = build(:edition, state: 'ready')
         guide = Guide.create!(slug: "/service-manual/topic-name/test", editions: [edition])
         expect(controller).to receive(:notify_airbrake)
@@ -42,7 +42,7 @@ RSpec.describe GuidesController, type: :controller do
       end
 
       it "sends an email notification when published by another user" do
-        allow_any_instance_of(Rummageable::Index).to receive(:add_batch)
+        allow_any_instance_of(GdsApi::Rummager).to receive(:add_document)
         edition = build(:edition, state: 'published')
         Guide.create!(slug: "/service-manual/topic-name/test", editions: [edition])
         publisher = build(:user, email: "ms.publisher@example.com")
@@ -56,7 +56,7 @@ RSpec.describe GuidesController, type: :controller do
       end
 
       it "avoids email notification when published by the author" do
-        allow_any_instance_of(Rummageable::Index).to receive(:add_batch)
+        allow_any_instance_of(GdsApi::Rummager).to receive(:add_document)
         edition = build(:edition, state: 'published')
         Guide.create!(slug: "/service-manual/topic-name/test", editions: [edition])
         allow_any_instance_of(Edition).to receive(:notification_subscribers).and_return([content_designer])

--- a/spec/models/guide_search_indexer_spec.rb
+++ b/spec/models/guide_search_indexer_spec.rb
@@ -10,16 +10,19 @@ RSpec.describe GuideSearchIndexer, "#index" do
                     )
     guide.editions << build(:edition, body: "I'm reconsidering this draft..")
 
-    expect(rummager_api).to receive(:add_batch).with([{
-      format:            "service_manual_guide",
-      _type:             "service_manual_guide",
-      description:       "Description",
-      indexable_content: "It's my published guide content",
-      title:             "My guide",
-      link:              "/service-manual/topic/some-slug",
-      manual:            "/service-manual",
-      organisations:     ["government-digital-service"]
-    }])
+    expect(rummager_api).to receive(:add_document).with(
+      "service_manual_guide",
+      "/service-manual/topic/some-slug",
+      {
+        format:            "service_manual_guide",
+        description:       "Description",
+        indexable_content: "It's my published guide content",
+        title:             "My guide",
+        link:              "/service-manual/topic/some-slug",
+        manual:            "/service-manual",
+        organisations:     ["government-digital-service"]
+      }
+    )
 
     described_class.new(guide, rummager_api: rummager_api).index
   end
@@ -28,7 +31,7 @@ RSpec.describe GuideSearchIndexer, "#index" do
     rummager_api = double(:rummager_api)
     guide = create(:guide)
 
-    expect(rummager_api).to_not receive(:add_batch)
+    expect(rummager_api).to_not receive(:add_document)
 
     described_class.new(guide, rummager_api: rummager_api).index
   end

--- a/spec/models/guide_search_indexer_spec.rb
+++ b/spec/models/guide_search_indexer_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe GuideSearchIndexer, "#index" do
   it "indexes a document in rummager for the live edition" do
-    rummager_index = double(:rummageable_index)
+    rummager_api = double(:rummager_api)
     guide = create(:published_guide,
                     title: "My guide",
                     body: "It's my published guide content",
@@ -10,7 +10,7 @@ RSpec.describe GuideSearchIndexer, "#index" do
                     )
     guide.editions << build(:edition, body: "I'm reconsidering this draft..")
 
-    expect(rummager_index).to receive(:add_batch).with([{
+    expect(rummager_api).to receive(:add_batch).with([{
       format:            "service_manual_guide",
       _type:             "service_manual_guide",
       description:       "Description",
@@ -21,26 +21,26 @@ RSpec.describe GuideSearchIndexer, "#index" do
       organisations:     ["government-digital-service"]
     }])
 
-    described_class.new(guide, rummager_index: rummager_index).index
+    described_class.new(guide, rummager_api: rummager_api).index
   end
 
   it "does not attempt to index a guide if it has no live editons" do
-    rummager_index = double(:rummageable_index)
+    rummager_api = double(:rummager_api)
     guide = create(:guide)
 
-    expect(rummager_index).to_not receive(:add_batch)
+    expect(rummager_api).to_not receive(:add_batch)
 
-    described_class.new(guide, rummager_index: rummager_index).index
+    described_class.new(guide, rummager_api: rummager_api).index
   end
 end
 
 RSpec.describe GuideSearchIndexer, "#delete" do
   it "deletes documents from rummager" do
-    rummager_index = double(:rummageable_index)
+    rummager_api = double(:rummager_api)
     guide = create(:guide, :with_draft_edition, slug: "/service-manual/topic/some-slug")
 
-    expect(rummager_index).to receive(:delete).with("/service-manual/topic/some-slug")
+    expect(rummager_api).to receive(:delete_content!).with("/service-manual/topic/some-slug")
 
-    described_class.new(guide, rummager_index: rummager_index).delete
+    described_class.new(guide, rummager_api: rummager_api).delete
   end
 end

--- a/spec/models/topic_search_indexer_spec.rb
+++ b/spec/models/topic_search_indexer_spec.rb
@@ -9,16 +9,19 @@ RSpec.describe TopicSearchIndexer do
       description: "The Topic Description",
     )
 
-    expect(rummager_api).to receive(:add_batch).with([{
-      format:            "service_manual_topic",
-      _type:             "service_manual_topic",
-      description:       topic.description,
-      indexable_content: topic.title + "\n\n" + topic.description,
-      title:             topic.title,
-      link:              topic.path,
-      manual:            "/service-manual",
-      organisations:     ["government-digital-service"]
-    }])
+    expect(rummager_api).to receive(:add_batch).with(
+      "service_manual_topic",
+      "/service-manual/topic1",
+      {
+        format:            "service_manual_topic",
+        description:       "The Topic Description",
+        indexable_content: "The Topic Title\n\nThe Topic Description",
+        title:             "The Topic Title",
+        link:              "/service-manual/topic1",
+        manual:            "/service-manual",
+        organisations:     ["government-digital-service"]
+      }
+    )
 
 
     described_class.new(topic, rummager_api: rummager_api).index

--- a/spec/models/topic_search_indexer_spec.rb
+++ b/spec/models/topic_search_indexer_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 RSpec.describe TopicSearchIndexer do
   it "indexes topics in rummager" do
-    rummager_index = double(:rummager_index)
+    rummager_api = double(:rummager_api)
     topic = Topic.create!(
       path: "/service-manual/topic1",
       title: "The Topic Title",
       description: "The Topic Description",
     )
 
-    expect(rummager_index).to receive(:add_batch).with([{
+    expect(rummager_api).to receive(:add_batch).with([{
       format:            "service_manual_topic",
       _type:             "service_manual_topic",
       description:       topic.description,
@@ -20,6 +20,7 @@ RSpec.describe TopicSearchIndexer do
       organisations:     ["government-digital-service"]
     }])
 
-    described_class.new(topic, rummager_index: rummager_index).index
+
+    described_class.new(topic, rummager_api: rummager_api).index
   end
 end


### PR DESCRIPTION
Deleting a document from rummager wasn't working with Rummageable because it was impossible to delete a document with a type other than `edition` or `best_bet`.

Rummageable is a deprecated thing and so we switch to using gds-api-adapaters.