### PR TITLE
Save and publish the standard when publising a point

### DIFF
--- a/app/forms/point_form.rb
+++ b/app/forms/point_form.rb
@@ -6,16 +6,4 @@ class PointForm < BaseGuideForm
   def slug_prefix
     "/service-manual/service-standard"
   end
-
-private
-
-  def save_draft_to_publishing_api
-    super
-
-    service_standard_for_publication = ServiceStandardPresenter.new(Point.all)
-    PUBLISHING_API.put_content(
-      service_standard_for_publication.content_id,
-      service_standard_for_publication.content_payload
-    )
-  end
 end

--- a/spec/features/point_page_spec.rb
+++ b/spec/features/point_page_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Create a point page', type: :feature, js: true do
 
     publishing_api = double(:publishing_api)
     stub_const("PUBLISHING_API", publishing_api)
-    expect(publishing_api).to receive(:put_content).twice
+    expect(publishing_api).to receive(:put_content).once
     expect(publishing_api).to receive(:patch_links).once
 
     fill_in "Description", with: "User needs should be your first focus."

--- a/spec/forms/point_form_spec.rb
+++ b/spec/forms/point_form_spec.rb
@@ -21,7 +21,7 @@ end
 
 RSpec.describe PointForm, "#save" do
   it "persists a point with an edition and doesn't place it in a topic section" do
-    expect(PUBLISHING_API).to receive(:put_content).twice
+    expect(PUBLISHING_API).to receive(:put_content).once
     expect(PUBLISHING_API).to receive(:patch_links).once
 
     guide_community = create(:guide_community)
@@ -45,45 +45,6 @@ RSpec.describe PointForm, "#save" do
     expect(edition).to be_persisted
 
     expect(TopicSectionGuide.count).to eq(0)
-  end
-
-  it "saves all points to the service standard when saving a point" do
-    user = create(:user)
-    edition = create(:edition, summary: "This is a summary", state: "published")
-    create(:point, editions: [edition])
-
-    point = Point.new
-    edition = point.editions.build
-    guide_form = described_class.new(guide: point, edition: edition, user: user)
-    guide_form.assign_attributes(body: "a fair old body",
-      description: "a pleasant description",
-      summary: "a exciting summary",
-      slug: "/service-manual/service-standard/do-ongoing-user-research",
-      title: "Do ongoing user research",
-      update_type: "minor",
-      )
-
-    # Stub communication with the publishing api for the point
-    allow(PUBLISHING_API).to receive(:put_content)
-    allow(PUBLISHING_API)
-      .to receive(:patch_links)
-      .with(an_instance_of(String), hash_including(links: an_instance_of(Hash)))
-
-    # Expect to save all published points to the publishing api when saving a point
-    expect(PUBLISHING_API)
-      .to receive(:put_content)
-      .with(
-        an_instance_of(String),
-        hash_including(
-          details: hash_including(
-            points: [
-              hash_including(:base_path, :summary, :title),
-            ]
-          )
-        )
-      )
-
-    guide_form.save
   end
 end
 

--- a/spec/models/guide_manager_spec.rb
+++ b/spec/models/guide_manager_spec.rb
@@ -126,8 +126,12 @@ RSpec.describe GuideManager, '#publish' do
     expect(result).to be_success
   end
 
-  it "publishes the service standard if publishing a point" do
+  it "saves and publishes the service standard with other published points if publishing a point" do
     user = create(:user)
+
+    other_edition = create(:edition, title: "Scrum", summary: "This is a summary", state: "published")
+    create(:point, editions: [other_edition])
+
     editions = [
       build(:edition, title: 'Agile', summary: "Summary"),
       build(:edition, title: 'Agile', summary: "Summary", state: 'review_requested'),
@@ -138,9 +142,25 @@ RSpec.describe GuideManager, '#publish' do
     expect(PUBLISHING_API).to receive(:publish)
       .with(point.content_id, an_instance_of(String))
       .once
+
+    expect(PUBLISHING_API).to receive(:put_content)
+      .with(
+        an_instance_of(String),
+        hash_including(
+          details: hash_including(
+            points: [
+              hash_including(:base_path, :summary, title: "Scrum"),
+              hash_including(:base_path, :summary, title: "Agile"),
+            ]
+          )
+        )
+      )
+      .once
+
     expect(PUBLISHING_API).to receive(:publish)
       .with(ServiceStandardPresenter::SERVICE_STANDARD_CONTENT_ID, "major")
       .once
+
     expect(RUMMAGER_API).to receive(:add_document)
 
     manager = described_class.new(guide: point, user: user)


### PR DESCRIPTION
Because the draft of the standard can be overwritten (by saving a different point) before it is published we need to save and publish the standard when a point has just been published.

Don't merge yet.. I'm going to give this a decent poke on integration first.