### PR TITLE
Update Airbrake gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'uglifier'
 gem 'unicorn'
 gem 'logstasher'
 gem 'plek'
-gem 'airbrake', '4.2.1'
+gem 'airbrake'
 
 gem 'govuk_admin_template'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,9 +42,9 @@ GEM
     acts_as_list (0.7.4)
       activerecord (>= 3.0)
     addressable (2.3.8)
-    airbrake (4.2.1)
-      builder
-      multi_json
+    airbrake (5.4.1)
+      airbrake-ruby (~> 1.4)
+    airbrake-ruby (1.4.3)
     arel (6.0.3)
     ast (2.3.0)
     auto_strip_attributes (2.0.6)
@@ -342,7 +342,7 @@ PLATFORMS
 DEPENDENCIES
   active_link_to
   acts_as_list
-  airbrake (= 4.2.1)
+  airbrake
   auto_strip_attributes
   better_errors
   binding_of_caller

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -2,9 +2,9 @@ if ENV['ERRBIT_API_KEY'].present?
   errbit_uri = Plek.find_uri('errbit')
 
   Airbrake.configure do |config|
-    config.api_key = ENV['ERRBIT_API_KEY']
+    config.project_id = ENV['ERRBIT_API_KEY']
+    config.project_key = ENV['ERRBIT_API_KEY']
     config.host = errbit_uri.host
-    config.secure = errbit_uri.scheme == 'https'
-    config.environment_name = ENV['ERRBIT_ENVIRONMENT_NAME']
+    config.environment = ENV['ERRBIT_ENVIRONMENT_NAME']
   end
 end


### PR DESCRIPTION
The configuration api changed for version 5 of airbrake.

This works in integration.. I managed to get an error into the Errbit interface.