### PR TITLE
Omit 'editions is invalid' error message

### DIFF
--- a/app/forms/base_guide_form.rb
+++ b/app/forms/base_guide_form.rb
@@ -128,8 +128,9 @@ private
   end
 
   def promote_errors_for(model)
+    ignored_attributes = [:editions]
     model.errors.each do |attrib, message|
-      errors.add(attrib, message)
+      errors.add(attrib, message) unless ignored_attributes.include? attrib
     end
   end
 

--- a/app/forms/base_guide_form.rb
+++ b/app/forms/base_guide_form.rb
@@ -67,7 +67,7 @@ class BaseGuideForm
 
         true
       else
-        promote_errors_for(guide)
+        promote_errors_for(guide, ignored_attributes: [:editions])
         promote_errors_for(edition)
 
         false
@@ -127,8 +127,8 @@ private
     end
   end
 
-  def promote_errors_for(model)
-    ignored_attributes = [:editions]
+  def promote_errors_for(model, opts = {})
+    ignored_attributes = opts.fetch(:ignored_attributes, [])
     model.errors.each do |attrib, message|
       errors.add(attrib, message) unless ignored_attributes.include? attrib
     end

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -218,6 +218,24 @@ RSpec.describe "Updating guides", type: :feature do
     end
   end
 
+  it "omits the redundant 'editions is invalid' error message" do
+    topic = create(:topic, path: "/service-manual/technology")
+    topic_section = create(:topic_section, topic: topic)
+    guide = create(
+      :guide,
+      slug: "/service-manual/topic-name/something",
+      editions: [build(:edition)],
+    )
+    topic_section.guides << guide
+    visit edit_guide_path(guide)
+    fill_in "Title", with: ""
+    click_first_button "Save"
+
+    within(".full-error-list") do
+      expect(page).not_to have_content("Editions is invalid")
+    end
+  end
+
   it 'displays an alert if it fails' do
     guide = create(
       :guide,

--- a/spec/forms/guide_form_spec.rb
+++ b/spec/forms/guide_form_spec.rb
@@ -391,7 +391,6 @@ RSpec.describe GuideForm, "validations" do
       "Slug can only contain letters, numbers and dashes",
       "Slug must be present and start with '/service-manual/[topic]'",
       "Latest edition must have a content owner",
-      "Editions is invalid",
       "Description can't be blank",
       "Title can't be blank",
       "Body can't be blank",

--- a/spec/forms/point_form_spec.rb
+++ b/spec/forms/point_form_spec.rb
@@ -60,7 +60,6 @@ RSpec.describe PointForm, "validations" do
     ).to include(
       "Slug can only contain letters, numbers and dashes",
       "Slug must be present and start with '/service-manual/[topic]'",
-      "Editions is invalid",
       "Description can't be blank",
       "Title can't be blank",
       "Body can't be blank",


### PR DESCRIPTION
It doesn't mean anything to the end user, so let's not include it when promoting errors from the guide model.