### PR TITLE
Add task to remove orphaned associations

### DIFF
--- a/lib/tasks/remove_orphaned_topic_section_guides.rake
+++ b/lib/tasks/remove_orphaned_topic_section_guides.rake
@@ -1,0 +1,11 @@
+desc "Remove orphaned topic section guide associations"
+task remove_orphaned_topic_section_guides: :environment do
+  puts "Removing orphaned associations..."
+
+  TopicSectionGuide.where([
+    "guide_id NOT IN (?)",
+    Guide.pluck("id")
+  ]).destroy_all
+
+  puts "Done."
+end


### PR DESCRIPTION
The associations between Guides and TopicSectionGuides was not previously marked as dependent.

This meant that when unpublished guides had their draft discarded, the topic_section_guide row remained but was associated with a Guide that does not exist.

This breaks the topic page within publisher as it tries to loop over all guides and print their title, but the non-existent guide is nil.

Related PR: https://github.com/alphagov/service-manual-publisher/pull/351