### PR TITLE
Remove strong params from guide controller

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -143,7 +143,7 @@ private
   end
 
   def guide_form_params
-    params.require(:guide).permit!
+    params.fetch(:guide, {})
   end
 
   def index_for_search(guide)


### PR DESCRIPTION
At the moment it doesn't matter whether we use strong params or not for the guide controller because we're not doing mass assignment. But if we start we might accidentally let something through. Better to avoid strong params so we will get an error if/when we start mass assigning.