### PR TITLE
Build the service standard points from the expanded links

### DIFF
--- a/app/models/guide_manager.rb
+++ b/app/models/guide_manager.rb
@@ -121,7 +121,7 @@ private
   # relevant point will not appear in the standard.
   #
   def save_and_publish_the_service_standard
-    service_standard_for_publication = ServiceStandardPresenter.new(Point.all)
+    service_standard_for_publication = ServiceStandardPresenter.new
     PUBLISHING_API.put_content(
       service_standard_for_publication.content_id,
       service_standard_for_publication.content_payload

--- a/app/models/guide_manager.rb
+++ b/app/models/guide_manager.rb
@@ -26,10 +26,6 @@ class GuideManager
       edition.save!
       PUBLISHING_API.publish(guide.content_id, edition.update_type)
 
-      if guide.is_a?(Point)
-        save_and_publish_the_service_standard
-      end
-
       unless edition.notification_subscribers == [user]
         NotificationMailer.published(guide, user).deliver_later
       end
@@ -110,26 +106,5 @@ private
       error_message = e.error_details['error']['message'] rescue "Could not communicate with upstream API"
       ManageResult.new(false, [error_message])
     end
-  end
-
-  # Until we can use custom link expansion we need to save a draft and publish the
-  # standard whenever we publish a new point.
-  #
-  # If we save a draft of the service standard when we save a draft of a specific point, the
-  # saving of any other point before our point will overwrite the previously created
-  # draft. This will confuse the user because they will click "publish" on a point page and the
-  # relevant point will not appear in the standard.
-  #
-  def save_and_publish_the_service_standard
-    service_standard_for_publication = ServiceStandardPresenter.new
-    PUBLISHING_API.put_content(
-      service_standard_for_publication.content_id,
-      service_standard_for_publication.content_payload
-    )
-
-    PUBLISHING_API.publish(
-      ServiceStandardPresenter::SERVICE_STANDARD_CONTENT_ID,
-      "major"
-    )
   end
 end

--- a/app/models/service_standard_search_indexer.rb
+++ b/app/models/service_standard_search_indexer.rb
@@ -1,6 +1,6 @@
 class ServiceStandardSearchIndexer
   def initialize
-    @service_standard = ServiceStandardPresenter.new(Point.all).content_payload
+    @service_standard = ServiceStandardPresenter.new.content_payload
   end
 
   def index

--- a/app/presenters/service_standard_presenter.rb
+++ b/app/presenters/service_standard_presenter.rb
@@ -1,10 +1,6 @@
 class ServiceStandardPresenter
   SERVICE_STANDARD_CONTENT_ID = "00f693d4-866a-4fe6-a8d6-09cd7db8980b".freeze
 
-  def initialize(points)
-    @points = points
-  end
-
   def content_id
     SERVICE_STANDARD_CONTENT_ID
   end
@@ -24,28 +20,7 @@ class ServiceStandardPresenter
       details: {
         introduction: "The Digital Service Standard is a set of 18 criteria to help government create and run good digital services.",
         body: "All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use.",
-        points: points_payload,
       }
     }
-  end
-
-private
-
-  attr_reader :points
-
-  def points_payload
-    point_payloads = points.map do |point|
-      edition = point.live_edition
-
-      if edition
-        {
-          base_path: point.slug,
-          summary: edition.description,
-          title: edition.title,
-        }
-      end
-    end
-
-    point_payloads.compact
   end
 end

--- a/spec/models/guide_manager_spec.rb
+++ b/spec/models/guide_manager_spec.rb
@@ -137,16 +137,7 @@ RSpec.describe GuideManager, '#publish' do
     expect(PUBLISHING_API).to receive(:put_content)
       .with(
         an_instance_of(String),
-        hash_including(
-          details: hash_including(
-            points: match_array(
-              [
-                hash_including(:base_path, :summary, title: "Scrum"),
-                hash_including(:base_path, :summary, title: "Agile"),
-              ]
-            )
-          )
-        )
+        an_instance_of(Hash)
       )
       .once
 

--- a/spec/models/guide_manager_spec.rb
+++ b/spec/models/guide_manager_spec.rb
@@ -124,33 +124,6 @@ RSpec.describe GuideManager, '#publish' do
     expect(result).to be_success
   end
 
-  it "saves and publishes the service standard with other published points if publishing a point" do
-    user = create(:user)
-
-    create(:point, :with_published_edition, title: 'Scrum')
-    point = create(:point, :with_ready_edition, title: 'Agile')
-
-    expect(PUBLISHING_API).to receive(:publish)
-      .with(point.content_id, an_instance_of(String))
-      .once
-
-    expect(PUBLISHING_API).to receive(:put_content)
-      .with(
-        an_instance_of(String),
-        an_instance_of(Hash)
-      )
-      .once
-
-    expect(PUBLISHING_API).to receive(:publish)
-      .with(ServiceStandardPresenter::SERVICE_STANDARD_CONTENT_ID, "major")
-      .once
-
-    expect(RUMMAGER_API).to receive(:add_document)
-
-    manager = described_class.new(guide: point, user: user)
-    manager.publish
-  end
-
   context "when communication with the publishing api fails" do
     it "doesn't create anything" do
       stub_publishing_api_to_fail

--- a/spec/presenters/service_standard_presenter_spec.rb
+++ b/spec/presenters/service_standard_presenter_spec.rb
@@ -2,19 +2,14 @@ require "rails_helper"
 
 RSpec.describe ServiceStandardPresenter, "#content_id" do
   it "returns a preassigned UUID" do
-    point_scope = double(:point_scope)
-
     expect(
-      described_class.new(point_scope).content_id
+      described_class.new.content_id
     ).to eq("00f693d4-866a-4fe6-a8d6-09cd7db8980b")
   end
 end
 
 RSpec.describe ServiceStandardPresenter, "#content_payload" do
   it "returns a hash suitable for a service standard draft" do
-    edition = create(:edition, description: "This is a description", title: "1. Understand user needs", state: "published")
-    point = create(:point, editions: [edition], slug: "/service-manual/service-standard/understand-user-needs")
-
     expected_payload = {
       base_path: '/service-manual/service-standard',
       document_type: 'service_manual_service_standard',
@@ -29,48 +24,11 @@ RSpec.describe ServiceStandardPresenter, "#content_payload" do
       details: {
         introduction: "The Digital Service Standard is a set of 18 criteria to help government create and run good digital services.",
         body: "All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use.",
-        points: [
-          {
-            title: "1. Understand user needs",
-            summary: "This is a description",
-            base_path: "/service-manual/service-standard/understand-user-needs",
-          }
-        ]
       }
     }
 
     expect(
-      described_class.new([point]).content_payload
+      described_class.new.content_payload
     ).to eq(expected_payload)
-  end
-
-  it "only includes published editions" do
-    point1_edition = create(:edition, description: "This is a description", title: "1. Understand user needs",)
-    create(:point, editions: [point1_edition], slug: "/service-manual/service-standard/understand-user-needs")
-
-    point2_edition = create(:edition, description: "This is a description", title: "2. Do ongoing user research", state: "published")
-    create(:point, editions: [point2_edition], slug: "/service-manual/service-standard/do-ongoing-user-research")
-
-    point3_edition1 = create(:edition, description: "This is a description", title: "3. Have a multidisciplinary team", state: "published")
-    point3_edition2 = create(:edition, description: "This is a description", title: "3. Have a multidisciplinary team with a typo")
-    create(:point, editions: [point3_edition1, point3_edition2], slug: "/service-manual/service-standard/have-a-multidisciplinary-team")
-
-    expected_points_payload =
-      [
-        {
-          title: "2. Do ongoing user research",
-          summary: "This is a description",
-          base_path: "/service-manual/service-standard/do-ongoing-user-research",
-        },
-        {
-          title: "3. Have a multidisciplinary team",
-          summary: "This is a description",
-          base_path: "/service-manual/service-standard/have-a-multidisciplinary-team",
-        }
-      ]
-
-    expect(
-      described_class.new(Point.all).content_payload[:details][:points]
-    ).to match_array(expected_points_payload)
   end
 end


### PR DESCRIPTION
Use link expansion to avoid saving and publishing the service standard every time a point changes.

Frontend PR: https://github.com/alphagov/service-manual-frontend/pull/50