### PR TITLE
Scope cleanup

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -14,6 +14,7 @@ class Edition < ActiveRecord::Base
 
   scope :draft, -> { where(state: 'draft') }
   scope :published, -> { where(state: 'published') }
+  scope :unpublished, -> { where(state: 'unpublished') }
   scope :review_requested, -> { where(state: 'review_requested') }
   scope :most_recent_first, -> { order('created_at DESC, id DESC') }
   scope :which_update_the_frontend, -> { where(state: STATES_THAT_UPDATE_THE_FRONTEND) }

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -88,7 +88,7 @@ class Guide < ActiveRecord::Base
   end
 
   def can_be_unpublished?
-    has_any_published_editions? && !has_unpublished_edition?
+    has_any_published_editions? && !has_any_unpublished_editions?
   end
 
   def editions_since_last_published
@@ -112,8 +112,8 @@ class Guide < ActiveRecord::Base
 
 private
 
-  def has_unpublished_edition?
-    editions.where(state: "unpublished").any?
+  def has_any_unpublished_editions?
+    editions.unpublished.any?
   end
 
   def slug_format

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -83,12 +83,12 @@ class Guide < ActiveRecord::Base
     topic.present?
   end
 
-  def has_published_edition?
-    editions.where(state: "published").any?
+  def has_any_published_editions?
+    editions.published.any?
   end
 
   def can_be_unpublished?
-    has_published_edition? && !has_unpublished_edition?
+    has_any_published_editions? && !has_unpublished_edition?
   end
 
   def editions_since_last_published
@@ -127,7 +127,7 @@ private
   end
 
   def slug_cant_be_changed_if_an_edition_has_been_published
-    if slug_changed? && has_published_edition?
+    if slug_changed? && has_any_published_editions?
       errors.add(:slug, "can't be changed if guide has a published edition")
     end
   end

--- a/app/models/guide_manager.rb
+++ b/app/models/guide_manager.rb
@@ -72,7 +72,7 @@ class GuideManager
 
   def discard_draft
     catching_gds_api_exceptions do
-      if guide.has_published_edition?
+      if guide.has_any_published_editions?
         guide
           .editions_since_last_published
           .destroy_all

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -6,7 +6,7 @@
       html: {
         class: "js-guide-form js-protect-data",
         data: {
-          "has-been-published": guide.has_published_edition?,
+          "has-been-published": guide.has_any_published_editions?,
           "slug-prefix": guide_form.slug_prefix
         }
       }
@@ -40,7 +40,7 @@
             Only use lowercase letters (not numbers or symbols) and separate words with a hyphen, eg <code>writing-user-stories</code>.
           </p>
         </div>
-        <%= f.text_field :title_slug, {value: guide_form.title_slug, class: 'input-md-12 form-control guide-slug js-title-slug', disabled: guide.has_published_edition?} %>
+        <%= f.text_field :title_slug, {value: guide_form.title_slug, class: 'input-md-12 form-control guide-slug js-title-slug', disabled: guide.has_any_published_editions?} %>
       </div>
 
       <% if guide_form.requires_topic? %>
@@ -53,7 +53,7 @@
 
       <div class="form-group">
         <%= f.label :slug, "Final URL" %>
-        <%= f.text_field :slug, class: "input-md-12 form-control js-slug", readonly: true, disabled: guide.has_published_edition? %>
+        <%= f.text_field :slug, class: "input-md-12 form-control js-slug", readonly: true, disabled: guide.has_any_published_editions? %>
       </div>
 
       <div class='form-group'>

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -1,6 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe Edition, type: :model do
+  describe ".unpublished" do
+    it "returns unpublished editions" do
+      create(:edition, state: 'draft')
+      unpublished_edition = create(:edition, state: 'unpublished')
+
+      expect(described_class.unpublished).to match_array([unpublished_edition])
+    end
+  end
+
   describe "#notification_subscribers" do
     let(:joe) { build(:user, name: "Joe") }
     let(:liz) { build(:user, name: "Liz") }


### PR DESCRIPTION
Just a little cleanup. The edition scopes should live in the Edition model and renamed the methods to be a little clearer.