### PR TITLE
Present multiline comments correctly in HTML emails

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,5 +6,4 @@
 @import 'edition-actions';
 @import 'topics';
 @import 'guide-history';
-@import 'comments';
 @import 'dragula.min';

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -1,6 +1,0 @@
-.event.comment {
-  .comment-body {
-    // http://stackoverflow.com/questions/9492249/render-a-string-in-html-and-preserve-spaces-and-newlines
-    white-space: pre-wrap;
-  }
-}

--- a/app/views/editions/edition_thread/_comment_event.html.erb
+++ b/app/views/editions/edition_thread/_comment_event.html.erb
@@ -6,6 +6,6 @@
     <%= event.comment.user.name %>
   </div>
   <div class="panel-body">
-    <div class="comment-body"><%= auto_link(event.comment.comment, :all, target: "_blank") %></div>
+    <%= auto_link(event.comment.comment, :all, target: "_blank") %>
   </div>
 </div>

--- a/app/views/editions/edition_thread/_comment_event.html.erb
+++ b/app/views/editions/edition_thread/_comment_event.html.erb
@@ -6,6 +6,6 @@
     <%= event.comment.user.name %>
   </div>
   <div class="panel-body">
-    <%= auto_link(event.comment.comment, :all, target: "_blank") %>
+    <%= auto_link(simple_format(event.comment.comment), :all, target: "_blank") %>
   </div>
 </div>

--- a/app/views/notification_mailer/comment_added.html.erb
+++ b/app/views/notification_mailer/comment_added.html.erb
@@ -5,7 +5,7 @@
 </p>
 
 <blockquote>
-  <%= simple_format(@comment.comment) %>
+  <%= auto_link(simple_format(@comment.comment), :all) %>
 </blockquote>
 
 <p>

--- a/app/views/notification_mailer/comment_added.html.erb
+++ b/app/views/notification_mailer/comment_added.html.erb
@@ -5,7 +5,7 @@
 </p>
 
 <blockquote>
-  <%= @comment.comment %>
+  <%= simple_format(@comment.comment) %>
 </blockquote>
 
 <p>

--- a/spec/features/comments_spec.rb
+++ b/spec/features/comments_spec.rb
@@ -30,6 +30,24 @@ RSpec.describe "Commenting", type: :feature do
         expect(page).to have_link "http://google.com", href: "http://google.com"
       end
     end
+
+    it "presents multi line comments correctly" do
+      guide = create(:guide, :with_draft_edition)
+
+      comment_text = %{This guide sure could use more cow bell.
+Cow bell makes everything better!
+
+Much better.}
+      formatted_comment = %{<p>This guide sure could use more cow bell.
+<br>Cow bell makes everything better!</p>
+
+<p>Much better.</p>}
+
+      write_a_comment(guide: guide, comment: comment_text)
+
+      comment_html = find('.comment').native.inner_html
+      expect(comment_html).to include formatted_comment
+    end
   end
 
   describe 'for a guide community' do

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -26,6 +26,29 @@ RSpec.describe NotificationMailer, type: :mailer do
         expect(part.body.to_s).to include "guides/#{guide.id}/editions"
       end
     end
+
+    it "presents multi line comments correctly" do
+      comment_text = %{This guide sure could use more cow bell.
+Cow bell makes everything better!
+
+Much better.}
+      formatted_comment = %{<p>This guide sure could use more cow bell.
+<br />Cow bell makes everything better!</p>
+
+<p>Much better.</p>}
+
+      comment = edition.comments.create!(comment: comment_text, user: luke)
+
+      email = NotificationMailer.comment_added(comment).deliver_now
+
+      # The HTML part of the email should include the comment wrapped in
+      # paragraph tags and using line breaks
+      expect(email.html_part.body.to_s).to include formatted_comment
+
+      # The text part of the email should include the comment with normal
+      # whitespace.
+      expect(email.text_part.body.to_s).to include comment_text
+    end
   end
 
   describe "#ready_for_publishing" do


### PR DESCRIPTION
Use simple_format to automatically wrap comment text in paragraph tags / use line breaks in the HTML part of new comment notifications