### PR TITLE
Rename `topics` to `service_manual_topics` in guide links payload

### DIFF
--- a/app/models/guide_tagger_job.rb
+++ b/app/models/guide_tagger_job.rb
@@ -8,12 +8,9 @@ class GuideTaggerJob < ActiveJob::Base
   end
 
   def perform(guide_content_id:, topic_content_id:)
-    publishing_api.patch_links(guide_content_id, links: { topics: [topic_content_id] })
-  end
-
-private
-
-  def publishing_api
-    PUBLISHING_API
+    PUBLISHING_API.patch_links(
+      guide_content_id,
+      links: { service_manual_topics: [ topic_content_id ] }
+      )
   end
 end

--- a/spec/models/guide_tagger_job_spec.rb
+++ b/spec/models/guide_tagger_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe GuideTaggerJob do
         expect(api_double).to receive(:patch_links)
           .with(
             guide_content_id,
-            links: { topics: [topic.content_id] },
+            links: { service_manual_topics: [topic.content_id] },
           )
       end
 


### PR DESCRIPTION
`topics` is a reserved field for actual topics. Our service_manual_topic is a separate format which happens to share the same name.