### PR TITLE
Allow the Homepage to be published

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -23,13 +23,13 @@ class TopicsController < ApplicationController
   end
 
   def update
-    @topic.assign_attributes(update_topic_params)
-
     if params[:add_heading]
+      @topic.assign_attributes(update_topic_params)
       add_heading(@topic)
     elsif params[:publish]
       topic_respond_with publish(@topic), notice: "Topic has been published"
     else
+      @topic.assign_attributes(update_topic_params)
       topic_respond_with save_draft(@topic), notice: "Topic has been updated"
     end
   end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -90,6 +90,7 @@ private
       :title,
       :description,
       :visually_collapsed,
+      :include_on_homepage,
       content_owner_ids: [],
       topic_sections_attributes: [
         :id,

--- a/app/models/homepage_search_indexer.rb
+++ b/app/models/homepage_search_indexer.rb
@@ -1,0 +1,25 @@
+class HomepageSearchIndexer
+  def initialize
+    @homepage = HomepagePresenter.new.content_payload
+  end
+
+  def index
+    RUMMAGER_API.add_document(
+      # Pretend the homepage is a guide, as far as Rummager's concerned it might
+      # as well be.
+      'service_manual_guide',
+      @homepage[:base_path],
+      format:            'service_manual_guide',
+      description:       @homepage[:description],
+      indexable_content: "",
+      title:             @homepage[:title],
+      link:              @homepage[:base_path],
+      manual:            '/service-manual',
+      organisations:     ['government-digital-service'],
+    )
+  end
+
+  def delete
+    RUMMAGER_API.delete_content!(@service_standard[:base_path])
+  end
+end

--- a/app/presenters/homepage_presenter.rb
+++ b/app/presenters/homepage_presenter.rb
@@ -12,7 +12,7 @@ class HomepagePresenter
       description: 'Helping government teams create and run great digital services that meet the Digital Service Standard.',
       details: {},
       routes: [
-        { type: 'exact', path: '/service-manual' }
+        { type: 'prefix', path: '/service-manual' }
       ],
       document_type: 'service_manual_homepage',
       schema_name: 'service_manual_homepage',

--- a/app/presenters/homepage_presenter.rb
+++ b/app/presenters/homepage_presenter.rb
@@ -4,4 +4,21 @@ class HomepagePresenter
   def content_id
     HOMEPAGE_CONTENT_ID
   end
+
+  def content_payload
+    {
+      base_path: '/service-manual',
+      title: 'Service Manual',
+      description: 'Helping government teams create and run great digital services that meet the Digital Service Standard.',
+      details: {},
+      routes: [
+        { type: 'exact', path: '/service-manual' }
+      ],
+      document_type: 'service_manual_homepage',
+      schema_name: 'service_manual_homepage',
+      publishing_app: 'service-manual-publisher',
+      rendering_app: 'service-manual-frontend',
+      locale: 'en'
+    }
+  end
 end

--- a/app/presenters/homepage_presenter.rb
+++ b/app/presenters/homepage_presenter.rb
@@ -1,0 +1,7 @@
+class HomepagePresenter
+  HOMEPAGE_CONTENT_ID = "6732c01a-39e2-4cec-8ee9-17eb7fded6a0".freeze
+
+  def content_id
+    HOMEPAGE_CONTENT_ID
+  end
+end

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -36,6 +36,7 @@ class TopicPresenter
         linked_items: topic.guides.map(&:content_id),
         content_owners: content_owner_content_ids,
         organisations: [ServiceManualPublisher::GDS_ORGANISATION_CONTENT_ID],
+        parent: parents
       }
     }
   end
@@ -43,6 +44,15 @@ class TopicPresenter
 private
 
   attr_reader :topic
+
+  def parents
+    if topic.include_on_homepage?
+      [HomepagePresenter::HOMEPAGE_CONTENT_ID]
+    else
+      []
+    end
+  end
+
 
   def groups
     topic.topic_sections.map do |topic_section|

--- a/app/views/topics/_form.html.erb
+++ b/app/views/topics/_form.html.erb
@@ -32,6 +32,12 @@
             By default the sections of a topic will be expanded. Setting this option will show all the sections collapsed, but expandable, when the user visits the page.
           </div>
         </div>
+        <div class="form-group">
+          <%= f.label :include_on_homepage do %>
+            <%= f.check_box :include_on_homepage %>
+            Include on homepage?
+          <% end %>
+        </div>
       </div>
 
       <div class="well">

--- a/db/migrate/20160914133843_add_include_on_homepage_to_topics.rb
+++ b/db/migrate/20160914133843_add_include_on_homepage_to_topics.rb
@@ -1,0 +1,5 @@
+class AddIncludeOnHomepageToTopics < ActiveRecord::Migration
+  def change
+    add_column :topics, :include_on_homepage, :boolean, default: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -345,7 +345,8 @@ CREATE TABLE topics (
     description character varying NOT NULL,
     content_id character varying,
     visually_collapsed boolean DEFAULT false,
-    email_alert_signup_content_id character varying
+    email_alert_signup_content_id character varying,
+    include_on_homepage boolean DEFAULT true
 );
 
 
@@ -840,6 +841,8 @@ INSERT INTO schema_migrations (version) VALUES ('20160630082357');
 INSERT INTO schema_migrations (version) VALUES ('20160729100003');
 
 INSERT INTO schema_migrations (version) VALUES ('20160816150906');
+
+INSERT INTO schema_migrations (version) VALUES ('20160914133843');
 
 INSERT INTO schema_migrations (version) VALUES ('20161208103043');
 

--- a/lib/tasks/migrate_homepage.rake
+++ b/lib/tasks/migrate_homepage.rake
@@ -1,0 +1,38 @@
+require 'gds_api/publishing_api'
+require 'highline'
+
+desc "Migrate the homepage"
+task migrate_homepage: :environment do
+  cli = HighLine.new
+  cli.say cli.color(
+    "Publishing the homepage will make the old service manual inaccessible. Continue?",
+    :red
+  )
+  exit unless cli.agree "Are you sure you wish to continue?"
+
+  publishing_api_v1 = GdsApi::PublishingApi.new(
+    Plek.new.find('publishing-api'),
+    bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
+  )
+
+  # Take ownership of the path reservation
+  publishing_api_v1.put_path('/service-manual',
+    publishing_app: 'service-manual-publisher',
+    override_existing: true
+  )
+
+  homepage = HomepagePresenter.new
+  
+  # Save and publish the homepage
+  PUBLISHING_API.put_content(
+    homepage.content_id,
+    homepage.content_payload
+  )
+
+  PUBLISHING_API.publish(
+    homepage.content_id,
+    "major"
+  )
+
+  puts "Done."
+end

--- a/lib/tasks/migrate_homepage.rake
+++ b/lib/tasks/migrate_homepage.rake
@@ -16,19 +16,32 @@ task migrate_homepage: :environment do
   )
 
   # Take ownership of the path reservation
+  puts "Taking ownership of the path..."
   publishing_api_v1.put_path('/service-manual',
     publishing_app: 'service-manual-publisher',
     override_existing: true
   )
 
   homepage = HomepagePresenter.new
-  
-  # Save and publish the homepage
+
+  # Save a draft of the homepage
+  puts "Creating homepage..."
   PUBLISHING_API.put_content(
     homepage.content_id,
     homepage.content_payload
   )
 
+  # Republish all topics (as children of the homepage)
+  Topic.find_each do |topic|
+    puts "Republishing #{topic.title}..."
+
+    publisher = TopicPublisher.new(topic: topic)
+    publisher.save_draft
+    publisher.publish
+  end
+
+  # Publish the homepage
+  puts "Publishing the homepage..."
   PUBLISHING_API.publish(
     homepage.content_id,
     "major"

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -1,6 +1,6 @@
 namespace :rummager do
   desc "index all guides, topics and the service standard in Rummager"
-  task index: [:index_guides, :index_topics, :index_service_standard]
+  task index: [:index_guides, :index_topics, :index_service_standard, :index_homepage]
 
   desc 'Index all guides in Rummager'
   task index_guides: :environment do
@@ -25,5 +25,12 @@ namespace :rummager do
     puts "Indexing the Service Standard..."
 
     ServiceStandardSearchIndexer.new.index
+  end
+
+  desc 'Index the homepage in Rummager'
+  task index_homepage: :environment do
+    puts "Indexing the Homepage..."
+
+    HomepageSearchIndexer.new.index
   end
 end

--- a/spec/controllers/topics_controller_spec.rb
+++ b/spec/controllers/topics_controller_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe TopicsController, type: :controller do
+  before do
+    login_as build(:user)
+  end
+
+  describe '#update' do
+    context 'when publishing' do
+      it 'publishes the topic to the publishing api' do
+        stub_any_publishing_api_publish
+        stub_any_rummager_post
+        topic = create(:topic)
+
+        put :update, id: topic.id, publish: true
+
+        assert_publishing_api_publish(topic.content_id)
+      end
+
+      it 'sends the topic to rummager' do
+        stub_any_publishing_api_publish
+        stub_any_rummager_post
+        topic = create(:topic, path: '/service-manual/a-topic')
+
+        put :update, id: topic.id, publish: true
+
+        assert_rummager_posted_item(_id: '/service-manual/a-topic')
+      end
+    end
+  end
+end

--- a/spec/features/topic_spec.rb
+++ b/spec/features/topic_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe "Topics", type: :feature do
     expect(page).to_not have_button('Publish')
   end
 
+  it 'allows you to choose whether the topic should appear on the homepage' do
+    visit new_topic_path
+
+    expect(page).to have_checked_field 'Include on homepage?'
+  end
+
   it "saves a draft topic" do
     stub_const("PUBLISHING_API", api_double)
     expect(api_double).to receive(:put_content)
@@ -33,6 +39,7 @@ RSpec.describe "Topics", type: :feature do
     fill_in "Title", with: "The title"
     fill_in "Description", with: "The description"
     check "Collapsed"
+    uncheck "Include on homepage?"
     click_button "Add Heading"
     fill_in "Heading Title", with: "The heading title"
     fill_in "Heading Description", with: "The heading description"
@@ -41,6 +48,7 @@ RSpec.describe "Topics", type: :feature do
     expect(page).to have_field('Title', with: 'The title')
     expect(page).to have_field('Description', with: 'The description')
     expect(page).to have_checked_field('Collapsed')
+    expect(page).to have_unchecked_field('Include on homepage?')
 
     expect(find_field("Heading Title").value).to eq "The heading title"
     expect(find_field("Heading Description").value).to eq "The heading description"

--- a/spec/models/homepage_search_indexer_spec.rb
+++ b/spec/models/homepage_search_indexer_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe HomepageSearchIndexer, '#index' do
+  it 'indexes a document in rummager' do
+    stub_any_rummager_post
+
+    described_class.new.index
+
+    assert_rummager_posted_item(
+      _type:              'service_manual_guide',
+      _id:                '/service-manual',
+      format:             'service_manual_guide',
+      description:        'Helping government teams create and run great digital services that meet the Digital Service Standard.',
+      indexable_content:  '',
+      title:              'Service Manual',
+      link:               '/service-manual',
+      manual:             '/service-manual',
+      organisations:      ['government-digital-service'],
+    )
+  end
+end
+
+RSpec.describe ServiceStandardSearchIndexer, '#delete' do
+  it 'deletes the homepage from rummager' do
+    stub_any_rummager_delete_content
+
+    described_class.new.delete
+
+    assert_rummager_deleted_content '/service-manual'
+  end
+end

--- a/spec/presenters/homepage_presenter_spec.rb
+++ b/spec/presenters/homepage_presenter_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe HomepagePresenter, "#content_id" do
+  it "returns a preassigned UUID" do
+    expect(
+      described_class.new.content_id
+    ).to eq("6732c01a-39e2-4cec-8ee9-17eb7fded6a0")
+  end
+end
+
+RSpec.describe HomepagePresenter, "#content_payload" do
+  it "conforms to the schema" do
+    homepage_presenter = described_class.new
+
+    expect(homepage_presenter.content_payload).to be_valid_against_schema('service_manual_homepage')
+  end
+
+  it 'includes a title for the service manual' do
+    payload = described_class.new.content_payload
+
+    expect(payload).to include title: "Service Manual"
+  end
+
+  it 'includes a description for the service manual' do
+    payload = described_class.new.content_payload
+
+    expect(payload).to include \
+      description: 'Helping government teams create and run great digital services that meet the Digital Service Standard.'
+  end
+
+  it 'includes a base path and route for the service manual' do
+    payload = described_class.new.content_payload
+
+    expect(payload).to include \
+      base_path: '/service-manual',
+      routes: [
+        { type: 'exact', path: '/service-manual' }
+      ]
+  end
+
+  it 'includes the rendering and publishing apps' do
+    payload = described_class.new.content_payload
+
+    expect(payload).to include \
+      publishing_app: 'service-manual-publisher',
+      rendering_app: 'service-manual-frontend'
+  end
+
+  it 'includes the document and schema type' do
+    payload = described_class.new.content_payload
+
+    expect(payload).to include \
+      document_type: 'service_manual_homepage',
+      schema_name: 'service_manual_homepage'
+  end
+end

--- a/spec/presenters/homepage_presenter_spec.rb
+++ b/spec/presenters/homepage_presenter_spec.rb
@@ -28,13 +28,13 @@ RSpec.describe HomepagePresenter, "#content_payload" do
       description: 'Helping government teams create and run great digital services that meet the Digital Service Standard.'
   end
 
-  it 'includes a base path and route for the service manual' do
+  it 'includes a base path and prefix route for the service manual' do
     payload = described_class.new.content_payload
 
     expect(payload).to include \
       base_path: '/service-manual',
       routes: [
-        { type: 'exact', path: '/service-manual' }
+        { type: 'prefix', path: '/service-manual' }
       ]
   end
 

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -166,6 +166,30 @@ RSpec.describe TopicPresenter, "#links_payload" do
     ).to eq([])
   end
 
+  context 'when the topic should be included on the homepage' do
+    it "includes the homepage as a parent" do
+      topic = create(:topic, include_on_homepage: true)
+
+      presented_topic = described_class.new(topic)
+
+      expect(presented_topic.links_payload[:links]).to include(
+        parent: ['6732c01a-39e2-4cec-8ee9-17eb7fded6a0']
+      )
+    end
+  end
+
+  context 'when the topic should not be included on the homepage' do
+    it "explicitly removes any parent" do
+      topic = create(:topic, include_on_homepage: false)
+
+      presented_topic = described_class.new(topic)
+
+      expect(presented_topic.links_payload[:links]).to include(
+        parent: []
+      )
+    end
+  end
+
   def create_topic_in_groups(groups)
     topic = create(:topic)
     groups.each do |group_guides|


### PR DESCRIPTION
This updates the topic presenter to include a link to the homepage as a `parent` if the topic is set to be included on the homepage (the communities topic won't be, and we need a way to filter that out)

We don't currently have a good way to publish the homepage, so the HomepagePresenter only exists to define a content id for the homepage. I'm not sure of the implications of creating links to things that don't exist yet, so that's why this PR is marked as do not merge.
