### PR TITLE
Fix diff links

### DIFF
--- a/app/views/editions/index.html.erb
+++ b/app/views/editions/index.html.erb
@@ -5,7 +5,8 @@
   <%= render 'editions/actions', publish_controls_only: true, form: f, guide: @guide, edition: @current_edition %>
 <% end %>
 
-<% @latest_edition_per_edition_group.each do |latest_edition_of_group| %>
+<% @latest_edition_per_edition_group.each.with_index do |latest_edition_of_group, index| %>
+  <% previous_latest_edition_of_group = @latest_edition_per_edition_group[index + 1] %>
   <% if latest_edition_of_group == @current_edition %>
     <div class="panel-edition open-edition panel panel-default">
       <div class="panel-heading">
@@ -29,7 +30,7 @@
           <% end %>
         </span>
         <div class="pull-right">
-          <%= link_to "View changes", edition_changes_path(latest_edition_of_group) %>
+          <%= link_to "View changes", edition_changes_path(previous_latest_edition_of_group, latest_edition_of_group) %>
         </div>
       </div>
       <div class="panel-body">

--- a/spec/features/guide_history_spec.rb
+++ b/spec/features/guide_history_spec.rb
@@ -3,15 +3,46 @@ require 'rails_helper'
 RSpec.describe "Guide history", type: :feature do
   include ActiveSupport::Testing::TimeHelpers
 
-  before do
-    topic = create(:topic)
-    create(:topic_section, topic: topic)
+  it "shows a history of the latest edition" do
+    stub_publisher
+    create(:topic_section, topic: create(:topic))
+    community = create(:guide_community)
+
+    travel_to "2004-11-24".to_time do
+      visit root_path
+      click_on "Create a Guide"
+      fill_in_final_url "/service-manual/the/path"
+      select TopicSection.first.title, from: "Topic section"
+      select community.title, from: "Community"
+      fill_in "Description", with: "This guide acts as a test case"
+      fill_in "Title", with: "First Edition Title"
+      fill_in "Body", with: "## First Edition Title"
+
+      click_first_button "Save"
+    end
+
+    travel_to "2004-11-25".to_time do
+      click_on "Comments and history"
+
+      within ".open-edition" do
+        fill_in "Add new comment", with: "What a great piece of writing"
+        click_button "Save comment"
+      end
+    end
+
+    travel_to "2004-11-26".to_time do
+      click_first_button "Send for review"
+    end
+
+    click_on "Comments and history"
+
+    expect(events[0].text).to eq "26 November 2004 Review requested by Stub User"
+    expect(events[1].text).to include "25 November 2004 Stub User What a great piece of writing"
+    expect(events[2].text).to eq "24 November 2004 Assigned to Stub User"
+    expect(events[3].text).to eq "24 November 2004 New draft created by Stub User"
   end
 
   it "shows a header with pertinent edition information" do
-    stub_publisher
-    create_guide_community
-
     guide = create(:published_guide)
     published_edition = guide.editions.find_by(state: "published")
     published_edition.update_attribute(:updated_at, "2004-11-24".to_time)
@@ -40,75 +71,6 @@ RSpec.describe "Guide history", type: :feature do
     end
   end
 
-  it "shows a history of the latest edition" do
-    stub_publisher
-    create_guide_community
-
-    travel_to "2004-11-24".to_time do
-      visit root_path
-      click_on "Create a Guide"
-      fill_out_new_guide_fields
-      click_first_button "Save"
-    end
-
-    travel_to "2004-11-25".to_time do
-      click_on "Comments and history"
-
-      within ".open-edition" do
-        fill_in "Add new comment", with: "What a great piece of writing"
-        click_button "Save comment"
-      end
-    end
-
-    travel_to "2004-11-26".to_time do
-      click_first_button "Send for review"
-    end
-
-    click_on "Comments and history"
-
-    expect(events.first).to eq "24 November 2004 New draft created by Stub User"
-    expect(events.second).to eq "24 November 2004 Assigned to Stub User"
-    expect(events.third).to include "25 November 2004 Stub User What a great piece of writing"
-    expect(events.fourth).to eq "26 November 2004 Review requested by Stub User"
-  end
-
-  def stub_publisher
-    publishing_api = double(:publishing_api)
-    stub_const("PUBLISHING_API", publishing_api)
-    allow(publishing_api).to receive(:put_content)
-                            .with(an_instance_of(String), be_valid_against_schema('service_manual_guide'))
-    allow(publishing_api).to receive(:patch_links)
-                            .with(an_instance_of(String), an_instance_of(Hash))
-  end
-
-  def create_guide_community
-    @community = create(:guide_community)
-  end
-
-  def fill_out_new_guide_fields
-    fill_in_final_url "/service-manual/the/path"
-    select TopicSection.first.title, from: "Topic section"
-    select @community.title, from: "Community"
-    fill_in "Description", with: "This guide acts as a test case"
-
-    fill_in "Title", with: "First Edition Title"
-    fill_in "Body", with: "## First Edition Title"
-    select Topic
-  end
-
-  def within_edition(number, &block)
-    within(:xpath, "//div[contains(@class, 'panel') and div[contains(@class, 'panel-heading') and contains(., 'Edition ##{number}')]]", &block)
-  end
-
-  def events
-    all(".event")
-      .map(&:text)
-      .reverse
-  end
-end
-
-
-RSpec.describe "Guide history", type: :feature do
   scenario "viewing previous editions" do
     guide = create(:published_guide)
     guide.editions << build(:edition, version: 2)
@@ -116,7 +78,7 @@ RSpec.describe "Guide history", type: :feature do
     visit guide_editions_path(guide)
 
     within_edition(1) do
-      expect(events_visible).to be_empty
+      expect(events).to be_empty
     end
     within_edition(2) do
       expect(page).to have_css(".event", text: "New draft created")
@@ -128,7 +90,7 @@ RSpec.describe "Guide history", type: :feature do
       expect(page).to have_css(".event", text: "New draft created")
     end
     within_edition(2) do
-      expect(events_visible).to be_empty
+      expect(events).to be_empty
     end
   end
 
@@ -136,7 +98,16 @@ RSpec.describe "Guide history", type: :feature do
     within(:xpath, "//div[contains(@class, 'panel') and div[contains(@class, 'panel-heading') and contains(., 'Edition ##{number}')]]", &block)
   end
 
-  def events_visible
+  def events
     all(".event")
+  end
+
+  def stub_publisher
+    publishing_api = double(:publishing_api)
+    stub_const("PUBLISHING_API", publishing_api)
+    allow(publishing_api).to receive(:put_content)
+                            .with(an_instance_of(String), be_valid_against_schema('service_manual_guide'))
+    allow(publishing_api).to receive(:patch_links)
+                            .with(an_instance_of(String), an_instance_of(Hash))
   end
 end

--- a/spec/features/guide_history_spec.rb
+++ b/spec/features/guide_history_spec.rb
@@ -95,7 +95,12 @@ RSpec.describe "Guide history", type: :feature do
   end
 
   def within_edition(number, &block)
-    within(:xpath, "//div[contains(@class, 'panel') and div[contains(@class, 'panel-heading') and contains(., 'Edition ##{number}')]]", &block)
+    within(:xpath, "//div
+                        [contains(@class, 'panel')]
+                        [div
+                          [contains(@class, 'panel-heading')]
+                          [contains(., 'Edition ##{number}')]
+                        ]", &block)
   end
 
   def events


### PR DESCRIPTION
https://trello.com/c/W65pPhg1

The compare link only contained one edition. The route needs two editions to compare them.