### PR TITLE
Fix deleting topic sections

### DIFF
--- a/app/assets/javascripts/topics.js
+++ b/app/assets/javascripts/topics.js
@@ -1,5 +1,5 @@
 $(function() {
-  var $topics = $(".topics");
+  var $topics = $(".js-topic-section-list");
 
   $topics.on("click", ".js-delete-list-group-item", function() {
     $item = $(this).parents(".list-group-item");

--- a/spec/features/deletion_of_topic_sections.rb
+++ b/spec/features/deletion_of_topic_sections.rb
@@ -1,18 +1,27 @@
 require 'rails_helper'
 
-RSpec.describe "Deletion of topic sections", type: :feature do
-  it "lets you delete empty topic sections" do
+RSpec.describe "Deletion of topic sections", type: :feature, js: true do
+  before do
+    stub_any_publishing_api_call
+  end
+
+  it "allows you to delete empty topic sections" do
     topic = create(:topic)
-    section_without_guides = topic.topic_sections.create!(title: "Empty Group")
+    section_without_guides = create(:topic_section, title: "Empty Group", topic: topic)
+    topic.topic_sections << section_without_guides
 
     visit edit_topic_path(topic)
 
     within_topic_section(section_without_guides.title) do
-      expect(page).to have_css '.js-delete-list-group-item'
+      find('.js-delete-list-group-item').click
     end
+
+    click_button 'Save'
+
+    expect(page).not_to have_css '.topic-section-list .list-group-item'
   end
 
-  it "does not let you delete topic sections that contain guides" do
+  it "does not display the delete icon for sections that contain guides" do
     topic = create(:topic, :with_some_guides)
     section_with_guides = topic.topic_sections[0]
 


### PR DESCRIPTION
When I removed the topics class from the body of the topic page section deletion stopped working. We didn't notice because it wasn't tested.

So add a test, and then fix it.