### PR TITLE
"View changes" links for past versions should have a valid diff link

### DIFF
--- a/app/views/editions/_edition.html.erb
+++ b/app/views/editions/_edition.html.erb
@@ -1,0 +1,45 @@
+<div class="panel-edition <% if is_open -%>open-edition<% end -%> panel panel-default">
+  <div class="panel-heading">
+    <span class="glyphicon glyphicon-chevron-down"></span>
+
+    <span class="panel-heading-part">
+      <% if is_open %>
+        Edition #<%= latest_edition_of_group.version %>
+      <% else %>
+        <%= link_to "Edition ##{latest_edition_of_group.version}", guide_editions_path(@guide, current_edition: latest_edition_of_group) %>
+      <% end %>
+    </span>
+
+    <span class="panel-heading-part">
+      <%= latest_edition_of_group.update_type.titlecase %> update
+    </span>
+
+    <span class="panel-heading-part">
+      <% if latest_edition_of_group.published? %>
+        Published on <%= l latest_edition_of_group.updated_at, format: :date_without_time %>
+      <% else %>
+        Not yet published
+      <% end %>
+    </span>
+
+    <span class="panel-heading-part">
+      <% if latest_edition_of_group.major? %>
+        "<%= latest_edition_of_group.change_summary %>"
+      <% end %>
+    </span>
+
+    <div class="pull-right">
+      <%= link_to "View changes", edition_changes_path(previous_latest_edition_of_group, latest_edition_of_group) %>
+    </div>
+  </div>
+
+  <% if is_open %>
+    <div class="panel-body">
+      <%= render 'comment_form', comment: comment, edition: latest_edition_of_group %>
+
+      <% EditionThread.new(latest_edition_of_group).events.reverse.each do |event| %>
+        <%= render "editions/#{event.class.to_s.underscore}", event: event %>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/editions/index.html.erb
+++ b/app/views/editions/index.html.erb
@@ -64,7 +64,11 @@
           <% end %>
         </span>
         <div class="pull-right">
-          <%= link_to "View changes", edition_changes_path(latest_edition_of_group) %>
+          <% if previous_latest_edition_of_group.present? %>
+            <%= link_to "View changes", edition_changes_path(latest_edition_of_group, previous_latest_edition_of_group) %>
+          <% else %>
+            <%= link_to "View changes", edition_changes_path(latest_edition_of_group) %>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/editions/index.html.erb
+++ b/app/views/editions/index.html.erb
@@ -7,68 +7,13 @@
 
 <% @latest_edition_per_edition_group.each.with_index do |latest_edition_of_group, index| %>
   <% previous_latest_edition_of_group = @latest_edition_per_edition_group[index + 1] %>
-  <% if latest_edition_of_group == @current_edition %>
-    <div class="panel-edition open-edition panel panel-default">
-      <div class="panel-heading">
-        <span class="glyphicon glyphicon-chevron-down"></span>
-        <span class="panel-heading-part">
-          Edition #<%= latest_edition_of_group.version %>
-        </span>
-        <span class="panel-heading-part">
-          <%= latest_edition_of_group.update_type.titlecase %> update
-        </span>
-        <span class="panel-heading-part">
-          <% if latest_edition_of_group.published? %>
-            Published on <%= l latest_edition_of_group.updated_at, format: :date_without_time %>
-          <% else %>
-            Not yet published
-          <% end %>
-        </span>
-        <span class="panel-heading-part">
-          <% if latest_edition_of_group.major? %>
-            "<%=latest_edition_of_group.change_summary%>"
-          <% end %>
-        </span>
-        <div class="pull-right">
-          <%= link_to "View changes", edition_changes_path(previous_latest_edition_of_group, latest_edition_of_group) %>
-        </div>
-      </div>
-      <div class="panel-body">
-        <%= render 'comment_form', comment: @comment, edition: latest_edition_of_group %>
 
-        <% EditionThread.new(latest_edition_of_group).events.reverse.each do |event| %>
-          <%= render "editions/#{event.class.to_s.underscore}", event: event %>
-        <% end %>
-      </div>
-    </div>
-  <% else %>
-    <div class="panel-edition panel panel-default">
-      <div class="panel-heading">
-        <span class="glyphicon glyphicon-chevron-right"></span>
-        <span class="panel-heading-part">
-          <%= link_to "Edition ##{latest_edition_of_group.version}", guide_editions_path(@guide, current_edition: latest_edition_of_group) %>
-        </span>
-        <span class="panel-heading-part">
-          <%= latest_edition_of_group.update_type.titlecase %> update
-        </span>
-        <span class="panel-heading-part">
-          <% if latest_edition_of_group.published? %>
-            Published on <%= l latest_edition_of_group.updated_at, format: :date_without_time %>
-          <% else %>
-            Not yet published
-          <% end %>
-        </span>
-        <span class="panel-heading-part">
-          <% if latest_edition_of_group.major? %>
-            "<%=latest_edition_of_group.change_summary%>"
-          <% end %>
-        </span>
-        <div class="pull-right">
-          <%= link_to "View changes", edition_changes_path(previous_latest_edition_of_group, latest_edition_of_group) %>
-        </div>
-      </div>
-    </div>
-  <% end %>
+  <%= render 'edition',
+        is_open: latest_edition_of_group == @current_edition,
+        latest_edition_of_group: latest_edition_of_group,
+        previous_latest_edition_of_group: previous_latest_edition_of_group,
+        comment: @comment
+  %>
 <% end %>
 
 <%= guide_form_for @guide do |f| %>

--- a/app/views/editions/index.html.erb
+++ b/app/views/editions/index.html.erb
@@ -64,11 +64,7 @@
           <% end %>
         </span>
         <div class="pull-right">
-          <% if previous_latest_edition_of_group.present? %>
-            <%= link_to "View changes", edition_changes_path(latest_edition_of_group, previous_latest_edition_of_group) %>
-          <% else %>
-            <%= link_to "View changes", edition_changes_path(latest_edition_of_group) %>
-          <% end %>
+          <%= link_to "View changes", edition_changes_path(previous_latest_edition_of_group, latest_edition_of_group) %>
         </div>
       </div>
     </div>

--- a/spec/features/guide_history_spec.rb
+++ b/spec/features/guide_history_spec.rb
@@ -44,21 +44,33 @@ RSpec.describe "Guide history", type: :feature do
 
   it "shows a header with pertinent edition information" do
     guide = create(:published_guide)
-    published_edition = guide.editions.find_by(state: "published")
-    published_edition.update_attribute(:updated_at, "2004-11-24".to_time)
-    draft_edition = build(:edition, version: 2, update_type: "minor")
+    first_published_edition = guide.editions.find_by(state: "published")
+    first_published_edition.update_attribute(:updated_at, "2004-11-24".to_time)
+
+    second_published_edition = build(:edition, version: 2, update_type: "minor", state: "published", updated_at: "2004-11-25".to_time)
+    guide.editions << second_published_edition
+
+    draft_edition = build(:edition, version: 3, update_type: "minor")
     guide.editions << draft_edition
 
     visit edit_guide_path(guide)
 
     click_on "Comments and history"
 
-    within_edition(2) do
-      expect(page).to have_content("Edition #2")
+    within_edition(3) do
+      expect(page).to have_content("Edition #3")
       expect(page).to have_content("Minor update")
       expect(page).to have_content("Not yet published")
       # A link that compares this version to the previous version
-      expect(page).to have_link("View changes", href: edition_changes_path(published_edition, draft_edition))
+      expect(page).to have_link("View changes", href: edition_changes_path(second_published_edition, draft_edition))
+    end
+
+    within_edition(2) do
+      expect(page).to have_content("Edition #2")
+      expect(page).to have_content("Minor update")
+      expect(page).to have_content("Published on 25 November 2004")
+      # A link that compares this version to the previous version
+      expect(page).to have_link("View changes", href: edition_changes_path(first_published_edition, second_published_edition))
     end
 
     within_edition(1) do
@@ -67,7 +79,7 @@ RSpec.describe "Guide history", type: :feature do
       expect(page).to have_content("Published on 24 November 2004")
       expect(page).to have_content('"change summary"')
       # A link that shows one large addition for the first version
-      expect(page).to have_link("View changes", href: edition_changes_path(nil, published_edition))
+      expect(page).to have_link("View changes", href: edition_changes_path(nil, first_published_edition))
     end
   end
 


### PR DESCRIPTION
We were only showing a diff link for the latest version on the history tab.

Here we link to valid diffs for all versions and also remove the branching in the template which probably contributed to this bug slipping through the cracks.