### PR TITLE
Handle exceptions better when publishing topics

### DIFF
--- a/app/models/topic_publisher.rb
+++ b/app/models/topic_publisher.rb
@@ -39,7 +39,9 @@ private
         end
       end
     rescue GdsApi::HTTPErrorResponse => e
-      Response.new(success: false, error: e.error_details['error']['message'])
+      Airbrake.notify(e)
+      error_message = e.error_details['error']['message'] rescue "Could not communicate with upstream API"
+      Response.new(success: false, error: error_message)
     end
   end
 


### PR DESCRIPTION
Send the exception to Airbrake so that we’re aware of it, and handle cases where error_details does not contain an `error.message`.