### PR TITLE
Replace deprecated format field with schema_name, document_type

### DIFF
--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -12,7 +12,8 @@ class GuidePresenter
     {
       publishing_app: "service-manual-publisher",
       rendering_app: "service-manual-frontend",
-      format: "service_manual_guide",
+      schema_name: "service_manual_guide",
+      document_type: "service_manual_guide",
       locale: "en",
       update_type: edition.update_type,
       base_path: guide.slug,

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -11,7 +11,8 @@ class TopicPresenter
     {
       publishing_app: "service-manual-publisher",
       rendering_app: "service-manual-frontend",
-      format: "service_manual_topic",
+      schema_name: "service_manual_topic",
+      document_type: "service_manual_topic",
       locale: "en",
       update_type: "minor",
       base_path: topic.path,

--- a/spec/presenters/guide_presenter_spec.rb
+++ b/spec/presenters/guide_presenter_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe GuidePresenter do
         description: "Description",
         update_type: "major",
         phase: "beta",
-        format: "service_manual_guide",
+        schema_name: "service_manual_guide",
+        document_type: "service_manual_guide",
         base_path: "/service/manual/test"
       )
     end

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe TopicPresenter, "#content_payload" do
       description: "Topic description",
       update_type: "minor",
       phase: "beta",
-      format: "service_manual_topic",
+      schema_name: "service_manual_topic",
+      document_type: "service_manual_topic",
       base_path: "/service-manual/test-topic"
     )
   end


### PR DESCRIPTION
The `format` field has been removed from the list of allowed attributes in the schema definition. We now need to send both `schema_name` and `document_type` instead.

Related to https://github.com/alphagov/govuk-content-schemas/pull/374