### PR TITLE
Update #add_batch to #add_document for Topic indexer

### DIFF
--- a/app/models/topic_search_indexer.rb
+++ b/app/models/topic_search_indexer.rb
@@ -8,7 +8,7 @@ class TopicSearchIndexer
     type = "service_manual_topic"
     id = topic.path
 
-    rummager_api.add_batch(
+    rummager_api.add_document(
       type,
       id,
       {

--- a/spec/models/topic_search_indexer_spec.rb
+++ b/spec/models/topic_search_indexer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe TopicSearchIndexer do
       description: "The Topic Description",
     )
 
-    expect(rummager_api).to receive(:add_batch).with(
+    expect(rummager_api).to receive(:add_document).with(
       "service_manual_topic",
       "/service-manual/topic1",
       {


### PR DESCRIPTION
This method wasn't updated to use the method name from gds api adapters from the rummageable version.