### PR TITLE
Service standard

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,4 +4,4 @@
 require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
-task default: "jasmine:ci"
+task default: ["jasmine:ci", "lint"]

--- a/app/assets/javascripts/slug-generation.js
+++ b/app/assets/javascripts/slug-generation.js
@@ -13,8 +13,6 @@ $(function() {
   var hasBeenPublished = $form.data("has-been-published");
   var titleSlugManuallyChanged = false;
 
-  generateSlug();
-
   $(document).on("input", ".js-title-slug", function() {
     titleSlugManuallyChanged = true;
     generateSlug();

--- a/app/assets/javascripts/slug-generation.js
+++ b/app/assets/javascripts/slug-generation.js
@@ -29,26 +29,43 @@ $(function() {
       return;
     }
 
-    // If a user has manually changed the slug, then we don't generate
-    // it from the title anymore.
+    // Update the title slug field as long as it hasn't been manually edited yet
     if (!titleSlugManuallyChanged) {
-      $titleSlug.val(slugify($title.val()));
+      $titleSlug.val(slugifiedGuideTitle());
     }
 
     var slug = "";
-
-    // We get the first part of the full from the chosen topic sections' topic.
-    // This will be in the format /service-manual/topic-path
-    var topicPath = $topicSection.find(":selected").parent().data("path");
-    if (!topicPath) { return }
-    slug += topicPath + "/";
-
-    // Now add whatever title slug was generated (or manually entered by user)
-    // to the full slug.
-    if (!$titleSlug.val()) { return }
-    slug += slugify($titleSlug.val())
+    slug += slugPrefix();
+    slug += topicSectionPathIfPresent();
+    slug += "/" + slugifiedSlugTitle();
 
     $slug.val(slug);
+  }
+
+  function topicSectionPathIfPresent() {
+    var $topicSection = $(".js-topic-section");
+
+    if ($topicSection.length) {
+      var selectedParent = $topicSection.find(":selected").parent('optgroup');
+
+      if (selectedParent.length) {
+        return selectedParent.data("path");
+      }
+    }
+
+    return "";
+  }
+
+  function slugPrefix() {
+    return $form.data("slug-prefix");
+  }
+
+  function slugifiedGuideTitle() {
+    return slugify($title.val());
+  }
+
+  function slugifiedSlugTitle() {
+    return slugify($titleSlug.val());
   }
 
   function slugify(text) {

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -8,7 +8,7 @@ class GuidesController < ApplicationController
     type = params[:type].presence_in(%w{ GuideCommunity Point })
     guide = Guide.new(type: type)
 
-    @guide_form = GuideForm.new(
+    @guide_form = GuideForm.build(
       guide: guide,
       edition: Edition.new,
       user: current_user,
@@ -24,7 +24,7 @@ class GuidesController < ApplicationController
   def edit
     guide = Guide.find(params[:id])
 
-    @guide_form = GuideForm.new(
+    @guide_form = GuideForm.build(
       guide: guide,
       edition: guide.latest_edition,
       user: current_user
@@ -68,7 +68,7 @@ private
     if result.success?
       redirect_to redirect, notice: message
     else
-      @guide_form = GuideForm.new(
+      @guide_form = GuideForm.build(
         guide: guide,
         edition: guide.latest_edition,
         user: current_user
@@ -82,7 +82,7 @@ private
   def save(guide)
     failure_template = guide.persisted? ? 'edit' : 'new'
 
-    @guide_form = GuideForm.new(
+    @guide_form = GuideForm.build(
       guide: guide,
       edition: guide.editions.build(created_by: current_user),
       user: current_user

--- a/app/controllers/slug_migrations_controller.rb
+++ b/app/controllers/slug_migrations_controller.rb
@@ -11,27 +11,10 @@ class SlugMigrationsController < ApplicationController
 
   def edit
     @slug_migration = SlugMigration.find(params[:id])
-    @select_options = select_options
-  end
-
-  def select_options
-    guide_select_options = Guide
-      .with_published_editions
-      .order(:slug).pluck(:slug)
-      .map { |g| [g, g] }
-    topic_select_options = Topic
-      .order(:path).pluck(:path)
-      .map { |g| [g, g] }
-    {
-      "Other" => ["/service-manual"],
-      "Topics" => topic_select_options,
-      "Guides" => guide_select_options,
-    }
   end
 
   def update
     @slug_migration = SlugMigration.find(params[:id])
-    @select_options = select_options
 
     slug_migration_parameters = params.require(:slug_migration)
       .permit(:redirect_to)

--- a/app/forms/base_guide_form.rb
+++ b/app/forms/base_guide_form.rb
@@ -1,0 +1,155 @@
+class BaseGuideForm
+  DEFAULT_UPDATE_TYPE = "major".freeze
+
+  include ActiveModel::Model
+
+  attr_reader :guide, :edition, :user
+  attr_accessor :author_id, :body, :change_note, :change_summary, :content_owner_id, :description, :slug,
+    :summary, :title, :title_slug, :type, :update_type, :version
+
+  delegate :persisted?, to: :guide
+
+  def self.build(**args)
+    guide = args.fetch(:guide)
+
+    if guide.is_a? Point
+      PointForm.new(**args)
+    else
+      GuideForm.new(**args)
+    end
+  end
+
+  def initialize(guide:, edition:, user:)
+    @guide = guide
+    @edition = edition
+    @user = user
+
+    self.author_id = next_author_id
+    self.body = edition.body
+    self.change_note = edition.change_note
+    self.change_summary = edition.change_summary
+    self.content_owner_id = edition.content_owner_id
+    self.description = edition.description
+    self.slug = guide.slug
+    self.summary = edition.summary
+    self.title = edition.title
+    self.title_slug = extracted_title_from_slug
+    self.type = guide.type
+    self.update_type = next_update_type
+    self.version = next_edition_version
+
+    load_custom_attributes
+
+    if edition.published?
+      self.change_note = nil
+      self.change_summary = nil
+    end
+  end
+
+  def save
+    guide.slug = slug
+    edition.author_id = author_id
+    edition.body = body
+    edition.change_note = change_note
+    edition.change_summary = change_summary
+    edition.content_owner_id = content_owner_id
+    edition.created_by_id = user.id
+    edition.description = description
+    edition.state = Edition::STATES.first
+    edition.summary = summary
+    edition.title = title
+    edition.update_type = update_type
+    edition.version = version
+
+    set_custom_attributes
+
+    catching_gds_api_exceptions do
+      if valid? && guide.save
+        save_draft_to_publishing_api
+
+        true
+      else
+        promote_errors_for(guide)
+        promote_errors_for(edition)
+
+        false
+      end
+    end
+  end
+
+  def to_param
+    guide.id.to_s
+  end
+
+  def model_name
+    ActiveModel::Name.new(Guide)
+  end
+
+  def assign_attributes(attributes)
+    attributes.each do |k, v|
+      send("#{k}=", v)
+    end
+  end
+
+private
+
+  def load_custom_attributes
+    # optionally implemented in the concrete class
+  end
+
+  def set_custom_attributes
+    # optionally implemented in the concrete class
+  end
+
+  def extracted_title_from_slug
+    slug ? slug.split("/").last : nil
+  end
+
+  def next_edition_version
+    if edition.published?
+      edition.version + 1
+    else
+      edition.version || 1
+    end
+  end
+
+  def next_update_type
+    if edition.published?
+      DEFAULT_UPDATE_TYPE
+    else
+      edition.update_type || DEFAULT_UPDATE_TYPE
+    end
+  end
+
+  def next_author_id
+    if edition.published?
+      user.id
+    else
+      edition.author ? edition.author.id : user.id
+    end
+  end
+
+  def promote_errors_for(model)
+    model.errors.each do |attrib, message|
+      errors.add(attrib, message)
+    end
+  end
+
+  def catching_gds_api_exceptions
+    begin
+      ActiveRecord::Base.transaction do
+        yield
+      end
+    rescue GdsApi::HTTPErrorResponse => e
+      errors.add(:base, e.error_details['error']['message'])
+
+      false
+    end
+  end
+
+  def save_draft_to_publishing_api
+    content_for_publication = GuideFormPublicationPresenter.new(self)
+    PUBLISHING_API.put_content(content_for_publication.content_id, content_for_publication.content_payload)
+    PUBLISHING_API.patch_links(content_for_publication.content_id, content_for_publication.links_payload)
+  end
+end

--- a/app/forms/guide_form.rb
+++ b/app/forms/guide_form.rb
@@ -49,19 +49,8 @@ class GuideForm
   end
 
   def save
-    guide.slug = slug
-    edition.author_id = author_id
-    edition.body = body
-    edition.change_note = change_note
-    edition.change_summary = change_summary
-    edition.content_owner_id = content_owner_id
-    edition.created_by_id = user.id
-    edition.description = description
-    edition.state = Edition::STATES.first
-    edition.summary = summary
-    edition.title = title
-    edition.update_type = update_type
-    edition.version = version
+    set_guide_attributes
+    set_edition_attributes
     topic_section_guide.topic_section_id = topic_section_id
 
     catching_gds_api_exceptions do
@@ -92,7 +81,34 @@ class GuideForm
     end
   end
 
+  def requires_topic?
+    true
+  end
+
+  def slug_prefix
+    "/service-manual"
+  end
+
 private
+
+  def set_guide_attributes
+    guide.slug = slug
+  end
+
+  def set_edition_attributes
+    edition.author_id = author_id
+    edition.body = body
+    edition.change_note = change_note
+    edition.change_summary = change_summary
+    edition.content_owner_id = content_owner_id
+    edition.created_by_id = user.id
+    edition.description = description
+    edition.state = Edition::STATES.first
+    edition.summary = summary
+    edition.title = title
+    edition.update_type = update_type
+    edition.version = version
+  end
 
   def topic_section_guide
     @_topic_section_guide ||= TopicSectionGuide
@@ -170,9 +186,5 @@ private
     content_for_publication = GuideFormPublicationPresenter.new(self)
     PUBLISHING_API.put_content(content_for_publication.content_id, content_for_publication.content_payload)
     PUBLISHING_API.patch_links(content_for_publication.content_id, content_for_publication.links_payload)
-  end
-
-  def requires_topic?
-    true
   end
 end

--- a/app/forms/guide_form.rb
+++ b/app/forms/guide_form.rb
@@ -59,8 +59,12 @@ class GuideForm
         save_draft_to_publishing_api
 
         if guide.is_a? Point
-          PUBLISHING_API.put_content("", {})
-          PUBLISHING_API.patch_links("", links: {points: []})
+          service_standard_for_publication =
+            ServiceStandardPresenter.new(Point.all)
+          PUBLISHING_API.patch_links(
+            service_standard_for_publication.content_id,
+            service_standard_for_publication.links_payload
+          )
         end
 
         true

--- a/app/forms/guide_form.rb
+++ b/app/forms/guide_form.rb
@@ -68,15 +68,6 @@ class GuideForm
       if valid? && guide.save && topic_section_guide.save
         save_draft_to_publishing_api
 
-        if guide.is_a? Point
-          service_standard_for_publication =
-            ServiceStandardPresenter.new(Point.all)
-          PUBLISHING_API.patch_links(
-            service_standard_for_publication.content_id,
-            service_standard_for_publication.links_payload
-          )
-        end
-
         true
       else
         promote_errors_for(guide)

--- a/app/forms/guide_form.rb
+++ b/app/forms/guide_form.rb
@@ -1,85 +1,8 @@
-class GuideForm
-  DEFAULT_UPDATE_TYPE = "major".freeze
-
-  include ActiveModel::Model
-
-  attr_reader :guide, :edition, :user
-  attr_accessor :author_id, :body, :change_note, :change_summary, :content_owner_id, :description, :slug,
-    :summary, :title, :title_slug, :topic_section_id, :type, :update_type, :version
+class GuideForm < BaseGuideForm
+  attr_accessor :topic_section_id
 
   validates_presence_of :topic_section_id, if: :requires_topic?
   validate :topic_cannot_change
-
-  delegate :persisted?, to: :guide
-
-  def self.build(**args)
-    guide = args.fetch(:guide)
-
-    if guide.is_a? Point
-      PointForm.new(**args)
-    else
-      self.new(**args)
-    end
-  end
-
-  def initialize(guide:, edition:, user:)
-    @guide = guide
-    @edition = edition
-    @user = user
-
-    self.author_id = next_author_id
-    self.body = edition.body
-    self.change_note = edition.change_note
-    self.change_summary = edition.change_summary
-    self.content_owner_id = edition.content_owner_id
-    self.description = edition.description
-    self.slug = guide.slug
-    self.summary = edition.summary
-    self.title = edition.title
-    self.title_slug = extracted_title_from_slug
-    self.topic_section_id = topic_section.try(:id)
-    self.type = guide.type
-    self.update_type = next_update_type
-    self.version = next_edition_version
-
-    if edition.published?
-      self.change_note = nil
-      self.change_summary = nil
-    end
-  end
-
-  def save
-    set_guide_attributes
-    set_edition_attributes
-    topic_section_guide.topic_section_id = topic_section_id
-
-    catching_gds_api_exceptions do
-      if valid? && guide.save && topic_section_guide.save
-        save_draft_to_publishing_api
-
-        true
-      else
-        promote_errors_for(guide)
-        promote_errors_for(edition)
-
-        false
-      end
-    end
-  end
-
-  def to_param
-    guide.id.to_s
-  end
-
-  def model_name
-    ActiveModel::Name.new(Guide)
-  end
-
-  def assign_attributes(attributes)
-    attributes.each do |k, v|
-      send("#{k}=", v)
-    end
-  end
 
   def requires_topic?
     true
@@ -91,70 +14,23 @@ class GuideForm
 
 private
 
-  def set_guide_attributes
-    guide.slug = slug
+  def load_custom_attributes
+    self.topic_section_id = topic_section.try(:id)
   end
 
-  def set_edition_attributes
-    edition.author_id = author_id
-    edition.body = body
-    edition.change_note = change_note
-    edition.change_summary = change_summary
-    edition.content_owner_id = content_owner_id
-    edition.created_by_id = user.id
-    edition.description = description
-    edition.state = Edition::STATES.first
-    edition.summary = summary
-    edition.title = title
-    edition.update_type = update_type
-    edition.version = version
+  def set_custom_attributes
+    topic_section_guide.topic_section_id = topic_section_id
   end
 
   def topic_section_guide
-    @_topic_section_guide ||= TopicSectionGuide
-      .includes(:topic_section)
-      .references(:topic_section)
-      .find_or_initialize_by(guide: guide)
-  end
-
-  def extracted_title_from_slug
-    slug ? slug.split("/").last : nil
+    @_topic_section_guide ||=
+      guide.topic_section_guides[0] || guide.topic_section_guides.build
   end
 
   def topic_section
     TopicSection
       .joins(:topic_section_guides)
       .find_by('topic_section_guides.guide_id = ?', guide.id)
-  end
-
-  def next_edition_version
-    if edition.published?
-      edition.version + 1
-    else
-      edition.version || 1
-    end
-  end
-
-  def next_update_type
-    if edition.published?
-      DEFAULT_UPDATE_TYPE
-    else
-      edition.update_type || DEFAULT_UPDATE_TYPE
-    end
-  end
-
-  def next_author_id
-    if edition.published?
-      user.id
-    else
-      edition.author ? edition.author.id : user.id
-    end
-  end
-
-  def promote_errors_for(model)
-    model.errors.each do |attrib, message|
-      errors.add(attrib, message)
-    end
   end
 
   def topic_cannot_change
@@ -168,23 +44,5 @@ private
     if old_section.topic_id != new_section.topic_id
       errors.add(:topic_section_id, "cannot change to a different topic")
     end
-  end
-
-  def catching_gds_api_exceptions
-    begin
-      ActiveRecord::Base.transaction do
-        yield
-      end
-    rescue GdsApi::HTTPErrorResponse => e
-      errors.add(:base, e.error_details['error']['message'])
-
-      false
-    end
-  end
-
-  def save_draft_to_publishing_api
-    content_for_publication = GuideFormPublicationPresenter.new(self)
-    PUBLISHING_API.put_content(content_for_publication.content_id, content_for_publication.content_payload)
-    PUBLISHING_API.patch_links(content_for_publication.content_id, content_for_publication.links_payload)
   end
 end

--- a/app/forms/guide_form.rb
+++ b/app/forms/guide_form.rb
@@ -58,6 +58,11 @@ class GuideForm
       if valid? && guide.save && topic_section_guide.save
         save_draft_to_publishing_api
 
+        if guide.is_a? Point
+          PUBLISHING_API.put_content("", {})
+          PUBLISHING_API.patch_links("", links: {points: []})
+        end
+
         true
       else
         promote_errors_for(guide)

--- a/app/forms/guide_form.rb
+++ b/app/forms/guide_form.rb
@@ -7,10 +7,20 @@ class GuideForm
   attr_accessor :author_id, :body, :change_note, :change_summary, :content_owner_id, :description, :slug,
     :summary, :title, :title_slug, :topic_section_id, :type, :update_type, :version
 
-  validates_presence_of :topic_section_id
+  validates_presence_of :topic_section_id, if: :requires_topic?
   validate :topic_cannot_change
 
   delegate :persisted?, to: :guide
+
+  def self.build(**args)
+    guide = args.fetch(:guide)
+
+    if guide.is_a? Point
+      PointForm.new(**args)
+    else
+      self.new(**args)
+    end
+  end
 
   def initialize(guide:, edition:, user:)
     @guide = guide
@@ -169,5 +179,9 @@ private
     content_for_publication = GuideFormPublicationPresenter.new(self)
     PUBLISHING_API.put_content(content_for_publication.content_id, content_for_publication.content_payload)
     PUBLISHING_API.patch_links(content_for_publication.content_id, content_for_publication.links_payload)
+  end
+
+  def requires_topic?
+    true
   end
 end

--- a/app/forms/point_form.rb
+++ b/app/forms/point_form.rb
@@ -6,4 +6,16 @@ class PointForm < BaseGuideForm
   def slug_prefix
     "/service-manual/service-standard"
   end
+
+private
+
+  def save_draft_to_publishing_api
+    super
+
+    service_standard_for_publication = ServiceStandardPresenter.new(Point.all)
+    PUBLISHING_API.put_content(
+      service_standard_for_publication.content_id,
+      service_standard_for_publication.content_payload
+    )
+  end
 end

--- a/app/forms/point_form.rb
+++ b/app/forms/point_form.rb
@@ -1,27 +1,9 @@
-class PointForm < GuideForm
+class PointForm < BaseGuideForm
   def requires_topic?
     false
   end
 
   def slug_prefix
     "/service-manual/service-standard"
-  end
-
-  def save
-    set_guide_attributes
-    set_edition_attributes
-
-    catching_gds_api_exceptions do
-      if valid? && guide.save
-        save_draft_to_publishing_api
-
-        true
-      else
-        promote_errors_for(guide)
-        promote_errors_for(edition)
-
-        false
-      end
-    end
   end
 end

--- a/app/forms/point_form.rb
+++ b/app/forms/point_form.rb
@@ -1,7 +1,27 @@
 class PointForm < GuideForm
-
-private
   def requires_topic?
     false
+  end
+
+  def slug_prefix
+    "/service-manual/service-standard"
+  end
+
+  def save
+    set_guide_attributes
+    set_edition_attributes
+
+    catching_gds_api_exceptions do
+      if valid? && guide.save
+        save_draft_to_publishing_api
+
+        true
+      else
+        promote_errors_for(guide)
+        promote_errors_for(edition)
+
+        false
+      end
+    end
   end
 end

--- a/app/forms/point_form.rb
+++ b/app/forms/point_form.rb
@@ -1,0 +1,7 @@
+class PointForm < GuideForm
+
+private
+  def requires_topic?
+    false
+  end
+end

--- a/app/helpers/guide_helper.rb
+++ b/app/helpers/guide_helper.rb
@@ -36,10 +36,12 @@ module GuideHelper
 
   def topic_section_options_for_select
     Topic.includes(:topic_sections).map do |topic|
+      relative_path = topic.path.gsub("/service-manual", "")
+
       [
         topic.title,
         topic.topic_sections.map { |ts| ["#{topic.title} -> #{ts.title}", ts.id] },
-        { "data-path" => topic.path }
+        { "data-path" => relative_path }
       ]
     end
   end

--- a/app/helpers/guide_helper.rb
+++ b/app/helpers/guide_helper.rb
@@ -36,7 +36,7 @@ module GuideHelper
 
   def topic_section_options_for_select
     Topic.includes(:topic_sections).map do |topic|
-      relative_path = topic.path.gsub("/service-manual", "")
+      relative_path = topic.path.sub("/service-manual", "")
 
       [
         topic.title,

--- a/app/helpers/slug_migrations_helper.rb
+++ b/app/helpers/slug_migrations_helper.rb
@@ -1,0 +1,18 @@
+module SlugMigrationsHelper
+  def select_options
+    guide_select_options = Guide
+      .with_published_editions
+      .order(:slug).pluck(:slug)
+      .map { |g| [g, g] }
+
+    topic_select_options = Topic
+      .order(:path).pluck(:path)
+      .map { |g| [g, g] }
+
+    {
+      "Other" => ["/service-manual"],
+      "Topics" => topic_select_options,
+      "Guides" => guide_select_options,
+    }
+  end
+end

--- a/app/helpers/slug_migrations_helper.rb
+++ b/app/helpers/slug_migrations_helper.rb
@@ -10,7 +10,7 @@ module SlugMigrationsHelper
       .map { |g| [g, g] }
 
     {
-      "Other" => ["/service-manual"],
+      "Other" => ["/service-manual", "/service-manual/service-standard"],
       "Topics" => topic_select_options,
       "Guides" => guide_select_options,
     }

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -6,6 +6,7 @@ class Guide < ActiveRecord::Base
   validate :new_edition_has_summary, if: :requires_summary?
 
   has_many :editions, dependent: :destroy
+  has_many :topic_section_guides, autosave: true
 
   scope :only_latest_edition, -> {
     joins(:editions)

--- a/app/models/guide_manager.rb
+++ b/app/models/guide_manager.rb
@@ -26,6 +26,13 @@ class GuideManager
       edition.save!
       PUBLISHING_API.publish(guide.content_id, edition.update_type)
 
+      if guide.is_a?(Point)
+        PUBLISHING_API.publish(
+          ServiceStandardPresenter::SERVICE_STANDARD_CONTENT_ID,
+          "major"
+        )
+      end
+
       unless edition.notification_subscribers == [user]
         NotificationMailer.published(guide, user).deliver_later
       end

--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -38,6 +38,10 @@ class GuidePresenter
       links[:content_owners] = [edition.content_owner.content_id]
     end
 
+    if guide.is_a?(Point)
+      links[:parent] = [ServiceStandardPresenter::SERVICE_STANDARD_CONTENT_ID]
+    end
+
     { links: links }
   end
 

--- a/app/presenters/service_standard_presenter.rb
+++ b/app/presenters/service_standard_presenter.rb
@@ -7,6 +7,21 @@ class ServiceStandardPresenter
     "00f693d4-866a-4fe6-a8d6-09cd7db8980b"
   end
 
+  def content_payload
+    {
+      base_path: '/service-manual/service-standard',
+      document_type: 'service_manual_service_standard',
+      phase: 'beta',
+      publishing_app: 'service-manual-publisher',
+      rendering_app: 'service-manual-frontend',
+      routes: [
+        { type: 'exact', path: '/service-manual/service-standard' }
+      ],
+      schema_name: 'service_manual_service_standard',
+      title: 'The Digital Service Standard',
+    }
+  end
+
   def links_payload
     {
       links: {

--- a/app/presenters/service_standard_presenter.rb
+++ b/app/presenters/service_standard_presenter.rb
@@ -20,7 +20,7 @@ class ServiceStandardPresenter
         { type: 'exact', path: '/service-manual/service-standard' }
       ],
       schema_name: 'service_manual_service_standard',
-      title: 'The Digital Service Standard',
+      title: 'Digital Service Standard',
       details: {
         introduction: "The Digital Service Standard is a set of 18 criteria to help government create and run good digital services.",
         body: "All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use.",

--- a/app/presenters/service_standard_presenter.rb
+++ b/app/presenters/service_standard_presenter.rb
@@ -1,9 +1,5 @@
 class ServiceStandardPresenter
-  SERVICE_STANDARD_CONTENT_ID = "00f693d4-866a-4fe6-a8d6-09cd7db8980b"
-
-  def initialize(points)
-    @points = points
-  end
+  SERVICE_STANDARD_CONTENT_ID = "00f693d4-866a-4fe6-a8d6-09cd7db8980b".freeze
 
   def content_id
     SERVICE_STANDARD_CONTENT_ID
@@ -26,13 +22,7 @@ class ServiceStandardPresenter
 
   def links_payload
     {
-      links: {
-        points: points.map(&:content_id)
-      }
+      links: {}
     }
   end
-
-private
-
-  attr_reader :points
 end

--- a/app/presenters/service_standard_presenter.rb
+++ b/app/presenters/service_standard_presenter.rb
@@ -1,0 +1,21 @@
+class ServiceStandardPresenter
+  def initialize(points)
+    @points = points
+  end
+
+  def content_id
+    "00f693d4-866a-4fe6-a8d6-09cd7db8980b"
+  end
+
+  def links_payload
+    {
+      links: {
+        points: points.map(&:content_id)
+      }
+    }
+  end
+
+private
+
+  attr_reader :points
+end

--- a/app/presenters/service_standard_presenter.rb
+++ b/app/presenters/service_standard_presenter.rb
@@ -17,6 +17,10 @@ class ServiceStandardPresenter
       ],
       schema_name: 'service_manual_service_standard',
       title: 'The Digital Service Standard',
+      details: {
+        introduction: "The Digital Service Standard is a set of 18 criteria to help government create and run good digital services.",
+        body: "All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use.",
+      }
     }
   end
 

--- a/app/presenters/service_standard_presenter.rb
+++ b/app/presenters/service_standard_presenter.rb
@@ -1,6 +1,10 @@
 class ServiceStandardPresenter
   SERVICE_STANDARD_CONTENT_ID = "00f693d4-866a-4fe6-a8d6-09cd7db8980b".freeze
 
+  def initialize(points)
+    @points = points
+  end
+
   def content_id
     SERVICE_STANDARD_CONTENT_ID
   end
@@ -20,13 +24,24 @@ class ServiceStandardPresenter
       details: {
         introduction: "The Digital Service Standard is a set of 18 criteria to help government create and run good digital services.",
         body: "All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use.",
+        points: points_payload,
       }
     }
   end
 
-  def links_payload
-    {
-      links: {}
-    }
+private
+
+  attr_reader :points
+
+  def points_payload
+    points.map do |point|
+      edition = point.latest_edition
+
+      {
+        base_path: point.slug,
+        summary: edition.summary,
+        title: edition.title,
+      }
+    end
   end
 end

--- a/app/presenters/service_standard_presenter.rb
+++ b/app/presenters/service_standard_presenter.rb
@@ -1,10 +1,12 @@
 class ServiceStandardPresenter
+  SERVICE_STANDARD_CONTENT_ID = "00f693d4-866a-4fe6-a8d6-09cd7db8980b"
+
   def initialize(points)
     @points = points
   end
 
   def content_id
-    "00f693d4-866a-4fe6-a8d6-09cd7db8980b"
+    SERVICE_STANDARD_CONTENT_ID
   end
 
   def content_payload

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -1,7 +1,16 @@
 <% guide = guide_form.guide %>
 <% edition = guide_form.edition %>
 
-<%= form_for guide_form, html: { class: "js-guide-form js-protect-data", data: { "has-been-published": guide.has_published_edition? } } do |f| %>
+<%= form_for(
+      guide_form,
+      html: {
+        class: "js-guide-form js-protect-data",
+        data: {
+          "has-been-published": guide.has_published_edition?,
+          "slug-prefix": guide_form.slug_prefix
+        }
+      }
+    ) do |f| %>
   <% disable_inputs = edition.unpublished? %>
 
   <%= f.hidden_field :type %>
@@ -34,11 +43,13 @@
         <%= f.text_field :title_slug, {value: guide_form.title_slug, class: 'input-md-12 form-control guide-slug js-title-slug', disabled: guide.has_published_edition?} %>
       </div>
 
-      <div class='form-group'>
-        <%= f.label :topic_section_id, "Topic section" %>
-        <%= f.error_list :topic_section_id %>
-        <%= f.select :topic_section_id, grouped_options_for_select(topic_section_options_for_select, guide_form.topic_section_id), {include_blank: ""}, {class: 'js-topic-section select2 input-md-12 form-control'} %>
-      </div>
+      <% if guide_form.requires_topic? %>
+        <div class='form-group'>
+          <%= f.label :topic_section_id, "Topic section" %>
+          <%= f.error_list :topic_section_id %>
+          <%= f.select :topic_section_id, grouped_options_for_select(topic_section_options_for_select, guide_form.topic_section_id), {include_blank: ""}, {class: 'js-topic-section select2 input-md-12 form-control'} %>
+        </div>
+      <% end %>
 
       <div class="form-group">
         <%= f.label :slug, "Final URL" %>

--- a/app/views/slug_migrations/edit.html.erb
+++ b/app/views/slug_migrations/edit.html.erb
@@ -8,7 +8,7 @@
       <% end %>
       <%=
         f.select :redirect_to,
-          grouped_options_for_select(@select_options),
+          grouped_options_for_select(select_options),
           {include_blank: "Please choose a path to redirect to"},
           {class: "select2 input-md-12 form-control"}
       %>

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -11,5 +11,3 @@ task :lint do
     sh "bundle exec govuk-lint-sass #{sass_paths}"
   end
 end
-
-Rake::Task[:default].enhance [:lint]

--- a/lib/tasks/publish_service_standard.rake
+++ b/lib/tasks/publish_service_standard.rake
@@ -1,0 +1,14 @@
+desc "Save draft and publish the service standard"
+task publish_service_standard: :environment do
+  service_standard_for_publication =
+    ServiceStandardPresenter.new(Point.all)
+
+  PUBLISHING_API.put_content(
+    service_standard_for_publication.content_id,
+    service_standard_for_publication.content_payload
+  )
+  PUBLISHING_API.publish(
+    service_standard_for_publication.content_id,
+    "major"
+  )
+end

--- a/lib/tasks/publish_service_standard.rake
+++ b/lib/tasks/publish_service_standard.rake
@@ -1,6 +1,7 @@
 desc "Save draft and publish the service standard"
 task publish_service_standard: :environment do
-  service_standard_for_publication = ServiceStandardPresenter.new
+  service_standard_for_publication =
+    ServiceStandardPresenter.new(Point.all)
 
   PUBLISHING_API.put_content(
     service_standard_for_publication.content_id,

--- a/lib/tasks/publish_service_standard.rake
+++ b/lib/tasks/publish_service_standard.rake
@@ -1,7 +1,6 @@
 desc "Save draft and publish the service standard"
 task publish_service_standard: :environment do
-  service_standard_for_publication =
-    ServiceStandardPresenter.new(Point.all)
+  service_standard_for_publication = ServiceStandardPresenter.new
 
   PUBLISHING_API.put_content(
     service_standard_for_publication.content_id,

--- a/spec/features/point_page_spec.rb
+++ b/spec/features/point_page_spec.rb
@@ -1,10 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe 'Create a point page', type: :feature do
+RSpec.describe 'Create a point page', type: :feature, js: true do
   it 'successfully creates a point' do
-    topic1 = create(:topic, title: "My Topic Number 1", path: "/service-manual/topic-path1")
-    create(:topic_section, topic: topic1, title: "My Topic Section Number 1")
-
     visit root_path
     click_link "Create a Point"
 
@@ -13,8 +10,6 @@ RSpec.describe 'Create a point page', type: :feature do
     expect(publishing_api).to receive(:put_content).once
     expect(publishing_api).to receive(:patch_links).twice
 
-    fill_in_final_url '/service-manual/service-standard/point-1'
-    select "My Topic Section Number 1", from: "Topic section"
     fill_in "Description", with: "User needs should be your first focus."
     fill_in "Summary", with: "Understand user needs. Research to develop a deep knowledge of who the service users are and what that means for the design of the service."
     fill_in "Title", with: "Understand user needs"
@@ -29,7 +24,7 @@ RSpec.describe 'Create a point page', type: :feature do
     # the content of the fields
     visit current_path
 
-    expect(page).to have_field('Final URL', with: "/service-manual/service-standard/point-1")
+    expect(page).to have_field('Final URL', with: "/service-manual/service-standard/understand-user-needs")
     expect(page).to have_field('Description', with: "User needs should be your first focus.")
     expect(page).to have_field('Summary', with: "Understand user needs. Research to develop a deep knowledge of who the service users are and what that means for the design of the service.")
     expect(page).to have_field('Title', with: "Understand user needs")

--- a/spec/features/point_page_spec.rb
+++ b/spec/features/point_page_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Create a point page', type: :feature do
 
     publishing_api = double(:publishing_api)
     stub_const("PUBLISHING_API", publishing_api)
-    expect(publishing_api).to receive(:put_content).twice
+    expect(publishing_api).to receive(:put_content).once
     expect(publishing_api).to receive(:patch_links).twice
 
     fill_in_final_url '/service-manual/service-standard/point-1'

--- a/spec/features/point_page_spec.rb
+++ b/spec/features/point_page_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe 'Create a point page', type: :feature do
 
     publishing_api = double(:publishing_api)
     stub_const("PUBLISHING_API", publishing_api)
-    expect(publishing_api).to receive(:put_content)
-    expect(publishing_api).to receive(:patch_links)
+    expect(publishing_api).to receive(:put_content).twice
+    expect(publishing_api).to receive(:patch_links).twice
 
     fill_in_final_url '/service-manual/service-standard/point-1'
     select "My Topic Section Number 1", from: "Topic section"

--- a/spec/features/point_page_spec.rb
+++ b/spec/features/point_page_spec.rb
@@ -31,10 +31,11 @@ RSpec.describe 'Create a point page', type: :feature, js: true do
     expect(page).to have_field('Body', with: "## Why it's in the standard")
   end
 
-  it 'does not have a content owner field' do
+  it 'does not have a content owner or a topic section field' do
     visit root_path
     click_link "Create a Point"
 
+    expect(page).to_not have_field('Topic section')
     expect(page).to_not have_field('Community')
   end
 end

--- a/spec/features/point_page_spec.rb
+++ b/spec/features/point_page_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Create a point page', type: :feature, js: true do
     publishing_api = double(:publishing_api)
     stub_const("PUBLISHING_API", publishing_api)
     expect(publishing_api).to receive(:put_content).once
-    expect(publishing_api).to receive(:patch_links).twice
+    expect(publishing_api).to receive(:patch_links).once
 
     fill_in "Description", with: "User needs should be your first focus."
     fill_in "Summary", with: "Understand user needs. Research to develop a deep knowledge of who the service users are and what that means for the design of the service."

--- a/spec/features/point_page_spec.rb
+++ b/spec/features/point_page_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Create a point page', type: :feature, js: true do
 
     publishing_api = double(:publishing_api)
     stub_const("PUBLISHING_API", publishing_api)
-    expect(publishing_api).to receive(:put_content).once
+    expect(publishing_api).to receive(:put_content).twice
     expect(publishing_api).to receive(:patch_links).once
 
     fill_in "Description", with: "User needs should be your first focus."

--- a/spec/forms/guide_form_spec.rb
+++ b/spec/forms/guide_form_spec.rb
@@ -274,47 +274,6 @@ RSpec.describe GuideForm, "#save" do
       expect(edition.change_summary).to eq("X happened")
       expect(edition.change_note).to eq("This happened because of X.")
     end
-
-    it "saves all points to the service standard when saving a point" do
-      guide_community = create(:guide_community)
-      user = create(:user)
-      topic = create(:topic)
-      topic_section = create(:topic_section, topic: topic)
-      create(:point)
-
-      point = Point.new
-      edition = point.editions.build
-      guide_form = described_class.new(guide: point, edition: edition, user: user)
-      guide_form.assign_attributes(body: "a fair old body",
-        content_owner_id: guide_community.id,
-        description: "a pleasant description",
-        summary: "a exciting summary",
-        slug: "/service-manual/service-standard/do-ongoing-user-research",
-        title: "Do ongoing user research",
-        update_type: "minor",
-        topic_section_id: topic_section.id)
-
-      # Stub communication with the publishing api for the point
-      allow(PUBLISHING_API).to receive(:put_content)
-      allow(PUBLISHING_API)
-        .to receive(:patch_links)
-        .with(an_instance_of(String), hash_including(links: an_instance_of(Hash)))
-
-      # Expect communication with the publishing api for the service
-      # standard
-      expect(PUBLISHING_API)
-        .to receive(:patch_links)
-        .with(
-          an_instance_of(String),
-          hash_including(
-            links: hash_including(
-              points: [an_instance_of(String), an_instance_of(String)]
-            )
-          )
-        )
-
-      guide_form.save
-    end
   end
 
   context "for a published guide" do

--- a/spec/forms/guide_form_spec.rb
+++ b/spec/forms/guide_form_spec.rb
@@ -260,6 +260,73 @@ RSpec.describe GuideForm, "#save" do
       expect(edition.change_summary).to eq("X happened")
       expect(edition.change_note).to eq("This happened because of X.")
     end
+
+    it "saves a service standard draft when saving a point" do
+      # We expect to publish a point and the service standard to the publishing API
+      # by calling put_content twice and patch_links twice
+      expect(PUBLISHING_API).to receive(:put_content).exactly(4).times
+      allow(PUBLISHING_API)
+        .to receive(:patch_links)
+        .with(an_instance_of(String), hash_including(:links => an_instance_of(Hash)))
+
+      guide_community = create(:guide_community)
+      user = create(:user)
+
+      topic = create(:topic)
+      topic_section = create(:topic_section, topic: topic)
+
+      point = Point.new
+      edition = point.editions.build
+      guide_form = described_class.new(guide: point, edition: edition, user: user)
+      guide_form.assign_attributes(body: "a fair old body",
+        content_owner_id: guide_community.id,
+        description: "a pleasant description",
+        summary: "a exciting summary",
+        slug: "/service-manual/service-standard/understand-user-needs",
+        title: "Understand user needs",
+        update_type: "minor",
+        topic_section_id: topic_section.id)
+
+      expect(PUBLISHING_API)
+        .to receive(:patch_links)
+        .with(
+          an_instance_of(String),
+          hash_including(
+            links: hash_including(
+              points: [an_instance_of(String)]
+            )
+          )
+        )
+        .once
+
+      guide_form.save
+
+      point = Point.new
+      edition = point.editions.build
+      guide_form = described_class.new(guide: point, edition: edition, user: user)
+      guide_form.assign_attributes(body: "a fair old body",
+        content_owner_id: guide_community.id,
+        description: "a pleasant description",
+        summary: "a exciting summary",
+        slug: "/service-manual/service-standard/do-ongoing-user-research",
+        title: "Do ongoing user research",
+        update_type: "minor",
+        topic_section_id: topic_section.id)
+
+      expect(PUBLISHING_API)
+        .to receive(:patch_links)
+        .with(
+          an_instance_of(String),
+          hash_including(
+            links: hash_including(
+              points: [an_instance_of(String), an_instance_of(String)]
+            )
+          )
+        )
+        .once
+
+      guide_form.save
+    end
   end
 
   context "for a published guide" do

--- a/spec/forms/guide_form_spec.rb
+++ b/spec/forms/guide_form_spec.rb
@@ -389,12 +389,12 @@ RSpec.describe GuideForm, "validations" do
       guide_form.errors.full_messages
     ).to include(
       "Slug can only contain letters, numbers and dashes",
-        "Slug must be present and start with '/service-manual/[topic]'",
-        "Latest edition must have a content owner",
-        "Editions is invalid",
-        "Description can't be blank",
-        "Title can't be blank",
-        "Body can't be blank",
+      "Slug must be present and start with '/service-manual/[topic]'",
+      "Latest edition must have a content owner",
+      "Editions is invalid",
+      "Description can't be blank",
+      "Title can't be blank",
+      "Body can't be blank",
     )
   end
 
@@ -416,5 +416,13 @@ RSpec.describe GuideForm, "#to_param" do
     guide_form = described_class.new(guide: guide, edition: edition, user: user)
 
     expect(guide_form.to_param).to eq("5")
+  end
+end
+
+RSpec.describe GuideForm, "#slug_prefix" do
+  it "is /service-manual" do
+    guide_form = described_class.new(guide: Guide.new, edition: Edition.new, user: User.new)
+
+    expect(guide_form.slug_prefix).to eq("/service-manual")
   end
 end

--- a/spec/forms/guide_form_spec.rb
+++ b/spec/forms/guide_form_spec.rb
@@ -264,7 +264,7 @@ RSpec.describe GuideForm, "#save" do
     it "saves a service standard draft when saving a point" do
       # We expect to publish a point and the service standard to the publishing API
       # by calling put_content twice and patch_links twice
-      expect(PUBLISHING_API).to receive(:put_content).exactly(4).times
+      expect(PUBLISHING_API).to receive(:put_content).exactly(2).times
       allow(PUBLISHING_API)
         .to receive(:patch_links)
         .with(an_instance_of(String), hash_including(:links => an_instance_of(Hash)))

--- a/spec/forms/guide_form_spec.rb
+++ b/spec/forms/guide_form_spec.rb
@@ -284,7 +284,7 @@ RSpec.describe GuideForm, "#save" do
       allow(PUBLISHING_API).to receive(:put_content)
       allow(PUBLISHING_API)
         .to receive(:patch_links)
-        .with(an_instance_of(String), hash_including(:links => an_instance_of(Hash)))
+        .with(an_instance_of(String), hash_including(links: an_instance_of(Hash)))
 
       # Expect communication with the publishing api for the service
       # standard

--- a/spec/forms/guide_form_spec.rb
+++ b/spec/forms/guide_form_spec.rb
@@ -409,7 +409,7 @@ RSpec.describe GuideForm, "validations" do
 end
 
 RSpec.describe GuideForm, "#to_param" do
-  it "is the guide id" do
+  it "returns the guide id" do
     guide = Guide.new(id: 5)
     edition = guide.editions.build
     user = User.new
@@ -420,7 +420,7 @@ RSpec.describe GuideForm, "#to_param" do
 end
 
 RSpec.describe GuideForm, "#slug_prefix" do
-  it "is /service-manual" do
+  it "returns /service-manual" do
     guide_form = described_class.new(guide: Guide.new, edition: Edition.new, user: User.new)
 
     expect(guide_form.slug_prefix).to eq("/service-manual")

--- a/spec/forms/guide_form_spec.rb
+++ b/spec/forms/guide_form_spec.rb
@@ -1,5 +1,19 @@
 require 'rails_helper'
 
+RSpec.describe GuideForm, ".build" do
+  it "returns a GuideForm for a Guide" do
+    expect(
+      described_class.build(guide: Guide.new, edition: Edition.new, user: User.new)
+    ).to be_instance_of GuideForm
+  end
+
+  it "returns a PointForm for a Point" do
+    expect(
+      described_class.build(guide: Point.new, edition: Edition.new, user: User.new)
+    ).to be_instance_of PointForm
+  end
+end
+
 RSpec.describe GuideForm, "#initialize" do
   context "for a brand new guide" do
     it "assigns a default update_type of major" do

--- a/spec/forms/point_form_spec.rb
+++ b/spec/forms/point_form_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe PointForm, "validations" do
 end
 
 RSpec.describe PointForm, "#slug_prefix" do
-  it "is /service-manual/service-standard" do
+  it "returns /service-manual/service-standard" do
     guide_form = described_class.new(guide: Guide.new, edition: Edition.new, user: User.new)
 
     expect(guide_form.slug_prefix).to eq("/service-manual/service-standard")

--- a/spec/forms/point_form_spec.rb
+++ b/spec/forms/point_form_spec.rb
@@ -10,3 +10,62 @@ RSpec.describe PointForm, "validations" do
     expect(guide_form.errors.full_messages).to_not include("Topic section can't be blank")
   end
 end
+
+RSpec.describe PointForm, "#slug_prefix" do
+  it "is /service-manual/service-standard" do
+    guide_form = described_class.new(guide: Guide.new, edition: Edition.new, user: User.new)
+
+    expect(guide_form.slug_prefix).to eq("/service-manual/service-standard")
+  end
+end
+
+RSpec.describe PointForm, "#save" do
+  it "persists a point with an edition and doesn't place it in a topic section" do
+    expect(PUBLISHING_API).to receive(:put_content)
+    expect(PUBLISHING_API).to receive(:patch_links)
+
+    guide_community = create(:guide_community)
+    user = create(:user)
+
+    point = Point.new
+    edition = point.editions.build
+    guide_form = described_class.new(guide: point, edition: edition, user: user)
+    guide_form.assign_attributes(
+      body: "a fair old body",
+      content_owner_id: guide_community.id,
+      description: "a pleasant description",
+      slug: "/service-manual/topic/a-fair-tale",
+      summary: "This is my nice summary",
+      title: "A fair tale",
+      update_type: "minor",
+    )
+    guide_form.save
+
+    expect(point).to be_persisted
+    expect(edition).to be_persisted
+
+    expect(TopicSectionGuide.count).to eq(0)
+  end
+end
+
+RSpec.describe PointForm, "validations" do
+  it "passes validation errors up from the models" do
+    point = Point.new
+
+    edition = point.editions.build
+    guide_form = described_class.new(guide: point, edition: edition, user: User.new)
+    guide_form.save
+
+    expect(
+      guide_form.errors.full_messages
+    ).to include(
+      "Slug can only contain letters, numbers and dashes",
+      "Slug must be present and start with '/service-manual/[topic]'",
+      "Editions is invalid",
+      "Description can't be blank",
+      "Title can't be blank",
+      "Body can't be blank",
+      "Latest edition must have a summary",
+    )
+  end
+end

--- a/spec/forms/point_form_spec.rb
+++ b/spec/forms/point_form_spec.rb
@@ -21,8 +21,8 @@ end
 
 RSpec.describe PointForm, "#save" do
   it "persists a point with an edition and doesn't place it in a topic section" do
-    expect(PUBLISHING_API).to receive(:put_content)
-    expect(PUBLISHING_API).to receive(:patch_links)
+    expect(PUBLISHING_API).to receive(:put_content).twice
+    expect(PUBLISHING_API).to receive(:patch_links).once
 
     guide_community = create(:guide_community)
     user = create(:user)
@@ -45,6 +45,47 @@ RSpec.describe PointForm, "#save" do
     expect(edition).to be_persisted
 
     expect(TopicSectionGuide.count).to eq(0)
+  end
+
+  it "saves all points to the service standard when saving a point" do
+    user = create(:user)
+    edition = create(:edition, summary: "This is a summary")
+    create(:point, editions: [edition])
+
+    point = Point.new
+    edition = point.editions.build
+    guide_form = described_class.new(guide: point, edition: edition, user: user)
+    guide_form.assign_attributes(body: "a fair old body",
+      description: "a pleasant description",
+      summary: "a exciting summary",
+      slug: "/service-manual/service-standard/do-ongoing-user-research",
+      title: "Do ongoing user research",
+      update_type: "minor",
+      )
+
+    # Stub communication with the publishing api for the point
+    allow(PUBLISHING_API).to receive(:put_content)
+    allow(PUBLISHING_API)
+      .to receive(:patch_links)
+      .with(an_instance_of(String), hash_including(links: an_instance_of(Hash)))
+
+    # Expect communication with the publishing api for the service
+    # standard
+    expect(PUBLISHING_API)
+      .to receive(:put_content)
+      .with(
+        an_instance_of(String),
+        hash_including(
+          details: hash_including(
+            points: [
+              hash_including(:base_path, :summary, :title),
+              hash_including(:base_path, :summary, :title),
+            ]
+          )
+        )
+      )
+
+    guide_form.save
   end
 end
 

--- a/spec/forms/point_form_spec.rb
+++ b/spec/forms/point_form_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe PointForm, "validations" do
+  it "does not require topic_section_id" do
+    guide = Point.new
+    edition = guide.editions.build
+    guide_form = described_class.new(guide: guide, edition: edition, user: User.new)
+    guide_form.save
+
+    expect(guide_form.errors.full_messages).to_not include("Topic section can't be blank")
+  end
+end

--- a/spec/helpers/guide_helper_spec.rb
+++ b/spec/helpers/guide_helper_spec.rb
@@ -33,3 +33,20 @@ RSpec.describe GuideHelper, '#guide_types_for_select', type: :helper do
     )
   end
 end
+
+RSpec.describe GuideHelper, '#topic_section_options_for_select', type: :helper do
+  it "returns topic sections options for a grouped select tag" do
+    topic = create(:topic, path: "/service-manual/agile", title: "Agile")
+    topic_section = create(:topic_section, topic: topic, title: "Scrum")
+
+    expect(helper.topic_section_options_for_select).to eq(
+      [
+        [
+          "Agile",
+          [["Agile -> Scrum", topic_section.id]],
+          { "data-path" => "/agile" }
+        ]
+      ]
+    )
+  end
+end

--- a/spec/helpers/slug_migrations_helper_spec.rb
+++ b/spec/helpers/slug_migrations_helper_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe SlugMigrationsHelper, '#select_options', type: :helper do
+  it 'should return all available slugs' do
+    guide = create(:published_guide)
+    topic = create(:topic)
+
+    expect(helper.select_options).to eq(
+      "Other" => ["/service-manual"],
+      "Topics" => [[topic.path, topic.path]],
+      "Guides" => [[guide.slug, guide.slug]]
+    )
+  end
+end

--- a/spec/helpers/slug_migrations_helper_spec.rb
+++ b/spec/helpers/slug_migrations_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SlugMigrationsHelper, '#select_options', type: :helper do
     topic = create(:topic)
 
     expect(helper.select_options).to eq(
-      "Other" => ["/service-manual"],
+      "Other" => ["/service-manual", "/service-manual/service-standard"],
       "Topics" => [[topic.path, topic.path]],
       "Guides" => [[guide.slug, guide.slug]]
     )

--- a/spec/models/guide_manager_spec.rb
+++ b/spec/models/guide_manager_spec.rb
@@ -126,6 +126,27 @@ RSpec.describe GuideManager, '#publish' do
     expect(result).to be_success
   end
 
+  it "publishes the service standard if publishing a point" do
+    user = create(:user)
+    editions = [
+      build(:edition, title: 'Agile', summary: "Summary"),
+      build(:edition, title: 'Agile', summary: "Summary", state: 'review_requested'),
+      build(:edition, title: 'Agile', summary: "Summary", state: 'ready')
+    ]
+    point = create(:point, editions: editions)
+
+    expect(PUBLISHING_API).to receive(:publish)
+      .with(point.content_id, an_instance_of(String))
+      .once
+    expect(PUBLISHING_API).to receive(:publish)
+      .with(ServiceStandardPresenter::SERVICE_STANDARD_CONTENT_ID, "major")
+      .once
+    expect(RUMMAGER_API).to receive(:add_document)
+
+    manager = described_class.new(guide: point, user: user)
+    manager.publish
+  end
+
   context "when communication with the publishing api fails" do
     it "doesn't create anything" do
       stub_publishing_api_to_fail

--- a/spec/presenters/guide_presenter_spec.rb
+++ b/spec/presenters/guide_presenter_spec.rb
@@ -99,3 +99,16 @@ RSpec.describe GuidePresenter do
     end
   end
 end
+
+RSpec.describe GuidePresenter, "for a Point" do
+  it "includes the service standard as a parent in the links" do
+    edition = create(:edition)
+    point = create(:point, editions: [edition])
+
+    presenter = described_class.new(point, edition)
+
+    expect(presenter.links_payload[:links]).to include(
+      parent: ["00f693d4-866a-4fe6-a8d6-09cd7db8980b"]
+    )
+  end
+end

--- a/spec/presenters/service_standard_presenter_spec.rb
+++ b/spec/presenters/service_standard_presenter_spec.rb
@@ -2,18 +2,14 @@ require "rails_helper"
 
 RSpec.describe ServiceStandardPresenter, "#content_id" do
   it "is a preassigned UUID" do
-    point_scope = double(:point_scope)
-
     expect(
-      described_class.new(point_scope).content_id
+      described_class.new.content_id
     ).to eq("00f693d4-866a-4fe6-a8d6-09cd7db8980b")
   end
 end
 
 RSpec.describe ServiceStandardPresenter, "#content_payload" do
   it "returns a hash suitable for a service standard draft" do
-    point_scope = double(:point_scope)
-
     expected_payload = {
       base_path: '/service-manual/service-standard',
       document_type: 'service_manual_service_standard',
@@ -28,24 +24,7 @@ RSpec.describe ServiceStandardPresenter, "#content_payload" do
     }
 
     expect(
-      described_class.new(point_scope).content_payload
-    ).to eq(expected_payload)
-  end
-end
-
-RSpec.describe ServiceStandardPresenter, "#links_payload" do
-  it "includes points" do
-    point1 = create(:point)
-    point2 = create(:point)
-
-    expected_payload = {
-      links: {
-        points: [point1.content_id, point2.content_id]
-      }
-    }
-
-    expect(
-      described_class.new([point1, point2]).links_payload
+      described_class.new.content_payload
     ).to eq(expected_payload)
   end
 end

--- a/spec/presenters/service_standard_presenter_spec.rb
+++ b/spec/presenters/service_standard_presenter_spec.rb
@@ -2,14 +2,19 @@ require "rails_helper"
 
 RSpec.describe ServiceStandardPresenter, "#content_id" do
   it "is a preassigned UUID" do
+    point_scope = double(:point_scope)
+
     expect(
-      described_class.new.content_id
+      described_class.new(point_scope).content_id
     ).to eq("00f693d4-866a-4fe6-a8d6-09cd7db8980b")
   end
 end
 
 RSpec.describe ServiceStandardPresenter, "#content_payload" do
   it "returns a hash suitable for a service standard draft" do
+    edition = create(:edition, summary: "This is a summary", title: "1. Understand user needs")
+    point = create(:point, editions: [edition], slug: "/service-manual/service-standard/understand-user-needs")
+
     expected_payload = {
       base_path: '/service-manual/service-standard',
       document_type: 'service_manual_service_standard',
@@ -24,11 +29,18 @@ RSpec.describe ServiceStandardPresenter, "#content_payload" do
       details: {
         introduction: "The Digital Service Standard is a set of 18 criteria to help government create and run good digital services.",
         body: "All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use.",
+        points: [
+          {
+            title: "1. Understand user needs",
+            summary: "This is a summary",
+            base_path: "/service-manual/service-standard/understand-user-needs",
+          }
+        ]
       }
     }
 
     expect(
-      described_class.new.content_payload
+      described_class.new([point]).content_payload
     ).to eq(expected_payload)
   end
 end

--- a/spec/presenters/service_standard_presenter_spec.rb
+++ b/spec/presenters/service_standard_presenter_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ServiceStandardPresenter, "#content_id" do
-  it "is a preassigned UUID" do
+  it "returns a preassigned UUID" do
     point_scope = double(:point_scope)
 
     expect(

--- a/spec/presenters/service_standard_presenter_spec.rb
+++ b/spec/presenters/service_standard_presenter_spec.rb
@@ -10,6 +10,29 @@ RSpec.describe ServiceStandardPresenter, "#content_id" do
   end
 end
 
+RSpec.describe ServiceStandardPresenter, "#content_payload" do
+  it "returns a hash suitable for a service standard draft" do
+    point_scope = double(:point_scope)
+
+    expected_payload = {
+      base_path: '/service-manual/service-standard',
+      document_type: 'service_manual_service_standard',
+      phase: 'beta',
+      publishing_app: 'service-manual-publisher',
+      rendering_app: 'service-manual-frontend',
+      routes: [
+        { type: 'exact', path: '/service-manual/service-standard' }
+      ],
+      schema_name: 'service_manual_service_standard',
+      title: 'The Digital Service Standard',
+    }
+
+    expect(
+      described_class.new(point_scope).content_payload
+    ).to eq(expected_payload)
+  end
+end
+
 RSpec.describe ServiceStandardPresenter, "#links_payload" do
   it "includes points" do
     point1 = create(:point)

--- a/spec/presenters/service_standard_presenter_spec.rb
+++ b/spec/presenters/service_standard_presenter_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe ServiceStandardPresenter, "#content_id" do
+  it "is a preassigned UUID" do
+    point_scope = double(:point_scope)
+
+    expect(
+      described_class.new(point_scope).content_id
+    ).to eq("00f693d4-866a-4fe6-a8d6-09cd7db8980b")
+  end
+end
+
+RSpec.describe ServiceStandardPresenter, "#links_payload" do
+  it "includes points" do
+    point1 = create(:point)
+    point2 = create(:point)
+
+    expected_payload = {
+      links: {
+        points: [point1.content_id, point2.content_id]
+      }
+    }
+
+    expect(
+      described_class.new([point1, point2]).links_payload
+    ).to eq(expected_payload)
+  end
+end

--- a/spec/presenters/service_standard_presenter_spec.rb
+++ b/spec/presenters/service_standard_presenter_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe ServiceStandardPresenter, "#content_payload" do
       ],
       schema_name: 'service_manual_service_standard',
       title: 'The Digital Service Standard',
+      details: {
+        introduction: "The Digital Service Standard is a set of 18 criteria to help government create and run good digital services.",
+        body: "All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use.",
+      }
     }
 
     expect(

--- a/spec/presenters/service_standard_presenter_spec.rb
+++ b/spec/presenters/service_standard_presenter_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ServiceStandardPresenter, "#content_payload" do
         { type: 'exact', path: '/service-manual/service-standard' }
       ],
       schema_name: 'service_manual_service_standard',
-      title: 'The Digital Service Standard',
+      title: 'Digital Service Standard',
       details: {
         introduction: "The Digital Service Standard is a set of 18 criteria to help government create and run good digital services.",
         body: "All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use.",


### PR DESCRIPTION
We are replacing https://www.gov.uk/service-manual/digital-by-default.

https://trello.com/c/oDSuK5ay

Broadly speaking this PR..

* Publishes a new schema service_manual_service_standard
* Removes the need for a topic for Points

We are storing the relationship between the standard and the points in the details hash of the service_manual_service_standard. This will be moved to the links hash when we can take advantage of custom fields in link expansion.