### PR TITLE
Just delete the duplicated technology topic

### DIFF
--- a/lib/tasks/delete_duplicate_technology_topic.rake
+++ b/lib/tasks/delete_duplicate_technology_topic.rake
@@ -1,0 +1,7 @@
+desc "Delete the duplicated technology topic"
+task delete_duplicated_technology_topic: :environment do
+  topic = Topic.find_by(id: 16, path: "/service-manual/technology")
+  if topic && topic.topic_sections.empty?
+    topic.destroy
+  end
+end


### PR DESCRIPTION
This will leave the topic content item in the publishing-api but we have a bunch of these. We'll address removing them at a later date.