### PR TITLE
Topic path should be unique

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -2,6 +2,7 @@ class Topic < ActiveRecord::Base
   include ContentIdentifiable
   validate :path_can_be_set_once
   validate :path_format
+  validates :path, uniqueness: true
 
   has_many :topic_sections, -> { order(position: :asc) }
   accepts_nested_attributes_for :topic_sections, allow_destroy: true

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -174,12 +174,14 @@ RSpec.describe "creating guides", type: :feature do
     end
 
     it "shows the summary of validation errors" do
+      topic = create(:topic, path: "/service-manual/technology")
+      topic_section = create(:topic_section, topic: topic)
       guide = create(
         :guide,
-        :with_topic_section,
         slug: "/service-manual/topic-name/something",
         editions: [ build(:edition) ],
       )
+      topic_section.guides << guide
       visit edit_guide_path(guide)
       fill_in "Title", with: ""
       click_first_button "Save"

--- a/spec/forms/guide_form_spec.rb
+++ b/spec/forms/guide_form_spec.rb
@@ -296,9 +296,9 @@ RSpec.describe GuideForm, "#save" do
     end
 
     it "isn't possible to change the topic" do
-      original_topic = create(:topic)
+      original_topic = create(:topic, path: "/service-manual/original-topic")
       original_topic_section = create(:topic_section, topic: original_topic)
-      different_topic = create(:topic)
+      different_topic = create(:topic, path: "/service-manual/different-topic")
       different_topic_section = create(:topic_section, topic: different_topic)
       user = create(:user)
       guide = create(:published_guide)

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -26,6 +26,16 @@ RSpec.describe Topic do
     expect(topic.errors.full_messages_for(:path)).to eq ["Path can only contain letters, numbers and dashes"]
   end
 
+  it "has a unique path" do
+    create(:topic, path: "/service-manual/nice-topic")
+    topic = build(:topic, path: "/service-manual/nice-topic")
+    topic.valid?
+
+    expect(
+      topic.errors.full_messages_for(:path)
+      ).to include("Path has already been taken")
+  end
+
   describe "on create callbacks" do
     it "generates and sets content_id" do
       topic = build(:topic, content_id: nil)


### PR DESCRIPTION
We recently created a topic with a duplicate path which has left a 'detached' content item in the publishing-api until we develop the topic editior to be able to clean it up. We want to avoid doing more of that for the moment.