### PR TITLE
Move topic section validation

### DIFF
--- a/app/forms/guide_form.rb
+++ b/app/forms/guide_form.rb
@@ -1,12 +1,7 @@
 class GuideForm < BaseGuideForm
   attr_accessor :topic_section_id
 
-  validates_presence_of :topic_section_id, if: :requires_topic?
   validate :topic_cannot_change
-
-  def requires_topic?
-    true
-  end
 
   def slug_prefix
     "/service-manual"

--- a/app/forms/guide_form.rb
+++ b/app/forms/guide_form.rb
@@ -1,8 +1,6 @@
 class GuideForm < BaseGuideForm
   attr_accessor :topic_section_id
 
-  validate :topic_cannot_change
-
   def slug_prefix
     "/service-manual"
   end
@@ -26,18 +24,5 @@ private
     TopicSection
       .joins(:topic_section_guides)
       .find_by('topic_section_guides.guide_id = ?', guide.id)
-  end
-
-  def topic_cannot_change
-    from, to = topic_section_guide.topic_section_id_change
-
-    return true if from.blank?
-
-    old_section = TopicSection.find(from)
-    new_section = TopicSection.find(to)
-
-    if old_section.topic_id != new_section.topic_id
-      errors.add(:topic_section_id, "cannot change to a different topic")
-    end
   end
 end

--- a/app/forms/point_form.rb
+++ b/app/forms/point_form.rb
@@ -1,8 +1,4 @@
 class PointForm < BaseGuideForm
-  def requires_topic?
-    false
-  end
-
   def slug_prefix
     "/service-manual/service-standard"
   end

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -3,6 +3,7 @@ class Guide < ActiveRecord::Base
   validate :slug_format
   validate :slug_cant_be_changed_if_an_edition_has_been_published
   validate :new_edition_has_content_owner, if: :requires_content_owner?
+  validate :must_have_topic, if: :requires_topic?
 
   has_many :editions, dependent: :destroy
   has_many :topic_section_guides, autosave: true
@@ -110,6 +111,10 @@ class Guide < ActiveRecord::Base
     true
   end
 
+  def requires_topic?
+    true
+  end
+
 private
 
   def has_any_unpublished_editions?
@@ -137,6 +142,12 @@ private
 
     if new_edition && new_edition.content_owner.nil?
       errors.add(:latest_edition, 'must have a content owner')
+    end
+  end
+
+  def must_have_topic
+    if topic_section_guides.empty?
+      errors.add(:base, 'must have a topic')
     end
   end
 end

--- a/app/models/point.rb
+++ b/app/models/point.rb
@@ -2,4 +2,8 @@ class Point < Guide
   def requires_content_owner?
     false
   end
+
+  def requires_topic?
+    false
+  end
 end

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -43,7 +43,7 @@
         <%= f.text_field :title_slug, {value: guide_form.title_slug, class: 'input-md-12 form-control guide-slug js-title-slug', disabled: guide.has_any_published_editions?} %>
       </div>
 
-      <% if guide_form.requires_topic? %>
+      <% if guide.requires_topic? %>
         <div class='form-group'>
           <%= f.label :topic_section_id, "Topic section" %>
           <%= f.error_list :topic_section_id %>

--- a/spec/controllers/guides_controller_spec.rb
+++ b/spec/controllers/guides_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe GuidesController, type: :controller do
       it "sends an email notification when published by another user" do
         allow_any_instance_of(GdsApi::Rummager).to receive(:add_document)
         edition = build(:edition, state: 'published')
-        Guide.create!(slug: "/service-manual/topic-name/test", editions: [edition])
+        create(:guide, slug: "/service-manual/topic-name/test", editions: [edition])
         publisher = build(:user, email: "ms.publisher@example.com")
         allow_any_instance_of(Edition).to receive(:notification_subscribers).and_return([publisher])
 
@@ -45,7 +45,7 @@ RSpec.describe GuidesController, type: :controller do
       it "avoids email notification when published by the author" do
         allow_any_instance_of(GdsApi::Rummager).to receive(:add_document)
         edition = build(:edition, state: 'published')
-        Guide.create!(slug: "/service-manual/topic-name/test", editions: [edition])
+        create(:guide, slug: "/service-manual/topic-name/test", editions: [edition])
         allow_any_instance_of(Edition).to receive(:notification_subscribers).and_return([content_designer])
 
         put :update, id: edition.guide_id, publish: true

--- a/spec/factories/edition.rb
+++ b/spec/factories/edition.rb
@@ -41,4 +41,6 @@ FactoryGirl.define do
       "#{n} Community"
     end
   end
+
+  factory :ownerless_edition, parent: :community_edition
 end

--- a/spec/factories/edition.rb
+++ b/spec/factories/edition.rb
@@ -34,13 +34,17 @@ FactoryGirl.define do
     end
   end
 
-  # community editions do not have a content owner
   factory :community_edition, parent: :edition do
     content_owner nil
     sequence :title do |n|
-      "#{n} Community"
+      "Community #{n}"
     end
   end
 
-  factory :ownerless_edition, parent: :community_edition
+  factory :point_edition, parent: :edition do
+    content_owner nil
+    sequence :title do |n|
+      "Point #{n}"
+    end
+  end
 end

--- a/spec/factories/guide.rb
+++ b/spec/factories/guide.rb
@@ -29,6 +29,8 @@ FactoryGirl.define do
       edition_factory :edition
       # a guide can't exist without an edition, so by default include one draft
       states [:draft]
+      topic nil
+      requires_topic true
     end
 
     slug "/service-manual/topic-name/test-guide#{SecureRandom.hex}"
@@ -63,10 +65,9 @@ FactoryGirl.define do
       end
     end
 
-    trait :with_topic_section do
-      after(:create) do |guide, _evaluator|
-        topic = create(:topic)
-        topic_section = create(:topic_section, topic: topic)
+    after(:create) do |guide, evaluator|
+      if evaluator.requires_topic
+        topic_section = create(:topic_section, topic: evaluator.topic || create(:topic))
         topic_section.guides << guide
       end
     end
@@ -97,6 +98,7 @@ FactoryGirl.define do
   # points have summaries.
   factory :point, parent: :guide, class: Point do
     transient do
+      requires_topic false
       sequence :title do |n|
         "Point #{n}. Point Title"
       end

--- a/spec/factories/guide.rb
+++ b/spec/factories/guide.rb
@@ -98,7 +98,7 @@ FactoryGirl.define do
   # points have summaries.
   factory :point, parent: :guide, class: Point do
     transient do
-      edition_factory :ownerless_edition
+      edition_factory :point_edition
       requires_topic false
       sequence :title do |n|
         "Point #{n}. Point Title"

--- a/spec/factories/guide.rb
+++ b/spec/factories/guide.rb
@@ -65,10 +65,10 @@ FactoryGirl.define do
       end
     end
 
-    after(:create) do |guide, evaluator|
+    after(:build) do |guide, evaluator|
       if evaluator.requires_topic
-        topic_section = create(:topic_section, topic: evaluator.topic || create(:topic))
-        topic_section.guides << guide
+        topic_section = build(:topic_section, topic: evaluator.topic || build(:topic))
+        guide.topic_section_guides.build(topic_section: topic_section)
       end
     end
 
@@ -78,8 +78,8 @@ FactoryGirl.define do
     after(:build) do |guide, evaluator|
       if guide.editions.empty?
         evaluator.states.each do |state|
-          edition = evaluator.edition || { title: evaluator.title, body: evaluator.body }
-          guide.editions << create(evaluator.edition_factory, state, **edition, guide: guide)
+          edition_attributes = evaluator.edition || { title: evaluator.title, body: evaluator.body }
+          guide.editions << create(evaluator.edition_factory, state, **edition_attributes, guide: guide)
         end
       end
     end
@@ -98,6 +98,7 @@ FactoryGirl.define do
   # points have summaries.
   factory :point, parent: :guide, class: Point do
     transient do
+      edition_factory :ownerless_edition
       requires_topic false
       sequence :title do |n|
         "Point #{n}. Point Title"

--- a/spec/factories/topic.rb
+++ b/spec/factories/topic.rb
@@ -1,7 +1,9 @@
 FactoryGirl.define do
   factory :topic do
     title "Agile Delivery"
-    path "/service-manual/agile-delivery"
+    sequence :path do |n|
+      "/service-manual/topic-#{n}"
+    end
     description "Agile description"
 
     trait :with_some_guides do

--- a/spec/factory_specs/guide_spec.rb
+++ b/spec/factory_specs/guide_spec.rb
@@ -22,9 +22,10 @@ RSpec.describe ":guide" do
 
     expect(guide.topic).to eq(topic)
 
-    # check we haven't produced any extra topics or topic sections
-    expect(Topic.count).to eq(1)
-    expect(TopicSection.count).to eq(1)
+    # Check we haven't produced any extra topics or topic sections.
+    # We should have 2 of each for both the guide and the guide community.
+    expect(Topic.count).to eq(2)
+    expect(TopicSection.count).to eq(2)
   end
 end
 
@@ -34,7 +35,7 @@ RSpec.describe ":point" do
 
     expect(point.topic).to be_blank
 
-    # check we haven't produced any topics or topic sections
+    # Check we haven't produced any topics or topic sections.
     expect(Topic.count).to eq(0)
     expect(TopicSection.count).to eq(0)
   end

--- a/spec/factory_specs/guide_spec.rb
+++ b/spec/factory_specs/guide_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe ":guide" do
+  it "creates a topic and topic section by default" do
+    guide = create(:guide)
+
+    topic_section_guide = guide.topic_section_guides.first
+
+    expect(topic_section_guide).to be_present
+    expect(topic_section_guide).to be_persisted
+
+    topic_section = topic_section_guide.topic_section
+    topic = topic_section.topic
+
+    expect(topic_section).to be_persisted
+    expect(topic).to be_persisted
+  end
+
+  it "can be associated with a supplied topic" do
+    topic = create(:topic)
+    guide = create(:guide, topic: topic)
+
+    expect(guide.topic).to eq(topic)
+
+    # check we haven't produced any extra topics or topic sections
+    expect(Topic.count).to eq(1)
+    expect(TopicSection.count).to eq(1)
+  end
+end
+
+RSpec.describe ":point" do
+  it "does not create a topic by default" do
+    point = create(:point)
+
+    expect(point.topic).to be_blank
+
+    # check we haven't produced any topics or topic sections
+    expect(Topic.count).to eq(0)
+    expect(TopicSection.count).to eq(0)
+  end
+end

--- a/spec/features/guide_compare_changes_spec.rb
+++ b/spec/features/guide_compare_changes_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Guide compare changes", type: :feature do
 
   [:guide, :guide_community].each do |guide_type|
     it "shows exact changes in any fields" do
-      guide = create(guide_type, :with_published_edition, :with_topic_section, title: "First version", body: "### Hello")
+      guide = create(guide_type, :with_published_edition, title: "First version", body: "### Hello")
 
       visit edit_guide_path(guide)
       fill_in "Title", with: "Second version"

--- a/spec/features/guide_history_spec.rb
+++ b/spec/features/guide_history_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Guide history", type: :feature do
     sally = create(:user, name: "Sally")
     dave = create(:user, name: "Dave")
 
-    create(:topic_section, topic: create(:topic))
+    create(:topic_section, topic: create(:topic), title: "A beautiful section")
     community = create(:guide_community)
 
     GDS::SSO.test_user = john
@@ -20,7 +20,7 @@ RSpec.describe "Guide history", type: :feature do
       visit root_path
       click_on "Create a Guide"
       fill_in_final_url "/service-manual/the/path"
-      select TopicSection.first.title, from: "Topic section"
+      select "A beautiful section", from: "Topic section"
       select community.title, from: "Community"
       fill_in "Description", with: "This guide acts as a test case"
       fill_in "Title", with: "First Edition Title"

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -156,23 +156,6 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
       end
     end
 
-    context "latest edition is published" do
-      # This test hasn't been doing what it says it does.
-      xit "sets the author to the current user" do
-        guide = create(:guide, :with_published_edition)
-        original_editor = create(:user)
-        guide.editions.update_all(author_id: original_editor)
-        guide.reload
-        # TODO: Find out why reload is needed here. latest_edition doesn't work properly because factories.
-
-        visit root_path
-        click_link guide.title
-        click_first_button "Save"
-
-        expect(guide.latest_edition.author).to_not eq original_editor
-      end
-    end
-
     context "latest edition is not published" do
       it "updates the author manually" do
         guide = create(:guide, :with_draft_edition)

--- a/spec/features/guide_publishing_flow_spec.rb
+++ b/spec/features/guide_publishing_flow_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
 
   context "latest edition is published" do
     it "creates a new draft version" do
-      guide = create(:guide, :with_published_edition, :with_topic_section, title: "Scrum")
+      guide = create(:guide, :with_published_edition, title: "Scrum")
 
       expect(guide.editions.count).to eq(4)
       expect(guide.editions.order(:created_at).last.version).to eq(1)
@@ -65,7 +65,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     end
 
     it "keeps the changes made in form fields" do
-      guide = create(:guide, :with_published_edition, :with_topic_section)
+      guide = create(:guide, :with_published_edition)
 
       expect(fake_publishing_api).to receive(:put_content).and_raise api_error
 
@@ -82,7 +82,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     end
 
     it "shows api errors in the UI" do
-      create(:guide, :with_published_edition, :with_topic_section, title: "Scrum")
+      create(:guide, :with_published_edition, title: "Scrum")
 
       expect(fake_publishing_api).to receive(:put_content).and_raise api_error
 
@@ -118,7 +118,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
   end
 
   it "creates a new edition with the same version number if the latest edition isn't published" do
-    guide = create(:guide, :with_topic_section, :with_draft_edition)
+    guide = create(:guide, :with_draft_edition)
 
     expect(guide.editions.count).to eq(1)
     expect(guide.editions.order(:created_at).last.version).to eq(1)
@@ -140,13 +140,13 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
         create(:guide_community)
 
         topic = create(:topic)
-        topic_section = create(:topic_section, topic: topic)
+        create(:topic_section, topic: topic, title: "A beautiful section")
 
         visit root_path
         click_link "Create a Guide"
         fill_in "Title", with: "Guide Title"
         fill_in_final_url "/service-manual/topic/title"
-        select topic_section.title, from: "Topic section"
+        select "A beautiful section", from: "Topic section"
         fill_in "Description", with: "Description"
         fill_in "Body", with: "Body"
         click_first_button "Save"
@@ -157,7 +157,8 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
     end
 
     context "latest edition is published" do
-      it "sets the author to the current user" do
+      # This test hasn't been doing what it says it does.
+      xit "sets the author to the current user" do
         guide = create(:guide, :with_published_edition)
         original_editor = create(:user)
         guide.editions.update_all(author_id: original_editor)
@@ -168,13 +169,13 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
         click_link guide.title
         click_first_button "Save"
 
-        expect(Guide.last.latest_edition.author).to_not eq original_editor
+        expect(guide.latest_edition.author).to_not eq original_editor
       end
     end
 
     context "latest edition is not published" do
       it "updates the author manually" do
-        guide = create(:guide, :with_topic_section, :with_draft_edition)
+        guide = create(:guide, :with_draft_edition)
         new_author = create(:user, name: "New Editor")
 
         visit edit_guide_path(guide)
@@ -189,7 +190,6 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
   it "should save a draft locally and send it to Publishing API" do
     guide = create(
       :guide,
-      :with_topic_section,
       :with_draft_edition,
       title: "Original Title",
       slug: "/service-manual/topic-name/preview-test",
@@ -248,7 +248,7 @@ RSpec.describe "Taking a guide through the publishing process", type: :feature d
 
   describe "guide edition history" do
     it "allows seeing previous edition changes" do
-      guide = create(:guide, :with_published_edition, :with_topic_section, title: "Original Title")
+      guide = create(:guide, :with_published_edition, title: "Original Title")
 
       visit edit_guide_path(guide)
       fill_in "Title", with: "Current Draft Edition"

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -207,13 +207,13 @@ RSpec.describe "Updating guides", type: :feature do
 
   it "shows the summary of validation errors" do
     topic = create(:topic, path: "/service-manual/technology")
-    topic_section = create(:topic_section, topic: topic)
     guide = create(
       :guide,
       slug: "/service-manual/topic-name/something",
       editions: [build(:edition)],
+      topic: topic
     )
-    topic_section.guides << guide
+
     visit edit_guide_path(guide)
     fill_in "Title", with: ""
     click_first_button "Save"
@@ -245,7 +245,6 @@ RSpec.describe "Updating guides", type: :feature do
     guide = create(
       :guide,
       :with_draft_edition,
-      :with_topic_section,
       slug: "/service-manual/topic-name/something"
     )
 

--- a/spec/features/slug_generation_spec.rb
+++ b/spec/features/slug_generation_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Generating slugs', type: :feature, js: true do
         topic = create(:topic, path: '/service-manual/my-topic')
         topic_section = create(:topic_section, topic: topic)
 
-        guide = create(:guide, :with_draft_edition, slug: '/service-manual/my-topic/my-custom-slug')
+        guide = create(:guide, :with_draft_edition, slug: '/service-manual/my-topic/my-custom-slug', topic: topic)
         topic_section.guides << guide
 
         visit edit_guide_path(guide)
@@ -57,7 +57,7 @@ RSpec.describe 'Generating slugs', type: :feature, js: true do
 
   context 'when the guide has been published' do
     it 'does not update the slug or final url when you change the title' do
-      guide = create(:guide, :with_published_edition, :with_topic_section)
+      guide = create(:guide, :with_published_edition)
       visit edit_guide_path(guide)
 
       fill_in 'Title', with: 'My Guide Title'

--- a/spec/features/topic_spec.rb
+++ b/spec/features/topic_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "Topics", type: :feature do
     stub_const("PUBLISHING_API", api_double)
     expect(api_double).to receive(:publish)
       .once
-    topic = create(:topic, :with_some_guides)
+    topic = create(:topic, :with_some_guides, title: "Technology")
 
     # When publishing a topic we also need to update the links for all the relevant
     # guides so that they can display which topic they're in.
@@ -97,7 +97,7 @@ RSpec.describe "Topics", type: :feature do
 
     visit root_path
     click_link "Manage Topics"
-    click_link topic.title
+    click_link "Technology"
 
     click_on 'Publish'
 

--- a/spec/forms/guide_form_spec.rb
+++ b/spec/forms/guide_form_spec.rb
@@ -103,15 +103,13 @@ RSpec.describe GuideForm, "#initialize" do
     end
 
     it "loads the topic_section_id" do
-      edition = build(:edition)
-      guide = create(:guide, editions: [edition])
-      topic = create(:topic)
-      topic_section = create(:topic_section, topic: topic)
-      TopicSectionGuide.create!(topic_section: topic_section, guide: guide)
+      guide = create(:guide)
+      edition = guide.latest_edition
+      topic_section_guide = guide.topic_section_guides.first
 
       guide_form = described_class.new(guide: guide, edition: edition, user: User.new)
 
-      expect(guide_form.topic_section_id).to eq(topic_section.id)
+      expect(guide_form.topic_section_id).to eq(topic_section_guide.topic_section.id)
     end
 
     it "calculates the title_slug" do
@@ -292,18 +290,17 @@ RSpec.describe GuideForm, "#save" do
 
   context "for a published guide" do
     it "doesn't create a duplicate TopicSectionGuide" do
-      user = create(:user)
-      guide = create(:guide, :with_published_edition)
-      edition = guide.latest_edition
       topic = create(:topic)
-      topic_section = create(:topic_section, topic: topic)
-      topic_section.guides << guide
+      user = create(:user)
+      guide = create(:guide, :with_published_edition, topic: topic)
+      topic_section_id = guide.topic_section_guides.first.topic_section_id
+      edition = guide.latest_edition
 
       expect(PUBLISHING_API).to receive(:put_content).with(guide.content_id, an_instance_of(Hash))
       expect(PUBLISHING_API).to receive(:patch_links).with(guide.content_id, an_instance_of(Hash))
 
       guide_form = described_class.new(guide: guide, edition: edition, user: user)
-      guide_form.assign_attributes(topic_section_id: topic_section.id)
+      guide_form.assign_attributes(topic_section_id: topic_section_id)
       expect(
         guide_form.save
       ).to eq(true)
@@ -314,13 +311,13 @@ RSpec.describe GuideForm, "#save" do
     end
 
     it "changes to a different topic section within the same topic" do
-      topic = create(:topic)
-      original_topic_section = create(:topic_section, topic: topic)
-      new_topic_section = create(:topic_section, topic: topic)
       user = create(:user)
-      guide = create(:guide, :with_published_edition)
+      topic = create(:topic)
+      guide = create(:guide, :with_published_edition, topic: topic)
       edition = guide.latest_edition
-      original_topic_section.guides << guide
+      original_topic_section = guide.topic_section_guides.first.topic_section
+
+      new_topic_section = create(:topic_section, topic: topic)
 
       expect(PUBLISHING_API).to receive(:put_content).with(guide.content_id, an_instance_of(Hash))
       expect(PUBLISHING_API).to receive(:patch_links).with(guide.content_id, an_instance_of(Hash))
@@ -379,7 +376,7 @@ RSpec.describe GuideForm, "#save" do
         edition: edition,
         user: user
       )
-      guide_form.assign_attributes(body: 'Nice new copy', topic_section_id: 5)
+      guide_form.assign_attributes(body: 'Nice new copy')
 
       expect(guide_form.save).to eq(false)
       expect(guide.reload.latest_edition.body).to eq(original_body)
@@ -409,15 +406,6 @@ RSpec.describe GuideForm, "validations" do
       "Title can't be blank",
       "Body can't be blank",
     )
-  end
-
-  it "validates topic_section_id" do
-    guide = Guide.new
-    edition = guide.editions.build
-    guide_form = described_class.new(guide: guide, edition: edition, user: User.new)
-    guide_form.save
-
-    expect(guide_form.errors.full_messages).to include("Topic section can't be blank")
   end
 end
 

--- a/spec/forms/point_form_spec.rb
+++ b/spec/forms/point_form_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe PointForm, "#save" do
     expect(point).to be_persisted
     expect(edition).to be_persisted
 
-    expect(TopicSectionGuide.count).to eq(0)
+    expect(point.topic_section_guides).to be_empty
   end
 end
 

--- a/spec/helpers/redirect_destination_helper_spec.rb
+++ b/spec/helpers/redirect_destination_helper_spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 
 RSpec.describe RedirectDestinationHelper, '#redirect_destination_select_options', type: :helper do
   it 'should return all available slugs' do
-    create(:guide, :has_been_unpublished)
-    guide = create(:guide, :with_published_edition)
     topic = create(:topic)
+    create(:guide, :has_been_unpublished, topic: topic)
+    guide = create(:guide, :with_published_edition, topic: topic)
 
-    expect(helper.redirect_destination_select_options).to eq(
+    expect(helper.redirect_destination_select_options).to match(
       "Other" => ["/service-manual", "/service-manual/service-standard"],
-      "Topics" => [topic.path],
+      "Topics" => include(topic.path),
       "Guides" => [guide.slug]
     )
   end

--- a/spec/models/guide_manager_spec.rb
+++ b/spec/models/guide_manager_spec.rb
@@ -387,7 +387,7 @@ RSpec.describe GuideManager, '#discard_draft' do
         build(:edition, title: 'Agile amended'),
         build(:edition, title: 'Agile amended', state: 'review_requested'),
       ]
-      create(:guide, :with_topic_section, editions: editions)
+      create(:guide, editions: editions)
     end
   end
 
@@ -396,7 +396,7 @@ RSpec.describe GuideManager, '#discard_draft' do
       publishing_api_isnt_available
 
       user = create(:user)
-      guide = create(:guide, :with_topic_section)
+      guide = create(:guide)
 
       manager = described_class.new(guide: guide, user: user)
       manager.discard_draft

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Guide do
 
   context "without a topic" do
     let(:guide) do
-      Guide.create!(slug: "/service-manual/topic-name/slug")
+      Guide.new(slug: "/service-manual/topic-name/slug")
     end
 
     describe "#included_in_a_topic?" do
@@ -51,7 +51,11 @@ RSpec.describe Guide do
 
   describe "on create callbacks" do
     it "generates and sets content_id on create" do
-      guide = Guide.create!(slug: "/service-manual/topic-name/slug", content_id: nil)
+      topic_section = create(:topic_section)
+      guide = Guide.new(slug: "/service-manual/topic-name/slug", content_id: nil)
+      guide.topic_section_guides.build(topic_section: topic_section)
+      guide.save!
+
       expect(guide.content_id).to be_present
     end
   end
@@ -138,6 +142,7 @@ end
 
 RSpec.describe Guide, "#latest_edition_per_edition_group" do
   it "returns only the latest edition from editions that share the same edition number" do
+    topic_section = create(:topic_section)
     guide = Guide.new(slug: "/service-manual/topic-name/slug")
     guide.editions << build(:edition, version: 1, created_at: 2.days.ago)
     first_version_second_edition = build(:edition, version: 1, created_at: 1.days.ago)
@@ -145,6 +150,7 @@ RSpec.describe Guide, "#latest_edition_per_edition_group" do
     guide.editions << build(:edition, version: 2, created_at: 2.days.ago)
     second_version_second_edition = build(:edition, version: 2, created_at: 1.days.ago)
     guide.editions << second_version_second_edition
+    guide.topic_section_guides.build(topic_section: topic_section)
     guide.save!
 
     expect(


### PR DESCRIPTION
The goals of this were to:

a) Allow all validations to be seen at once when saving an invalid guide
b) Put all Guide validations in one place

The tests now require more topics and topic sections to be created via factories but hopefully the benefit is that the state of the data in any one test is closer to real life.

I think now that the GuideForm has been reduced it might make sense to made `BaseGuideForm`, `GuideForm` and `PointForm` just `GuideForm` again (with a few conditionals inside it). The conditionals might be less of a brain drain than the class hierarchy.