### PR TITLE
Allow multi-line comments

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,4 +6,5 @@
 @import 'edition-actions';
 @import 'topics';
 @import 'guide-history';
+@import 'comments';
 @import 'dragula.min';

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -1,0 +1,6 @@
+.event.comment {
+  .comment-body {
+    // http://stackoverflow.com/questions/9492249/render-a-string-in-html-and-preserve-spaces-and-newlines
+    white-space: pre-wrap;
+  }
+}

--- a/app/views/editions/edition_thread/_comment_event.html.erb
+++ b/app/views/editions/edition_thread/_comment_event.html.erb
@@ -6,6 +6,6 @@
     <%= event.comment.user.name %>
   </div>
   <div class="panel-body">
-    <%= auto_link(event.comment.comment, :all, target: "_blank") %>
+    <div class="comment-body"><%= auto_link(event.comment.comment, :all, target: "_blank") %></div>
   </div>
 </div>


### PR DESCRIPTION
Store the contents as non-html string, but when rendering preserve new
lines.