### PR TITLE
Delete the `topics` field from guide links

### DIFF
--- a/app/models/guide_tagger_job.rb
+++ b/app/models/guide_tagger_job.rb
@@ -10,7 +10,7 @@ class GuideTaggerJob < ActiveJob::Base
   def perform(guide_content_id:, topic_content_id:)
     PUBLISHING_API.patch_links(
       guide_content_id,
-      links: { service_manual_topics: [ topic_content_id ] }
+      links: { service_manual_topics: [ topic_content_id ], topics: [] }
       )
   end
 end

--- a/spec/models/guide_tagger_job_spec.rb
+++ b/spec/models/guide_tagger_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe GuideTaggerJob do
         expect(api_double).to receive(:patch_links)
           .with(
             guide_content_id,
-            links: { service_manual_topics: [topic.content_id] },
+            links: { service_manual_topics: [topic.content_id], topics: [] },
           )
       end
 


### PR DESCRIPTION
This should be removed after we're republished.