### PR TITLE
Tag all content to GDS in publishing-api

### DIFF
--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -30,7 +30,9 @@ class GuidePresenter
   end
 
   def links_payload
-    links = {}
+    links = {
+      organisations: [ServiceManualPublisher::GDS_ORGANISATION_CONTENT_ID],
+    }
 
     if edition.content_owner
       links[:content_owners] = [ edition.content_owner.content_id ]

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -34,6 +34,7 @@ class TopicPresenter
       links: {
         linked_items: topic.guides.map(&:content_id),
         content_owners: content_owner_content_ids,
+        organisations: [ServiceManualPublisher::GDS_ORGANISATION_CONTENT_ID],
       }
     }
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,8 @@ require "sprockets/railtie"
 Bundler.require(*Rails.groups)
 
 module ServiceManualPublisher
+  GDS_ORGANISATION_CONTENT_ID = 'af07d5a5-df63-4ddc-9383-6a666845ebe9'
+
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/spec/presenters/guide_presenter_spec.rb
+++ b/spec/presenters/guide_presenter_spec.rb
@@ -81,6 +81,12 @@ RSpec.describe GuidePresenter do
   end
 
   describe '#links_payload' do
+    it "includes an organisation" do
+      expect(
+        presenter.links_payload[:links][:organisations]
+        ).to match_array([ an_instance_of(String) ])
+    end
+
     it 'returns an empty hash without a content owner' do
       expect(presenter.links_payload[:links][:content_owners]).to be_nil
     end

--- a/spec/presenters/guide_presenter_spec.rb
+++ b/spec/presenters/guide_presenter_spec.rb
@@ -82,16 +82,14 @@ RSpec.describe GuidePresenter do
 
   describe '#links_payload' do
     it 'returns an empty hash without a content owner' do
-      expect(presenter.links_payload).to eq({links: {}})
+      expect(presenter.links_payload[:links][:content_owners]).to be_nil
     end
 
     it 'returns the content owner if present' do
       edition.content_owner = build(:guide_community)
-      expect(presenter.links_payload).to eq({
-        links: {
-          content_owners: [edition.content_owner.content_id]
-        }
-      })
+      expect(presenter.links_payload[:links][:content_owners]).to eq(
+        [edition.content_owner.content_id]
+      )
     end
   end
 end

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -68,6 +68,18 @@ RSpec.describe TopicPresenter do
 end
 
 RSpec.describe TopicPresenter, "#links_payload" do
+  it "includes an organisation" do
+    guide1 = create(:guide, :with_draft_edition)
+    topic = create_topic_in_groups([[guide1]])
+    presented_topic = TopicPresenter.new(topic)
+
+    links = presented_topic.links_payload[:links]
+
+    expect(
+      presented_topic.links_payload[:links][:organisations]
+      ).to match_array([ an_instance_of(String) ])
+  end
+
   it "references all content_ids that appear in groups" do
     guide1 = create(:guide, :with_draft_edition)
     guide2 = create(:guide, :with_draft_edition)


### PR DESCRIPTION
This app currently [tags all content to the GDS org in Rummager](https://github.com/alphagov/service-manual-publisher/blob/f434aa0aa2671
3e829c93b838031dc0abfd2fe25/app/models/guide_search_indexer.rb#L24).

In the near future, Rummager will start indexing the `links` hash from the publishing-api. This means that we should start sending the `organisations` tagging to publishing-api too, so that rummager can copy this.

When we turn on the links-indexing the `organisations` tagging can be removed from the rummager payload.

https://trello.com/c/2PX73XvD

