### PR TITLE
First edition is major

### DIFF
--- a/app/forms/base_guide_form.rb
+++ b/app/forms/base_guide_form.rb
@@ -50,7 +50,7 @@ class BaseGuideForm
     edition.author_id = author_id
     edition.body = body
     edition.reason_for_change = reason_for_change
-    edition.change_note = change_note_or_default
+    edition.change_note = first_or_supplied_changed_note
     edition.content_owner_id = content_owner_id
     edition.created_by_id = user.id
     edition.description = description
@@ -103,18 +103,16 @@ private
     slug ? slug.split("/").last : nil
   end
 
-  def change_note_or_default
-    if change_note.present?
-      change_note
-    else
+  def first_or_supplied_changed_note
+    if version == 1
       default_change_note
+    else
+      change_note
     end
   end
 
   def default_change_note
-    if version == 1
-      'Guidance first published'
-    end
+    'Guidance first published'
   end
 
   def version=(number)

--- a/app/forms/base_guide_form.rb
+++ b/app/forms/base_guide_form.rb
@@ -3,9 +3,9 @@ class BaseGuideForm
 
   include ActiveModel::Model
 
-  attr_reader :guide, :edition, :user
+  attr_reader :guide, :edition, :user, :version
   attr_accessor :author_id, :body, :reason_for_change, :change_note, :content_owner_id, :description, :slug,
-    :title, :title_slug, :type, :update_type, :version
+    :title, :title_slug, :type, :update_type
 
   delegate :persisted?, to: :guide
 
@@ -112,13 +112,13 @@ private
   end
 
   def default_change_note
-    if first_version?
+    if version == 1
       'Guidance first published'
     end
   end
 
-  def first_version?
-    Integer(version) == 1
+  def version=(number)
+    @version = Integer(number)
   end
 
   def next_edition_version

--- a/app/forms/base_guide_form.rb
+++ b/app/forms/base_guide_form.rb
@@ -50,7 +50,7 @@ class BaseGuideForm
     edition.author_id = author_id
     edition.body = body
     edition.reason_for_change = reason_for_change
-    edition.change_note = change_note
+    edition.change_note = change_note_or_default
     edition.content_owner_id = content_owner_id
     edition.created_by_id = user.id
     edition.description = description
@@ -101,6 +101,24 @@ private
 
   def extracted_title_from_slug
     slug ? slug.split("/").last : nil
+  end
+
+  def change_note_or_default
+    if change_note.present?
+      change_note
+    else
+      default_change_note
+    end
+  end
+
+  def default_change_note
+    if first_version?
+      'Guidance first published'
+    end
+  end
+
+  def first_version?
+    Integer(version) == 1
   end
 
   def next_edition_version

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -23,6 +23,7 @@ class Edition < ActiveRecord::Base
 
   validates_presence_of [:state, :phase, :description, :title, :update_type, :body, :author]
   validates_inclusion_of :state, in: STATES
+  validates_inclusion_of :update_type, in: ['major'], if: :first_version?, message: 'must be major'
   validates :reason_for_change, presence: true, if: :major_and_not_first_version?
   validates :change_note, presence: true, if: :major?
   validates :version, presence: true
@@ -93,6 +94,10 @@ class Edition < ActiveRecord::Base
 private
 
   def major_and_not_first_version?
-    major? && (version || 1) > 1
+    major? && !first_version?
+  end
+
+  def first_version?
+    (version || 1) == 1
   end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -23,7 +23,7 @@ class Edition < ActiveRecord::Base
 
   validates_presence_of [:state, :phase, :description, :title, :update_type, :body, :author]
   validates_inclusion_of :state, in: STATES
-  validates :reason_for_change, presence: true, if: :major?
+  validates :reason_for_change, presence: true, if: :major_and_not_first_version?
   validates :change_note, presence: true, if: :major?
   validates :version, presence: true
   validates :created_by, presence: true
@@ -88,5 +88,11 @@ class Edition < ActiveRecord::Base
 
   def notification_subscribers
     [author, guide.latest_edition.author].uniq
+  end
+
+private
+
+  def major_and_not_first_version?
+    major? && (version || 1) > 1
   end
 end

--- a/app/presenters/guide_presenter/change_history_presenter.rb
+++ b/app/presenters/guide_presenter/change_history_presenter.rb
@@ -9,7 +9,7 @@ class GuidePresenter::ChangeHistoryPresenter
       {
         public_timestamp: edition.created_at.iso8601,
         note: edition.change_note,
-        reason_for_change: edition.reason_for_change
+        reason_for_change: edition.reason_for_change || ""
       }
     end
   end

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -82,7 +82,7 @@
       <% end %>
     </div>
 
-    <% if edition.version == 1 %>
+    <% if guide_form.version > 1 %>
       <div class="well">
         <h2>About this update</h2>
 

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -82,55 +82,51 @@
       <% end %>
     </div>
 
-    <% if guide.new_record? %>
-      <%= f.hidden_field :update_type, value: "minor" %>
-    <% else %>
-      <div class="well">
-        <h2>About this update</h2>
+    <div class="well">
+      <h2>About this update</h2>
 
-        <div class='form-group'>
-          <label>Impact of the update</label>
-          <%= f.error_list :update_type %>
-          <div class="radio">
-            <%= label_tag do %>
-              <%= f.radio_button :update_type, "minor", {disabled: disable_inputs, class: 'update-type-select'} %>
-              Minor update
-              <span class='text-muted'>e.g. spelling or typographic corrections.</span>
-            <% end %>
-          </div>
-          <div class="radio">
-            <%= label_tag do %>
-              <%= f.radio_button :update_type, "major", {disabled: disable_inputs, class: 'update-type-select'} %>
-              Major update
-              <span class='text-muted'>e.g. updates that change the meaning of the guidance.</span>
-            <% end %>
-          </div>
+      <div class='form-group'>
+        <label>Impact of the update</label>
+        <%= f.error_list :update_type %>
+        <div class="radio">
+          <%= label_tag do %>
+            <%= f.radio_button :update_type, "minor", {disabled: disable_inputs, class: 'update-type-select'} %>
+            Minor update
+            <span class='text-muted'>e.g. spelling or typographic corrections.</span>
+          <% end %>
         </div>
-
-        <div class="form-group change-note-form-group">
-          <%= f.label :change_note, "Summary of change" %>
-          <div class="help-block">What is being changed in this update</div>
-          <%= f.text_field :change_note, disabled: disable_inputs, class: 'input-md-12 form-control', rows: 5 %>
+        <div class="radio">
+          <%= label_tag do %>
+            <%= f.radio_button :update_type, "major", {disabled: disable_inputs, class: 'update-type-select'} %>
+            Major update
+            <span class='text-muted'>e.g. updates that change the meaning of the guidance.</span>
+          <% end %>
         </div>
-
-        <div class="form-group change-note-form-group">
-          <%= f.label :reason_for_change, "Why the change is being made" %>
-          <div class="help-block">Include any evidence from research and links to any related discussions</div>
-          <%= f.text_area :reason_for_change, disabled: disable_inputs, class: 'input-md-12 form-control text-area-auto-size js-text-area-auto-size', rows: 5 %>
-        </div>
-
-        <p class="text-strong change-note-form-group">
-          <span class="glyphicon glyphicon-warning-sign text-warning" aria-hidden="true"></span>
-          <strong>These notes will be made visible to the public and subscribed users will receive an email update when this guide is published.</strong>
-        </p>
       </div>
 
-      <div class="well">
-        <h2>Assign authorship</h2>
-        <%= f.label :author_id, class: "add-top-margin nav-header" %>
-        <%= f.select :author_id, user_options, {include_blank: "Choose a user"}, {disabled: disable_inputs, class: 'select2 input-md-12 form-control'} %>
+      <div class="form-group change-note-form-group">
+        <%= f.label :change_note, "Summary of change" %>
+        <div class="help-block">What is being changed in this update</div>
+        <%= f.text_field :change_note, disabled: disable_inputs, class: 'input-md-12 form-control', rows: 5 %>
       </div>
-    <% end %>
+
+      <div class="form-group change-note-form-group">
+        <%= f.label :reason_for_change, "Why the change is being made" %>
+        <div class="help-block">Include any evidence from research and links to any related discussions</div>
+        <%= f.text_area :reason_for_change, disabled: disable_inputs, class: 'input-md-12 form-control text-area-auto-size js-text-area-auto-size', rows: 5 %>
+      </div>
+
+      <p class="text-strong change-note-form-group">
+        <span class="glyphicon glyphicon-warning-sign text-warning" aria-hidden="true"></span>
+        <strong>These notes will be made visible to the public and subscribed users will receive an email update when this guide is published.</strong>
+      </p>
+    </div>
+
+    <div class="well">
+      <h2>Assign authorship</h2>
+      <%= f.label :author_id, class: "add-top-margin nav-header" %>
+      <%= f.select :author_id, user_options, {include_blank: "Choose a user"}, {disabled: disable_inputs, class: 'select2 input-md-12 form-control'} %>
+    </div>
   </div>
 
   <div class="col-md-4">

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -82,45 +82,47 @@
       <% end %>
     </div>
 
-    <div class="well">
-      <h2>About this update</h2>
+    <% if edition.version == 1 %>
+      <div class="well">
+        <h2>About this update</h2>
 
-      <div class='form-group'>
-        <label>Impact of the update</label>
-        <%= f.error_list :update_type %>
-        <div class="radio">
-          <%= label_tag do %>
-            <%= f.radio_button :update_type, "minor", {disabled: disable_inputs, class: 'update-type-select'} %>
-            Minor update
-            <span class='text-muted'>e.g. spelling or typographic corrections.</span>
-          <% end %>
+        <div class='form-group'>
+          <label>Impact of the update</label>
+          <%= f.error_list :update_type %>
+          <div class="radio">
+            <%= label_tag do %>
+              <%= f.radio_button :update_type, "minor", {disabled: disable_inputs, class: 'update-type-select'} %>
+              Minor update
+              <span class='text-muted'>e.g. spelling or typographic corrections.</span>
+            <% end %>
+          </div>
+          <div class="radio">
+            <%= label_tag do %>
+              <%= f.radio_button :update_type, "major", {disabled: disable_inputs, class: 'update-type-select'} %>
+              Major update
+              <span class='text-muted'>e.g. updates that change the meaning of the guidance.</span>
+            <% end %>
+          </div>
         </div>
-        <div class="radio">
-          <%= label_tag do %>
-            <%= f.radio_button :update_type, "major", {disabled: disable_inputs, class: 'update-type-select'} %>
-            Major update
-            <span class='text-muted'>e.g. updates that change the meaning of the guidance.</span>
-          <% end %>
+
+        <div class="form-group change-note-form-group">
+          <%= f.label :change_note, "Summary of change" %>
+          <div class="help-block">What is being changed in this update</div>
+          <%= f.text_field :change_note, disabled: disable_inputs, class: 'input-md-12 form-control', rows: 5 %>
         </div>
-      </div>
 
-      <div class="form-group change-note-form-group">
-        <%= f.label :change_note, "Summary of change" %>
-        <div class="help-block">What is being changed in this update</div>
-        <%= f.text_field :change_note, disabled: disable_inputs, class: 'input-md-12 form-control', rows: 5 %>
-      </div>
+        <div class="form-group change-note-form-group">
+          <%= f.label :reason_for_change, "Why the change is being made" %>
+          <div class="help-block">Include any evidence from research and links to any related discussions</div>
+          <%= f.text_area :reason_for_change, disabled: disable_inputs, class: 'input-md-12 form-control text-area-auto-size js-text-area-auto-size', rows: 5 %>
+        </div>
 
-      <div class="form-group change-note-form-group">
-        <%= f.label :reason_for_change, "Why the change is being made" %>
-        <div class="help-block">Include any evidence from research and links to any related discussions</div>
-        <%= f.text_area :reason_for_change, disabled: disable_inputs, class: 'input-md-12 form-control text-area-auto-size js-text-area-auto-size', rows: 5 %>
+        <p class="text-strong change-note-form-group">
+          <span class="glyphicon glyphicon-warning-sign text-warning" aria-hidden="true"></span>
+          <strong>These notes will be made visible to the public and subscribed users will receive an email update when this guide is published.</strong>
+        </p>
       </div>
-
-      <p class="text-strong change-note-form-group">
-        <span class="glyphicon glyphicon-warning-sign text-warning" aria-hidden="true"></span>
-        <strong>These notes will be made visible to the public and subscribed users will receive an email update when this guide is published.</strong>
-      </p>
-    </div>
+    <% end %>
 
     <div class="well">
       <h2>Assign authorship</h2>

--- a/spec/features/guide_index_spec.rb
+++ b/spec/features/guide_index_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe 'Guide index', type: :feature do
     minor_update_guide = create(:guide, :with_published_edition)
     minor_update_guide.editions << create(:edition, :draft,
       update_type: "minor",
-      title: "Second Update Guide"
+      title: "Second Update Guide",
+      version: 2
     )
 
     visit root_path

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -32,13 +32,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     end
 
     it "defaults to a major update and the new change note is empty" do
-      title = "A guide to agile"
-      create(:guide, editions: [
-        build(:edition, state: "draft", title: title, update_type: "minor"),
-        build(:edition, state: "review_requested", title: title, update_type: "minor"),
-        build(:edition, state: "ready", title: title, update_type: "minor"),
-        build(:edition, state: "published", title: title, update_type: "minor"),
-      ])
+      create(:guide, :with_published_edition, title: "A guide to agile")
       visit guides_path
 
       within_guide_index_row("A guide to agile") do

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "creating guides", type: :feature do
     expect(edition.content_owner.title).to eq "Technology Community"
     expect(edition.title).to eq "First Edition Title"
     expect(edition.body).to eq "## First Edition Title"
-    expect(edition.update_type).to eq "minor"
+    expect(edition.update_type).to eq "major"
     expect(edition.draft?).to eq true
     expect(edition.published?).to eq false
 
@@ -99,7 +99,7 @@ RSpec.describe "creating guides", type: :feature do
       .with(an_instance_of(String), an_instance_of(Hash))
     expect(api_double).to receive(:publish)
       .once
-      .with(an_instance_of(String), 'minor')
+      .with(an_instance_of(String), 'major')
 
     click_first_button "Save"
     guide = Guide.joins(:editions).merge(Edition.where(title: 'First Edition Title')).first

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -129,22 +129,27 @@ RSpec.describe "creating guides", type: :feature do
     expect(edition.published?).to eq true
   end
 
-  context "when creating a new guide" do
-    it 'displays an alert if it fails' do
-      api_error = GdsApi::HTTPClientError.new(
-        422,
-        "An error occurred",
-        "error" => { "message" => "An error occurred" }
-      )
-      expect(PUBLISHING_API).to receive(:put_content).and_raise(api_error)
+  it "displays an alert if communication with the publishing-api fails" do
+    api_error = GdsApi::HTTPClientError.new(
+      422,
+      "An error occurred",
+      "error" => { "message" => "An error occurred" }
+    )
+    expect(PUBLISHING_API).to receive(:put_content).and_raise(api_error)
 
-      fill_in_guide_form
-      click_first_button "Save"
+    fill_in_guide_form
+    click_first_button "Save"
 
-      within ".full-error-list" do
-        expect(page).to have_content("An error occurred")
-      end
+    within ".full-error-list" do
+      expect(page).to have_content("An error occurred")
     end
+  end
+
+  it "does not show the 'About this update' fields for the first version" do
+    expect(page).to_not have_field("Major update")
+    expect(page).to_not have_field("Minor update")
+    expect(page).to_not have_field("Summary of change")
+    expect(page).to_not have_field("Why the change is being made")
   end
 
   describe "action buttons" do

--- a/spec/forms/guide_form_spec.rb
+++ b/spec/forms/guide_form_spec.rb
@@ -180,6 +180,15 @@ RSpec.describe GuideForm, "#initialize" do
   end
 end
 
+RSpec.describe GuideForm, "#assign_attributes" do
+  it "coerces version to an integer" do
+    guide_form = described_class.new(guide: Guide.new, edition: Edition.new, user: User.new)
+    guide_form.assign_attributes(version: "1")
+
+    expect(guide_form.version).to eq(1)
+  end
+end
+
 RSpec.describe GuideForm, "#save" do
   context "for a brand new guide" do
     it "persists a guide with an edition and puts it in the relevant topic section" do

--- a/spec/forms/guide_form_spec.rb
+++ b/spec/forms/guide_form_spec.rb
@@ -264,9 +264,19 @@ RSpec.describe GuideForm, "#save" do
       expect(edition.created_by).to eq(user)
     end
 
-    it "assigns the changed note and summary to the edition" do
+    it "assigns the default change_note to the first edition" do
       guide = Guide.new
       edition = guide.editions.build
+      user = User.new
+      guide_form = described_class.new(guide: guide, edition: edition, user: user)
+      guide_form.save
+
+      expect(edition.change_note).to eq('Guidance first published')
+    end
+
+    it "assigns the change_note and reason_for_change to the edition for later editions" do
+      guide = Guide.new
+      edition = guide.editions.build(version: 2)
       user = User.new
       guide_form = described_class.new(guide: guide, edition: edition, user: user)
       guide_form.assign_attributes(
@@ -277,16 +287,6 @@ RSpec.describe GuideForm, "#save" do
 
       expect(edition.change_note).to eq("X happened")
       expect(edition.reason_for_change).to eq("This happened because of X.")
-    end
-
-    it "assigns the first edition a change_note if it isn't supplied" do
-      guide = Guide.new
-      edition = guide.editions.build
-      user = User.new
-      guide_form = described_class.new(guide: guide, edition: edition, user: user)
-      guide_form.save
-
-      expect(edition.change_note).to eq('Guidance first published')
     end
   end
 

--- a/spec/forms/guide_form_spec.rb
+++ b/spec/forms/guide_form_spec.rb
@@ -274,6 +274,16 @@ RSpec.describe GuideForm, "#save" do
       expect(edition.change_note).to eq("X happened")
       expect(edition.reason_for_change).to eq("This happened because of X.")
     end
+
+    it "assigns the first edition a change_note if it isn't supplied" do
+      guide = Guide.new
+      edition = guide.editions.build
+      user = User.new
+      guide_form = described_class.new(guide: guide, edition: edition, user: user)
+      guide_form.save
+
+      expect(edition.change_note).to eq('Guidance first published')
+    end
   end
 
   context "for a published guide" do

--- a/spec/forms/guide_form_spec.rb
+++ b/spec/forms/guide_form_spec.rb
@@ -126,13 +126,7 @@ RSpec.describe GuideForm, "#initialize" do
 
   context "for an existing published guide" do
     it "defaults to an update_type of major" do
-      title = "A guide to agile"
-      guide = create(:guide, editions: [
-        build(:edition, state: "draft", title: title, update_type: "minor"),
-        build(:edition, state: "review_requested", title: title, update_type: "minor"),
-        build(:edition, state: "ready", title: title, update_type: "minor"),
-        build(:edition, state: "published", title: title, update_type: "minor"),
-      ])
+      guide = create(:guide, :with_published_edition, title: "A guide to agile")
       edition = guide.editions.build(guide.latest_edition.dup.attributes)
       user = User.new
 
@@ -201,13 +195,14 @@ RSpec.describe GuideForm, "#save" do
       guide = Guide.new
       edition = guide.editions.build
       guide_form = described_class.new(guide: guide, edition: edition, user: user)
-      guide_form.assign_attributes(body: "a fair old body",
+      guide_form.assign_attributes(
+        body: "a fair old body",
         content_owner_id: guide_community.id,
         description: "a pleasant description",
         slug: "/service-manual/topic/a-fair-tale",
         title: "A fair tale",
-        update_type: "minor",
-        topic_section_id: topic_section.id)
+        topic_section_id: topic_section.id
+      )
       guide_form.save
 
       expect(guide).to be_persisted

--- a/spec/forms/point_form_spec.rb
+++ b/spec/forms/point_form_spec.rb
@@ -35,8 +35,7 @@ RSpec.describe PointForm, "#save" do
       content_owner_id: guide_community.id,
       description: "a pleasant description",
       slug: "/service-manual/topic/a-fair-tale",
-      title: "A fair tale",
-      update_type: "minor",
+      title: "A fair tale"
     )
     guide_form.save
 

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -130,6 +130,14 @@ RSpec.describe Edition, type: :model do
       end
     end
 
+    describe "update_type" do
+      it "cannot be minor for the first edition" do
+        edition = build(:edition, update_type: "minor", reason_for_change: "")
+        edition.valid?
+        expect(edition.errors.full_messages_for(:update_type)).to include 'Update type must be major'
+      end
+    end
+
     it "requires a created_by user" do
       edition = build(:edition, created_by: nil)
       edition.valid?

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -94,29 +94,39 @@ RSpec.describe Edition, type: :model do
         edition.valid?
         expect(edition.errors.full_messages_for(:state).size).to eq 1
       end
+    end
 
-      it "does not allow empty reason_for_change when the update_type is 'major'" do
-        edition = build(:edition, update_type: "major", reason_for_change: "")
-        edition.valid?
-        expect(edition.errors.full_messages_for(:reason_for_change)).to eq ["Reason for change can't be blank"]
-      end
-
-      it "allows empty reason_for_change when the update_type is 'minor'" do
-        edition = build(:edition, update_type: "minor", reason_for_change: "")
-        edition.valid?
-        expect(edition.errors.full_messages_for(:reason_for_change).size).to eq 0
-      end
-
-      it "does not allow empty change_note when the update_type is 'major'" do
+    describe 'change_note' do
+      it "is not allowed to be empty when the update_type is 'major'" do
         edition = build(:edition, update_type: "major", change_note: "")
         edition.valid?
         expect(edition.errors.full_messages_for(:change_note)).to eq ["Change note can't be blank"]
       end
 
-      it "allows empty change_note when the update_type is 'minor'" do
+      it "is allowed to be empty if the update_type is 'minor'" do
         edition = build(:edition, update_type: "minor", change_note: "")
         edition.valid?
-        expect(edition.errors.full_messages_for(:change_note).size).to eq 0
+        expect(edition.errors.full_messages_for(:change_note)).to be_empty
+      end
+    end
+
+    describe "reason_for_change" do
+      it "is allowed to be empty if the update_type is 'major' and it is the first version" do
+        edition = build(:edition, update_type: "major", reason_for_change: "")
+        edition.valid?
+        expect(edition.errors.full_messages_for(:reason_for_change)).to be_empty
+      end
+
+      it "is not allowed to be empty if the update_type is 'major' and it is not the first version" do
+        edition = build(:edition, update_type: "major", reason_for_change: "", version: 2)
+        edition.valid?
+        expect(edition.errors.full_messages_for(:reason_for_change)).to eq ["Reason for change can't be blank"]
+      end
+
+      it "is allowed to be empty if the update_type is 'minor'" do
+        edition = build(:edition, update_type: "minor", reason_for_change: "")
+        edition.valid?
+        expect(edition.errors.full_messages_for(:reason_for_change)).to be_empty
       end
     end
 

--- a/spec/presenters/guide_presenter/change_history_presenter_spec.rb
+++ b/spec/presenters/guide_presenter/change_history_presenter_spec.rb
@@ -79,7 +79,8 @@ RSpec.describe GuidePresenter::ChangeHistoryPresenter do
         change_note: "",
         reason_for_change: "",
         update_type: "minor",
-        created_at: "2016-06-28T14:16:21Z"
+        created_at: "2016-06-28T14:16:21Z",
+        version: 2
       )
     ]
 

--- a/spec/presenters/guide_presenter/change_history_presenter_spec.rb
+++ b/spec/presenters/guide_presenter/change_history_presenter_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe GuidePresenter::ChangeHistoryPresenter do
   it 'includes all major editions in reverse chronological order' do
     editions = [
       *published_edition(
-        change_note: "Creating initial guide",
-        reason_for_change: "It needs to exist!",
+        change_note: "Guidance first published",
+        reason_for_change: nil,
         update_type: "major",
         created_at: "2016-06-25T14:16:21Z"
       ),
@@ -18,7 +18,7 @@ RSpec.describe GuidePresenter::ChangeHistoryPresenter do
     ]
 
     guide = create(:guide, editions: editions)
-    presenter = described_class.new(guide, guide.editions.last)
+    presenter = described_class.new(guide, guide.latest_edition)
 
     expect(presenter.change_history).to eq [
       {
@@ -28,8 +28,8 @@ RSpec.describe GuidePresenter::ChangeHistoryPresenter do
       },
       {
         public_timestamp: "2016-06-25T14:16:21Z",
-        note: "Creating initial guide",
-        reason_for_change: "It needs to exist!"
+        note: "Guidance first published",
+        reason_for_change: ""
       }
     ]
   end
@@ -37,8 +37,8 @@ RSpec.describe GuidePresenter::ChangeHistoryPresenter do
   it 'includes the change note of the current draft if it is major' do
     editions = [
       *published_edition(
-        change_note: "Creating initial guide",
-        reason_for_change: "It needs to exist!",
+        change_note: "Guidance first published",
+        reason_for_change: nil,
         update_type: "major",
         created_at: "2016-06-25T14:16:21Z"
       ),
@@ -51,7 +51,7 @@ RSpec.describe GuidePresenter::ChangeHistoryPresenter do
     ]
 
     guide = create(:guide, editions: editions)
-    presenter = described_class.new(guide, guide.editions.last)
+    presenter = described_class.new(guide, guide.latest_edition)
 
     expect(presenter.change_history).to eq [
       {
@@ -61,8 +61,8 @@ RSpec.describe GuidePresenter::ChangeHistoryPresenter do
       },
       {
         public_timestamp: "2016-06-25T14:16:21Z",
-        note: "Creating initial guide",
-        reason_for_change: "It needs to exist!"
+        note: "Guidance first published",
+        reason_for_change: ""
       }
     ]
   end
@@ -70,8 +70,8 @@ RSpec.describe GuidePresenter::ChangeHistoryPresenter do
   it 'does not include the current draft if it is a minor' do
     editions = [
       *published_edition(
-        change_note: "Creating initial guide",
-        reason_for_change: "It needs to exist!",
+        change_note: "Guidance first published",
+        reason_for_change: nil,
         update_type: "major",
         created_at: "2016-06-25T14:16:21Z"
       ),
@@ -85,13 +85,34 @@ RSpec.describe GuidePresenter::ChangeHistoryPresenter do
     ]
 
     guide = create(:guide, editions: editions)
-    presenter = described_class.new(guide, guide.editions.last)
+    presenter = described_class.new(guide, guide.latest_edition)
 
     expect(presenter.change_history).to eq [
       {
         public_timestamp: "2016-06-25T14:16:21Z",
-        note: "Creating initial guide",
-        reason_for_change: "It needs to exist!"
+        note: "Guidance first published",
+        reason_for_change: ""
+      }
+    ]
+  end
+
+  it 'assigns the reason_for_change an empty string if the reason_for_change is nil' \
+    ' because the definition in the content schema requires it' do
+    editions = published_edition(
+      change_note: "Guidance first published",
+      reason_for_change: nil,
+      update_type: "major",
+      created_at: "2016-06-25T14:16:21Z"
+    )
+
+    guide = create(:guide, editions: editions)
+    presenter = described_class.new(guide, guide.latest_edition)
+
+    expect(presenter.change_history).to eq [
+      {
+        public_timestamp: "2016-06-25T14:16:21Z",
+        note: "Guidance first published",
+        reason_for_change: ""
       }
     ]
   end


### PR DESCRIPTION
https://trello.com/c/fq2gTSIH

The publishing-api requires that the first edition has an update_type of 'major'.

Our content editors had the requirement that they did not want to give a change_note or reason_for_change for the first edition.

We automatically set the first version's change_note to "Guidance first published" and reason_for_change as an empty string.

The form fields have been removed for the first version so the user can't edit them anymore. The existing validations on change_note and reason_for_change have been changed and we've added a validation to ensure the first edition is minor too, partially for to protect against something changing later, and partially to ensure more real-life data in tests.
