### PR TITLE
Publish email signup first

### DIFF
--- a/app/models/topic_publisher.rb
+++ b/app/models/topic_publisher.rb
@@ -11,10 +11,10 @@ class TopicPublisher
     email_alert_signup_presenter = EmailAlertSignupPresenter.new(topic)
 
     save_catching_gds_api_errors do
+      publishing_api.put_content(email_alert_signup_presenter.content_id, email_alert_signup_presenter.content_payload)
+
       publishing_api.put_content(topic_presenter.content_id, topic_presenter.content_payload)
       publishing_api.patch_links(topic_presenter.content_id, topic_presenter.links_payload)
-
-      publishing_api.put_content(email_alert_signup_presenter.content_id, email_alert_signup_presenter.content_payload)
     end
   end
 


### PR DESCRIPTION
The link to the email alert signup does not currently get expanded correctly when you first publish a topic because it doesn’t exist yet.

Fix this by creating the email alert signup before creating the topic.