### PR TITLE
Set x_govuk_authenticated_user header...

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,9 +5,16 @@ class ApplicationController < ActionController::Base
 
   include GDS::SSO::ControllerMethods
   before_filter :require_signin_permission!
+  before_filter :set_authenticated_user_header
 
   def preview_content_model_url(content_model)
     [Plek.find('draft-origin'), content_model.slug].join('')
   end
   helper_method :preview_content_model_url
+
+  def set_authenticated_user_header
+    if current_user && GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user].nil?
+      GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, current_user.uid)
+    end
+  end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -12,5 +12,13 @@ RSpec.describe ApplicationController do
       expect(controller).to receive(:require_signin_permission!).and_return(true)
       get :index
     end
+
+    it "should set the authenticated user uid as a GdsApi::GovukHeader" do
+      user = double(:user, uid: "12345-67890", remotely_signed_out?: false, has_permission?: true)
+      login_as(user)
+
+      get :index
+      expect(GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user]).to eq("12345-67890")
+    end
   end
 end


### PR DESCRIPTION
https://trello.com/c/6nDCqZXi/729-user-id-into-event-log
The publishing API event log should have a reference to the authenticated user
so ensure that the appropriate GdsApi::GovukHeaders header is set to meet expectations
of the publishing API event logging.