### PR TITLE
Move introduction into description

### DIFF
--- a/app/models/service_standard_search_indexer.rb
+++ b/app/models/service_standard_search_indexer.rb
@@ -10,7 +10,7 @@ class ServiceStandardSearchIndexer
       'service_manual_guide',
       @service_standard[:base_path],
       format:            'service_manual_guide',
-      description:       @service_standard[:details][:introduction],
+      description:       @service_standard[:description],
       indexable_content: @service_standard[:details][:body],
       title:             @service_standard[:title],
       link:              @service_standard[:base_path],

--- a/app/presenters/service_standard_presenter.rb
+++ b/app/presenters/service_standard_presenter.rb
@@ -17,8 +17,8 @@ class ServiceStandardPresenter
       ],
       schema_name: 'service_manual_service_standard',
       title: 'Digital Service Standard',
+      description: "The Digital Service Standard is a set of 18 criteria to help government create and run good digital services.",
       details: {
-        introduction: "The Digital Service Standard is a set of 18 criteria to help government create and run good digital services.",
         body: "All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use.",
       }
     }

--- a/spec/presenters/service_standard_presenter_spec.rb
+++ b/spec/presenters/service_standard_presenter_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe ServiceStandardPresenter, "#content_payload" do
       ],
       schema_name: 'service_manual_service_standard',
       title: 'Digital Service Standard',
+      description: "The Digital Service Standard is a set of 18 criteria to help government create and run good digital services.",
       details: {
-        introduction: "The Digital Service Standard is a set of 18 criteria to help government create and run good digital services.",
         body: "All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use.",
       }
     }


### PR DESCRIPTION
The service manual frontend now uses description instead of details/introduction (since 925610d) so ensure we set a description. This is currently broken on frontend master with no description being shown.

Additionally, within the service standard content schema this introduction already appears as description and there is no `introduction` within the details hash, so this aligns what is published with what is in the schema.