### PR TITLE
Remove the filename from the failed upload alert

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -4,7 +4,9 @@ class UploadsController < ApplicationController
       format.js do
         file = params[:file]
         unless file.content_type.start_with?("image")
-          return render text: "The file '#{file.original_filename}' that you're trying to upload does not seem to be an image", status: :unprocessable_entity
+          render text: "The file that you're trying to upload does not seem "\
+            "to be an image", status: :unprocessable_entity
+          return
         end
 
         begin


### PR DESCRIPTION
There was a small risk of rendering unsanitized input and having the filename in the alert wasn't a huge benefit as the user will know which file they have just tried to upload.