### PR TITLE
Exclude the blank "" option from the page type filter drop down

### DIFF
--- a/app/helpers/guide_helper.rb
+++ b/app/helpers/guide_helper.rb
@@ -19,7 +19,7 @@ module GuideHelper
   end
 
   def guide_types_for_select
-    guide_types = Guide.distinct(:type).pluck(:type).compact
+    guide_types = Guide.distinct(:type).pluck(:type).reject(&:blank?)
     options = guide_types.map do |type|
       [type.underscore.humanize.titleize, type]
     end

--- a/spec/helpers/guide_helper_spec.rb
+++ b/spec/helpers/guide_helper_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe GuideHelper, '#guide_types_for_select', type: :helper do
     edition = build(:edition, content_owner: guide_community, title: "Scrum")
     create(:guide, editions: [edition])
 
+    # explicitly create a guide with an 'empty' type, to check we don't get
+    # a blank option in the drop down.
+    create(:guide, type: '')
+
     expect(helper.guide_types_for_select).to match_array(
       [
         %w(All All),


### PR DESCRIPTION
compact only rejects nil values, but we get empty strings when doing `Guide.distinct(:type).pluck(:type)` so exclude them too.