### PR TITLE
Remove duplicate elements in redirect select options

### DIFF
--- a/app/helpers/redirect_destination_helper.rb
+++ b/app/helpers/redirect_destination_helper.rb
@@ -3,11 +3,9 @@ module RedirectDestinationHelper
     guide_select_options = Guide
       .live
       .order(:slug).pluck(:slug)
-      .map { |g| [g, g] }
 
     topic_select_options = Topic
       .order(:path).pluck(:path)
-      .map { |g| [g, g] }
 
     {
       "Other" => ["/service-manual", "/service-manual/service-standard"],

--- a/spec/helpers/redirect_destination_helper_spec.rb
+++ b/spec/helpers/redirect_destination_helper_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe RedirectDestinationHelper, '#redirect_destination_select_options'
 
     expect(helper.redirect_destination_select_options).to eq(
       "Other" => ["/service-manual", "/service-manual/service-standard"],
-      "Topics" => [[topic.path, topic.path]],
-      "Guides" => [[guide.slug, guide.slug]]
+      "Topics" => [topic.path],
+      "Guides" => [guide.slug]
     )
   end
 end


### PR DESCRIPTION
In the RedirectDestinationHelper, it was not necessary to map the array when .order.pluck already does this. This has now been removed.