### PR TITLE
Only include published point editions in the service standard

### DIFF
--- a/app/presenters/service_standard_presenter.rb
+++ b/app/presenters/service_standard_presenter.rb
@@ -34,14 +34,18 @@ private
   attr_reader :points
 
   def points_payload
-    points.map do |point|
-      edition = point.latest_edition
+    point_payloads = points.map do |point|
+      edition = point.live_edition
 
-      {
-        base_path: point.slug,
-        summary: edition.summary,
-        title: edition.title,
-      }
+      if edition
+        {
+          base_path: point.slug,
+          summary: edition.summary,
+          title: edition.title,
+        }
+      end
     end
+
+    point_payloads.compact
   end
 end

--- a/spec/forms/point_form_spec.rb
+++ b/spec/forms/point_form_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe PointForm, "#save" do
 
   it "saves all points to the service standard when saving a point" do
     user = create(:user)
-    edition = create(:edition, summary: "This is a summary")
+    edition = create(:edition, summary: "This is a summary", state: "published")
     create(:point, editions: [edition])
 
     point = Point.new
@@ -69,8 +69,7 @@ RSpec.describe PointForm, "#save" do
       .to receive(:patch_links)
       .with(an_instance_of(String), hash_including(links: an_instance_of(Hash)))
 
-    # Expect communication with the publishing api for the service
-    # standard
+    # Expect to save all published points to the publishing api when saving a point
     expect(PUBLISHING_API)
       .to receive(:put_content)
       .with(
@@ -78,7 +77,6 @@ RSpec.describe PointForm, "#save" do
         hash_including(
           details: hash_including(
             points: [
-              hash_including(:base_path, :summary, :title),
               hash_including(:base_path, :summary, :title),
             ]
           )


### PR DESCRIPTION
We don't want the latest draft version of a point to creep in the published standard.