### PR TITLE
Do not send public updated at

### DIFF
--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -18,7 +18,6 @@ class GuidePresenter
       locale: "en",
       update_type: edition.update_type,
       base_path: guide.slug,
-      public_updated_at: edition.updated_at.iso8601,
       title: edition.title,
       description: edition.description,
       phase: edition.phase,

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -15,7 +15,6 @@ class TopicPresenter
       locale: "en",
       update_type: "minor",
       base_path: topic.path,
-      public_updated_at: topic.updated_at.iso8601,
       title: topic.title,
       description: topic.description,
       phase: "beta",

--- a/spec/factories/topic_section.rb
+++ b/spec/factories/topic_section.rb
@@ -1,7 +1,26 @@
 FactoryGirl.define do
+  # Example Usage
+  #
+  # Create a topic section with the title Hello World
+  # -> create(:topic_section, title: "Hello World")
+  #
+  # Create a topic section with associated guides
+  # -> create(:topic_section, guides: [create(:guide), create(:guide)])
+
   factory :topic_section do
+    transient do
+      guides []
+    end
+
     topic
     title "Topic Section Title"
     description "Topic Section Description"
+
+    after(:build) do |topic_section, evaluator|
+      evaluator.guides.each do |guide|
+        topic_section_guide = TopicSectionGuide.new(guide: guide, topic_section: topic_section)
+        topic_section.topic_section_guides << topic_section_guide
+      end
+    end
   end
 end

--- a/spec/presenters/guide_presenter_spec.rb
+++ b/spec/presenters/guide_presenter_spec.rb
@@ -41,8 +41,13 @@ RSpec.describe GuidePresenter do
       )
     end
 
-    it "doesn't contain public_updated_at so that it represents the published at time" \
-     " on the frontend" do
+    it "omits public_updated_at" do
+      # If the payload includes public_updated_at then the user facing timestamp on the
+      # frontend will reflect the time the draft was saved rather than the time it was
+      # published. For the service manual we want to display the published time to the user.
+      #
+      # https://github.com/alphagov/content-store/blob/master/doc/content_item_fields.md#public_updated_at
+      #
       expect(presenter.content_payload).to_not have_key(:public_updated_at)
     end
 

--- a/spec/presenters/guide_presenter_spec.rb
+++ b/spec/presenters/guide_presenter_spec.rb
@@ -28,27 +28,20 @@ RSpec.describe GuidePresenter do
       expect(presenter.content_payload).to be_valid_against_schema('service_manual_guide')
     end
 
+    describe "common service manual draft payload" do
+      let(:payload) { presenter.content_payload }
+
+      include_examples "common service manual draft payload"
+    end
+
     it "exports all necessary metadata" do
       expect(presenter.content_payload).to include(
         description: "Description",
         update_type: "major",
         phase: "beta",
-        publishing_app: "service-manual-publisher",
-        rendering_app: "service-manual-frontend",
         format: "service_manual_guide",
-        locale: "en",
         base_path: "/service/manual/test"
       )
-    end
-
-    it "omits public_updated_at" do
-      # If the payload includes public_updated_at then the user facing timestamp on the
-      # frontend will reflect the time the draft was saved rather than the time it was
-      # published. For the service manual we want to display the published time to the user.
-      #
-      # https://github.com/alphagov/content-store/blob/master/doc/content_item_fields.md#public_updated_at
-      #
-      expect(presenter.content_payload).to_not have_key(:public_updated_at)
     end
 
     it "omits the content owner if the edition doesn't have one" do

--- a/spec/presenters/guide_presenter_spec.rb
+++ b/spec/presenters/guide_presenter_spec.rb
@@ -41,6 +41,11 @@ RSpec.describe GuidePresenter do
       )
     end
 
+    it "doesn't contain public_updated_at so that it represents the published at time" \
+     " on the frontend" do
+      expect(presenter.content_payload).to_not have_key(:public_updated_at)
+    end
+
     it "omits the content owner if the edition doesn't have one" do
       edition.content_owner = nil
 

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe TopicPresenter, "#content_payload" do
     expect(topic_presenter.content_payload).to be_valid_against_schema('service_manual_topic')
   end
 
+  describe "common service manual draft payload" do
+    let(:payload) { described_class.new(build(:topic)).content_payload }
+
+    include_examples "common service manual draft payload"
+  end
+
   it "exports all necessary metadata" do
     topic = build(
       :topic,
@@ -19,24 +25,9 @@ RSpec.describe TopicPresenter, "#content_payload" do
       description: "Topic description",
       update_type: "minor",
       phase: "beta",
-      publishing_app: "service-manual-publisher",
-      rendering_app: "service-manual-frontend",
       format: "service_manual_topic",
-      locale: "en",
       base_path: "/service-manual/test-topic"
     )
-  end
-
-  it "omits public_updated_at" do
-    # If the payload includes public_updated_at then the user facing timestamp on the
-    # frontend will reflect the time the draft was saved rather than the time it was
-    # published. For the service manual we want to display the published time to the user.
-    #
-    # https://github.com/alphagov/content-store/blob/master/doc/content_item_fields.md#public_updated_at
-    #
-    topic_presenter = described_class.new(build(:topic))
-
-    expect(topic_presenter.content_payload).to_not have_key(:public_updated_at)
   end
 
   it "sets visually_collapsed" do

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe TopicPresenter, "#content_payload" do
     expect(topic_presenter.content_payload).to_not have_key(:public_updated_at)
   end
 
-  it "sets visually_expanded" do
+  it "sets visually_collapsed" do
     topic = build(:topic, visually_collapsed: true)
     topic_presenter = described_class.new(topic)
 

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -48,6 +48,11 @@ RSpec.describe TopicPresenter do
       )
     end
 
+    it "doesn't contain public_updated_at so that it represents the published at time" \
+     " on the frontend" do
+      expect(presented_topic.content_payload).to_not have_key(:public_updated_at)
+    end
+
     it "transforms nested guides into the groups format" do
       groups = presented_topic.content_payload[:details][:groups]
       expect(groups.size).to eq 2

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -27,8 +27,13 @@ RSpec.describe TopicPresenter, "#content_payload" do
     )
   end
 
-  it "doesn't contain public_updated_at so that it represents the published at time" \
-   " on the frontend" do
+  it "omits public_updated_at" do
+    # If the payload includes public_updated_at then the user facing timestamp on the
+    # frontend will reflect the time the draft was saved rather than the time it was
+    # published. For the service manual we want to display the published time to the user.
+    #
+    # https://github.com/alphagov/content-store/blob/master/doc/content_item_fields.md#public_updated_at
+    #
     topic_presenter = described_class.new(build(:topic))
 
     expect(topic_presenter.content_payload).to_not have_key(:public_updated_at)

--- a/spec/support/common_service_manual_draft_payload.rb
+++ b/spec/support/common_service_manual_draft_payload.rb
@@ -1,0 +1,23 @@
+shared_examples "common service manual draft payload" do
+  # If the payload includes public_updated_at then the user facing timestamp on the
+  # frontend will reflect the time the draft was saved rather than the time it was
+  # published. For the service manual we want to display the published time to the user.
+  #
+  # https://github.com/alphagov/content-store/blob/master/doc/content_item_fields.md#public_updated_at
+  #
+  it "omits public_updated_at" do
+    expect(payload).to_not have_key(:public_updated_at)
+  end
+
+  it "is published by the service-manual-publisher" do
+    expect(payload).to include(publishing_app: "service-manual-publisher")
+  end
+
+  it "is rendering by the service-manual-frontend" do
+    expect(payload).to include(rendering_app: "service-manual-frontend")
+  end
+
+  it "is in locale en" do
+    expect(payload).to include(locale: "en")
+  end
+end


### PR DESCRIPTION
https://trello.com/c/QzWdrdgO

This includes a bit of clean up for the topic presenter test.

The complication was that we were using `updated_at` on the frontend which is fixed by this: https://github.com/alphagov/service-manual-frontend/pull/42