### PR TITLE
Remove the group contents from the topic payload

### DIFF
--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -48,7 +48,6 @@ private
       {
         name: topic_section.title,
         description: topic_section.description,
-        contents: topic_section.guides.map(&:slug),
         content_ids: topic_section.guides.map(&:content_id),
       }
     end

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -52,7 +52,6 @@ RSpec.describe TopicPresenter do
       groups = presented_topic.content_payload[:details][:groups]
       expect(groups.size).to eq 2
       expect(groups.first).to include(name: "Group 1", description: "Fruits")
-      expect(groups.first[:contents]).to eq [guide_1.slug, guide_2.slug]
       expect(groups.first[:content_ids]).to eq [guide_1.content_id, guide_2.content_id]
       expect(groups.last).to include(name: "Group 2", description: "Berries")
     end


### PR DESCRIPTION
It seems as though it's not used in the frontend anymore.