### PR TITLE
Revert "Exclude unpublished guides"

### DIFF
--- a/app/helpers/guide_helper.rb
+++ b/app/helpers/guide_helper.rb
@@ -29,7 +29,7 @@ module GuideHelper
 
   def guide_community_options_for_select
     # TODO: N+1 on loading the most recent edition
-    GuideCommunity.with_published_editions.
+    GuideCommunity.all.
       sort_by(&:title).
       map { |g| [g.title, g.id] }
   end

--- a/spec/factories/edition.rb
+++ b/spec/factories/edition.rb
@@ -22,7 +22,7 @@ FactoryGirl.define do
     change_summary "change summary"
     body "Heading"
     version 1
-    content_owner { build(:guide_community, :with_published_edition) }
+    content_owner { build(:guide_community) }
     author { build(:user) }
     created_by { author }
 

--- a/spec/features/guide_history_spec.rb
+++ b/spec/features/guide_history_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Guide history", type: :feature do
     dave = create(:user, name: "Dave")
 
     create(:topic_section, topic: create(:topic))
-    community = create(:guide_community, :with_published_edition)
+    community = create(:guide_community)
 
     GDS::SSO.test_user = john
 

--- a/spec/features/guide_index_filter_spec.rb
+++ b/spec/features/guide_index_filter_spec.rb
@@ -45,11 +45,15 @@ RSpec.describe "filtering guides", type: :feature do
 
   it "filters by community" do
     [1, 2].each do |i|
-      guide_community = create(:guide_community, :with_published_edition, title: "Content Owner #{i}")
-      create(:guide, :with_review_requested_edition, edition: {
-        title: "Edition #{i}",
-        content_owner_id: guide_community.id
-      })
+      edition = build(:edition, content_owner: nil, title: "Content Owner #{i}")
+      guide_community = create(:guide_community, editions: [edition])
+
+      edition = build(:edition,
+                      state: "review_requested",
+                      title: "Edition #{i}",
+                      content_owner_id: guide_community.id,
+                     )
+      create(:guide, slug: "/service-manual/topic-name/#{i}", editions: [edition])
     end
 
     filter_by_community "Content Owner 1"
@@ -119,7 +123,8 @@ RSpec.describe "filtering guides", type: :feature do
 
   it "displays a page header that's based on the query" do
     ronan = create(:user, name: "Ronan")
-    guide_community = create(:guide_community, :with_published_edition, edition: { author: ronan })
+    edition = create(:edition, author: ronan)
+    guide_community = create(:guide_community, editions: [edition])
 
     visit root_path
     within ".filters" do

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
   describe "author behaviour" do
     context "creating a new guide" do
       it "sets the author to the current user" do
-        create(:guide_community, :with_published_edition)
+        create(:guide_community)
 
         topic = create(:topic)
         topic_section = create(:topic_section, topic: topic)

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -9,7 +9,12 @@ RSpec.describe "creating guides", type: :feature do
     create(:topic_section, topic: topic1, title: "My Topic Section Number 1")
     create(:topic_section, topic: topic2, title: "My Topic Section Number 2")
 
-    create(:guide_community, :with_published_edition, title: "Technology Community")
+    edition = build(
+      :edition,
+      content_owner: nil,
+      title: "Technology Community"
+    )
+    create(:guide_community, editions: [edition])
 
     topic = create(:topic)
     create(:topic_section, topic: topic)

--- a/spec/helpers/guide_helper_spec.rb
+++ b/spec/helpers/guide_helper_spec.rb
@@ -2,11 +2,9 @@ require 'rails_helper'
 
 RSpec.describe GuideHelper, '#guide_community_options_for_select', type: :helper do
   it 'returns an array of options for a select tag in alphabetical order' do
-    second = create(:guide_community, :with_published_edition, title: 'Banana')
-    first = create(:guide_community, :with_published_edition, title: 'Apple')
-    third = create(:guide_community, :with_previously_published_edition, title: 'Cucumber')
-
-    create(:guide_community, title: 'Draft which should not appear in the list')
+    second = create(:guide_community, editions: [build(:edition, title: 'Banana', content_owner: nil)])
+    first = create(:guide_community, editions: [build(:edition, title: 'Apple', content_owner: nil)])
+    third = create(:guide_community, editions: [build(:edition, title: 'Cucumber', content_owner: nil)])
 
     expect(helper.guide_community_options_for_select).to eq(
       [

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -105,31 +105,22 @@ RSpec.describe Guide do
     end
   end
 
-  describe ".with_published_editions" do
+  describe "#with_published_editions" do
     it "only returns published editions" do
-      guide_community = create(:guide_community, :with_published_edition)
-      create(:guide, slug: "/service-manual/topic-name/1", edition: {
-        content_owner_id: guide_community.id
-      })
-      published_guide = create(:guide, :with_published_edition,
-        slug: "/service-manual/topic-name/2",
-        edition: {
-          content_owner_id: guide_community.id
-        }
-      )
-
-      expect(Guide.with_published_editions).to match_array [guide_community, published_guide]
+      create(:guide, slug: "/service-manual/topic-name/1")
+      guide_with_published_editions = create(:guide, :with_published_edition, slug: "/service-manual/topic-name/2")
+      expect(Guide.with_published_editions.to_a).to eq [guide_with_published_editions]
     end
 
     it "does not return duplicates" do
-      guide_community = create(:guide_community, :with_published_edition)
       guide = create(:guide,
         slug: "/service-manual/topic-name/2",
-        states: [:draft, :review_requested, :ready, :published] * 2,
-        edition: { content_owner_id: guide_community.id }
-      )
-
-      expect(Guide.with_published_editions).to match_array [guide_community, guide]
+        editions: [
+          build(:edition, :published),
+          build(:edition, :published),
+        ],
+                    )
+      expect(Guide.with_published_editions.to_a).to eq [guide]
     end
   end
 


### PR DESCRIPTION
Reverts alphagov/service-manual-publisher#303 due to a misunderstanding about the word 'unpublished'… currently it excludes things that have _not yet_ been published, but does not exclude things which have been published and then _unpublished_.