### PR TITLE
Guide has button to view live version when published

### DIFF
--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -89,7 +89,7 @@ class Guide < ActiveRecord::Base
     editions.published.any?
   end
 
-  def can_be_unpublished?
+  def has_been_published?
     has_any_published_editions? && !has_any_unpublished_editions?
   end
 

--- a/app/policies/edition_policy.rb
+++ b/app/policies/edition_policy.rb
@@ -17,7 +17,7 @@ class EditionPolicy
   end
 
   def can_discard_draft?
-    !Edition::STATES_THAT_UPDATE_THE_FRONTEND.include?(edition.state)
+    is_being_edited?
   end
 
   def can_discard_new_draft?
@@ -25,7 +25,7 @@ class EditionPolicy
   end
 
   def can_preview?
-    edition.persisted?
+    edition.persisted? && is_being_edited?
   end
 
 private
@@ -42,5 +42,9 @@ private
 
   def allow_self_approval?
     ENV['ALLOW_SELF_APPROVAL'].present?
+  end
+
+  def is_being_edited?
+    !Edition::STATES_THAT_UPDATE_THE_FRONTEND.include?(edition.state)
   end
 end

--- a/app/views/editions/_actions.html.erb
+++ b/app/views/editions/_actions.html.erb
@@ -4,8 +4,12 @@
 
       <% edition_policy = EditionPolicy.new(current_user, edition) %>
 
-      <% if edition_policy.can_preview? %>
+      <% if edition_policy.can_preview? && edition_policy.can_discard_draft? %>
         <%= link_to "Preview", preview_content_model_url(guide), class: 'btn btn-default add-right-margin' %>
+      <% end %>
+
+      <% if guide.can_be_unpublished? %>
+        <%= link_to "View on website", [Plek.new.website_root, guide.slug].join(''), class: 'btn btn-default add-right-margin' %>
       <% end %>
 
       <% if !publish_controls_only %>

--- a/app/views/editions/_actions.html.erb
+++ b/app/views/editions/_actions.html.erb
@@ -4,7 +4,7 @@
 
       <% edition_policy = EditionPolicy.new(current_user, edition) %>
 
-      <% if edition_policy.can_preview? && edition_policy.can_discard_draft? %>
+      <% if edition_policy.can_preview? %>
         <%= link_to "Preview", preview_content_model_url(guide), class: 'btn btn-default add-right-margin' %>
       <% end %>
 

--- a/app/views/editions/_actions.html.erb
+++ b/app/views/editions/_actions.html.erb
@@ -8,7 +8,7 @@
         <%= link_to "Preview", preview_content_model_url(guide), class: 'btn btn-default add-right-margin' %>
       <% end %>
 
-      <% if guide.can_be_unpublished? %>
+      <% if guide.has_been_published? %>
         <%= link_to "View on website", [Plek.new.website_root, guide.slug].join(''), class: 'btn btn-default add-right-margin' %>
       <% end %>
 
@@ -48,7 +48,7 @@
             %>
         <% end %>
 
-        <% if guide.can_be_unpublished? %>
+        <% if guide.has_been_published? %>
           <%= link_to "Unpublish", unpublish_guide_path(guide), class: 'btn btn-danger pull-right' %>
         <% end %>
 

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -374,3 +374,56 @@ RSpec.describe "Guide publishing action buttons", type: :feature do
     expect(page).to     have_button("Publish")
   end
 end
+
+RSpec.describe "'View' and 'Preview' buttons", type: :feature do
+  describe "a draft guide" do
+    before do
+      guide = create(:guide, :with_draft_edition,
+        slug: "/service-manual/topic-name/new-guide",
+        )
+      visit edit_guide_path(guide)
+    end
+
+    it "has a 'Preview' link" do
+      expect(page).to have_link "Preview", href: "http://draft-origin.dev.gov.uk/service-manual/topic-name/new-guide"
+    end
+
+    it "does not have a 'View on website' button" do
+      expect(page).to_not have_button "View on website"
+    end
+  end
+
+  describe "a published guide" do
+    before do
+      guide = create(:guide, :with_published_edition,
+        slug: "/service-manual/topic-name/just-published",
+        )
+      visit edit_guide_path(guide)
+    end
+
+    it "does not have a 'Preview' link" do
+      expect(page).to_not have_button "Preview"
+    end
+
+    it "has a 'View on website' link" do
+      expect(page).to have_link "View on website", href: "http://www.dev.gov.uk/service-manual/topic-name/just-published"
+    end
+  end
+
+  describe "a draft that was previously published" do
+    before do
+      guide = create(:guide, :with_previously_published_edition,
+        slug: "/service-manual/topic-name/published-guide",
+      )
+      visit edit_guide_path(guide)
+    end
+
+    it "has a 'Preview' link" do
+      expect(page).to have_link "Preview", href: "http://draft-origin.dev.gov.uk/service-manual/topic-name/published-guide"
+    end
+
+    it "has a 'View on website' link" do
+      expect(page).to have_link "View on website", href: "http://www.dev.gov.uk/service-manual/topic-name/published-guide"
+    end
+  end
+end

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -205,15 +205,15 @@ RSpec.describe Guide, "#editions_since_last_published" do
   end
 end
 
-RSpec.describe Guide, "#can_be_unpublished?" do
+RSpec.describe Guide, "#has_been_published?" do
   it "returns true if the guide has been published" do
     guide = create(:guide, :with_published_edition)
-    expect(guide.can_be_unpublished?).to be true
+    expect(guide.has_been_published?).to be true
   end
 
   it "returns false if the guide has been unpublished" do
     guide = create(:guide, :has_been_unpublished)
-    expect(guide.can_be_unpublished?).to be false
+    expect(guide.has_been_published?).to be false
   end
 end
 


### PR DESCRIPTION
A 'View on website' button has been added which allows users to view the live version of the guide. It is always shown unless it has never been published.:w
The 'preview' button is only shown when a guide has been saved in a draft state.
