### PR TITLE
Remove the summary from editions

### DIFF
--- a/app/forms/base_guide_form.rb
+++ b/app/forms/base_guide_form.rb
@@ -5,7 +5,7 @@ class BaseGuideForm
 
   attr_reader :guide, :edition, :user
   attr_accessor :author_id, :body, :change_note, :change_summary, :content_owner_id, :description, :slug,
-    :summary, :title, :title_slug, :type, :update_type, :version
+    :title, :title_slug, :type, :update_type, :version
 
   delegate :persisted?, to: :guide
 
@@ -31,7 +31,6 @@ class BaseGuideForm
     self.content_owner_id = edition.content_owner_id
     self.description = edition.description
     self.slug = guide.slug
-    self.summary = edition.summary
     self.title = edition.title
     self.title_slug = extracted_title_from_slug
     self.type = guide.type
@@ -56,7 +55,6 @@ class BaseGuideForm
     edition.created_by_id = user.id
     edition.description = description
     edition.state = Edition::STATES.first
-    edition.summary = summary
     edition.title = title
     edition.update_type = update_type
     edition.version = version

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -3,7 +3,6 @@ class Guide < ActiveRecord::Base
   validate :slug_format
   validate :slug_cant_be_changed_if_an_edition_has_been_published
   validate :new_edition_has_content_owner, if: :requires_content_owner?
-  validate :new_edition_has_summary, if: :requires_summary?
 
   has_many :editions, dependent: :destroy
   has_many :topic_section_guides, autosave: true
@@ -102,10 +101,6 @@ class Guide < ActiveRecord::Base
     true
   end
 
-  def requires_summary?
-    false
-  end
-
 private
 
   def has_unpublished_edition?
@@ -133,14 +128,6 @@ private
 
     if new_edition && new_edition.content_owner.nil?
       errors.add(:latest_edition, 'must have a content owner')
-    end
-  end
-
-  def new_edition_has_summary
-    new_edition = editions.detect(&:new_record?)
-
-    if new_edition && new_edition.summary.blank?
-      errors.add(:latest_edition, 'must have a summary')
     end
   end
 end

--- a/app/models/guide_community.rb
+++ b/app/models/guide_community.rb
@@ -2,8 +2,4 @@ class GuideCommunity < Guide
   def requires_content_owner?
     false
   end
-
-  def requires_summary?
-    false
-  end
 end

--- a/app/models/point.rb
+++ b/app/models/point.rb
@@ -2,8 +2,4 @@ class Point < Guide
   def requires_content_owner?
     false
   end
-
-  def requires_summary?
-    true
-  end
 end

--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -55,8 +55,6 @@ private
       header_links: level_two_headers,
     }
 
-    details_hash[:summary] = edition.summary if edition.summary.present?
-
     details_hash
   end
 

--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -55,6 +55,10 @@ private
       header_links: level_two_headers,
     }
 
+    if guide.is_a?(Point)
+      details_hash[:show_description] = true
+    end
+
     details_hash
   end
 

--- a/app/presenters/service_standard_presenter.rb
+++ b/app/presenters/service_standard_presenter.rb
@@ -40,7 +40,7 @@ private
       if edition
         {
           base_path: point.slug,
-          summary: edition.summary,
+          summary: edition.description,
           title: edition.title,
         }
       end

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -63,15 +63,6 @@
         <%= f.text_area :description, disabled: disable_inputs, rows: 5, class: 'input-md-12 form-control text-area-auto-size js-text-area-auto-size' %>
       </div>
 
-      <% if guide.requires_summary? %>
-        <div class='form-group'>
-          <%= f.label :summary %>
-          <%= f.error_list :summary %>
-          <span class="help-block">The summary beneath the title which does not support formatting.</span>
-          <%= f.text_area :summary, disabled: disable_inputs, rows: 5, class: 'input-md-12 form-control text-area-auto-size js-text-area-auto-size' %>
-        </div>
-      <% end %>
-
       <div class="form-group">
         <%= f.label :body %>
         <%= f.error_list :body %>

--- a/db/migrate/20160630082357_drop_editions_summary.rb
+++ b/db/migrate/20160630082357_drop_editions_summary.rb
@@ -1,0 +1,5 @@
+class DropEditionsSummary < ActiveRecord::Migration
+  def change
+    remove_column :editions, :summary
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -132,7 +132,6 @@ CREATE TABLE editions (
     change_summary text,
     content_owner_id integer,
     version integer,
-    summary text,
     created_by_id integer
 );
 
@@ -827,4 +826,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160510122327');
 INSERT INTO schema_migrations (version) VALUES ('20160510122328');
 
 INSERT INTO schema_migrations (version) VALUES ('20160520134625');
+
+INSERT INTO schema_migrations (version) VALUES ('20160630082357');
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -119,14 +119,14 @@ FactoryGirl.define do
     transient do
       title "An Unpublished Point"
       body "Some Body Text"
-      summary "A summary"
+      description "A summary"
     end
 
     editions {
       [
-        build(:edition, state: "draft", title: title, body: body, summary: summary),
-        build(:edition, state: "published", title: title, body: body, summary: summary),
-        build(:edition, state: "unpublished", title: title, body: body, summary: summary),
+        build(:edition, state: "draft", title: title, body: body, description: description),
+        build(:edition, state: "published", title: title, body: body, description: description),
+        build(:edition, state: "unpublished", title: title, body: body, description: description),
       ]
     }
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -115,22 +115,6 @@ FactoryGirl.define do
     }
   end
 
-  factory :unpublished_point, parent: :guide, class: 'Point' do
-    transient do
-      title "An Unpublished Point"
-      body "Some Body Text"
-      description "A summary"
-    end
-
-    editions {
-      [
-        build(:edition, state: "draft", title: title, body: body, description: description),
-        build(:edition, state: "published", title: title, body: body, description: description),
-        build(:edition, state: "unpublished", title: title, body: body, description: description),
-      ]
-    }
-  end
-
   factory :user do
     name "Test User"
     permissions ["signin"]

--- a/spec/features/guide_community_spec.rb
+++ b/spec/features/guide_community_spec.rb
@@ -42,11 +42,4 @@ RSpec.describe 'Create a guide community', type: :feature do
 
     expect(page).to_not have_field('Community')
   end
-
-  it 'does not have a summary field' do
-    visit root_path
-    click_link "Create a Guide Community"
-
-    expect(page).to_not have_field('Summary')
-  end
 end

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -178,13 +178,6 @@ RSpec.describe "creating guides", type: :feature do
     end
   end
 
-  it 'does not have a summary field' do
-    visit root_path
-    click_link "Create a Guide"
-
-    expect(page).to_not have_field('Summary')
-  end
-
 private
 
   def fill_in_guide_form

--- a/spec/features/point_page_spec.rb
+++ b/spec/features/point_page_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe 'Create a point page', type: :feature, js: true do
     expect(publishing_api).to receive(:put_content).once
     expect(publishing_api).to receive(:patch_links).once
 
-    fill_in "Description", with: "User needs should be your first focus."
-    fill_in "Summary", with: "Understand user needs. Research to develop a deep knowledge of who the service users are and what that means for the design of the service."
+    fill_in "Description", with: "Understand user needs. Research to develop a deep knowledge of who the service users are and what that means for the design of the service."
     fill_in "Title", with: "Understand user needs"
     fill_in "Body", with: "## Why it's in the standard"
     click_first_button "Save"
@@ -25,8 +24,7 @@ RSpec.describe 'Create a point page', type: :feature, js: true do
     visit current_path
 
     expect(page).to have_field('Final URL', with: "/service-manual/service-standard/understand-user-needs")
-    expect(page).to have_field('Description', with: "User needs should be your first focus.")
-    expect(page).to have_field('Summary', with: "Understand user needs. Research to develop a deep knowledge of who the service users are and what that means for the design of the service.")
+    expect(page).to have_field('Description', with: "Understand user needs. Research to develop a deep knowledge of who the service users are and what that means for the design of the service.")
     expect(page).to have_field('Title', with: "Understand user needs")
     expect(page).to have_field('Body', with: "## Why it's in the standard")
   end

--- a/spec/features/unpublish_spec.rb
+++ b/spec/features/unpublish_spec.rb
@@ -116,13 +116,5 @@ RSpec.describe "unpublishing guides", type: :feature do
 
       expect(page).to_not have_field("Author")
     end
-
-    it "disables the summary field for a points page" do
-      guide = create(:unpublished_point)
-
-      visit edit_guide_path(guide)
-
-      expect(page).to_not have_field("Summary")
-    end
   end
 end

--- a/spec/forms/point_form_spec.rb
+++ b/spec/forms/point_form_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe PointForm, "#save" do
       content_owner_id: guide_community.id,
       description: "a pleasant description",
       slug: "/service-manual/topic/a-fair-tale",
-      summary: "This is my nice summary",
       title: "A fair tale",
       update_type: "minor",
     )
@@ -65,7 +64,6 @@ RSpec.describe PointForm, "validations" do
       "Description can't be blank",
       "Title can't be blank",
       "Body can't be blank",
-      "Latest edition must have a summary",
     )
   end
 end

--- a/spec/models/guide_manager_spec.rb
+++ b/spec/models/guide_manager_spec.rb
@@ -129,13 +129,13 @@ RSpec.describe GuideManager, '#publish' do
   it "saves and publishes the service standard with other published points if publishing a point" do
     user = create(:user)
 
-    other_edition = create(:edition, title: "Scrum", summary: "This is a summary", state: "published")
+    other_edition = create(:edition, title: "Scrum", description: "This is a description", state: "published")
     create(:point, editions: [other_edition])
 
     editions = [
-      build(:edition, title: 'Agile', summary: "Summary"),
-      build(:edition, title: 'Agile', summary: "Summary", state: 'review_requested'),
-      build(:edition, title: 'Agile', summary: "Summary", state: 'ready')
+      build(:edition, title: 'Agile', description: "Summary"),
+      build(:edition, title: 'Agile', description: "Summary", state: 'review_requested'),
+      build(:edition, title: 'Agile', description: "Summary", state: 'ready')
     ]
     point = create(:point, editions: editions)
 

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -97,26 +97,6 @@ RSpec.describe Guide do
       end
     end
 
-    describe "summary" do
-      [:guide, :guide_community].each do |klass|
-        it "does not require a summary if the guide is an instance of #{klass.to_s.classify}" do
-          edition = build(:edition)
-          guide = build(klass, editions: [edition])
-          guide.valid?
-
-          expect(guide.errors.full_messages_for(:latest_edition)).to be_empty
-        end
-      end
-
-      it "requires a summary if the guide is an instance of Point" do
-        edition = build(:edition)
-        guide = build(:point, editions: [edition])
-        guide.valid?
-
-        expect(guide.errors.full_messages_for(:latest_edition)).to include('Latest edition must have a summary')
-      end
-    end
-
     context "has a published edition" do
       it "does not allow changing the slug" do
         guide = create(:published_guide)

--- a/spec/presenters/guide_presenter_spec.rb
+++ b/spec/presenters/guide_presenter_spec.rb
@@ -64,20 +64,6 @@ RSpec.describe GuidePresenter do
       edition.title = "Agile Process"
       expect(presenter.content_payload[:title]).to eq("Agile Process")
     end
-
-    describe "summary" do
-      it "contains the summary" do
-        edition.summary = 'A sample summary'
-
-        expect(presenter.content_payload[:details][:summary]).to eq('A sample summary')
-      end
-
-      it "does not contain summary if the summary is not present" do
-        edition.summary = nil
-
-        expect(presenter.content_payload[:details]).to_not have_key(:summary)
-      end
-    end
   end
 
   describe '#links_payload' do

--- a/spec/presenters/guide_presenter_spec.rb
+++ b/spec/presenters/guide_presenter_spec.rb
@@ -97,4 +97,13 @@ RSpec.describe GuidePresenter, "for a Point" do
       parent: ["00f693d4-866a-4fe6-a8d6-09cd7db8980b"]
     )
   end
+
+  it "includes the show_description boolean in the details" do
+    edition = create(:edition)
+    point = create(:point, editions: [edition])
+
+    presenter = described_class.new(point, edition)
+
+    expect(presenter.content_payload[:details][:show_description]).to eq(true)
+  end
 end

--- a/spec/presenters/service_standard_presenter_spec.rb
+++ b/spec/presenters/service_standard_presenter_spec.rb
@@ -12,7 +12,7 @@ end
 
 RSpec.describe ServiceStandardPresenter, "#content_payload" do
   it "returns a hash suitable for a service standard draft" do
-    edition = create(:edition, summary: "This is a summary", title: "1. Understand user needs", state: "published")
+    edition = create(:edition, description: "This is a description", title: "1. Understand user needs", state: "published")
     point = create(:point, editions: [edition], slug: "/service-manual/service-standard/understand-user-needs")
 
     expected_payload = {
@@ -32,7 +32,7 @@ RSpec.describe ServiceStandardPresenter, "#content_payload" do
         points: [
           {
             title: "1. Understand user needs",
-            summary: "This is a summary",
+            summary: "This is a description",
             base_path: "/service-manual/service-standard/understand-user-needs",
           }
         ]
@@ -45,26 +45,26 @@ RSpec.describe ServiceStandardPresenter, "#content_payload" do
   end
 
   it "only includes published editions" do
-    point1_edition = create(:edition, summary: "This is a summary", title: "1. Understand user needs",)
+    point1_edition = create(:edition, description: "This is a description", title: "1. Understand user needs",)
     create(:point, editions: [point1_edition], slug: "/service-manual/service-standard/understand-user-needs")
 
-    point2_edition = create(:edition, summary: "This is a summary", title: "2. Do ongoing user research", state: "published")
+    point2_edition = create(:edition, description: "This is a description", title: "2. Do ongoing user research", state: "published")
     create(:point, editions: [point2_edition], slug: "/service-manual/service-standard/do-ongoing-user-research")
 
-    point3_edition1 = create(:edition, summary: "This is a summary", title: "3. Have a multidisciplinary team", state: "published")
-    point3_edition2 = create(:edition, summary: "This is a summary", title: "3. Have a multidisciplinary team with a typo")
+    point3_edition1 = create(:edition, description: "This is a description", title: "3. Have a multidisciplinary team", state: "published")
+    point3_edition2 = create(:edition, description: "This is a description", title: "3. Have a multidisciplinary team with a typo")
     create(:point, editions: [point3_edition1, point3_edition2], slug: "/service-manual/service-standard/have-a-multidisciplinary-team")
 
     expected_points_payload =
       [
         {
           title: "2. Do ongoing user research",
-          summary: "This is a summary",
+          summary: "This is a description",
           base_path: "/service-manual/service-standard/do-ongoing-user-research",
         },
         {
           title: "3. Have a multidisciplinary team",
-          summary: "This is a summary",
+          summary: "This is a description",
           base_path: "/service-manual/service-standard/have-a-multidisciplinary-team",
         }
       ]


### PR DESCRIPTION
It turned out there was no need to maintain a separate field for the meta description and the short point text.

To avoid changing everything at once we are leaving the summary in the details hash in the schema. This can potentially be removed in favour of using the description field instead but there needs to be a decision on how we distinguish a guide from a point.