### PR TITLE
Rake task to output published guide edtion history

### DIFF
--- a/lib/tasks/output_guide_change_history_details.rake
+++ b/lib/tasks/output_guide_change_history_details.rake
@@ -1,16 +1,16 @@
 desc "Print out guide details"
 task print_guide_details: :environment do
-	Guide.live.find_each do |guide|
-		editions = guide.editions
+  Guide.live.find_each do |guide|
+    editions = guide.editions
 
-		puts "Guide: #{guide.title}, slug: '#{guide.slug}'"
-		editions.published.major.each do |edition|
-			puts "Edition details:"
-			puts "Change note: '#{edition.change_note}'"
-			puts "Reason for change: '#{edition.reason_for_change}'"
-			puts ""
-		end
-		puts "---------------------------"
-	end
+    puts "Guide: #{guide.title}, slug: '#{guide.slug}'"
+    editions.published.major.each do |edition|
+      puts "Edition details:"
+      puts "Change note: '#{edition.change_note}'"
+      puts "Reason for change: '#{edition.reason_for_change}'"
+      puts ""
+    end
+    puts "---------------------------"
+  end
 
 end

--- a/lib/tasks/output_guide_change_history_details.rake
+++ b/lib/tasks/output_guide_change_history_details.rake
@@ -1,16 +1,21 @@
 desc "Print out guide details"
 task print_guide_details: :environment do
   Guide.live.find_each do |guide|
-    editions = guide.editions
+    editions = guide.editions.published.major
+    if editions.any?
+      puts "## #{guide.title}"
+      puts "#{guide.slug}"
+      puts ""
 
-    puts "Guide: #{guide.title}, slug: '#{guide.slug}'"
-    editions.published.major.each do |edition|
-      puts "Edition details:"
-      puts "Change note: '#{edition.change_note}'"
-      puts "Reason for change: '#{edition.reason_for_change}'"
+      editions.each do |edition|
+        puts "### #{edition.updated_at.to_formatted_s}"
+        puts "Change note: '#{edition.change_note}'"
+        puts "Reason for change: '#{edition.reason_for_change}'"
+        puts ""
+      end
+
       puts ""
     end
-    puts "---------------------------"
   end
 
 end

--- a/lib/tasks/output_guide_change_history_details.rake
+++ b/lib/tasks/output_guide_change_history_details.rake
@@ -1,0 +1,16 @@
+desc "Print out guide details"
+task print_guide_details: :environment do
+	Guide.live.find_each do |guide|
+		editions = guide.editions
+
+		puts "Guide: #{guide.title}, slug: '#{guide.slug}'"
+		editions.published.major.each do |edition|
+			puts "Edition details:"
+			puts "Change note: '#{edition.change_note}'"
+			puts "Reason for change: '#{edition.reason_for_change}'"
+			puts ""
+		end
+		puts "---------------------------"
+	end
+
+end

--- a/lib/tasks/print_change_history_for_published_guides.rake
+++ b/lib/tasks/print_change_history_for_published_guides.rake
@@ -1,5 +1,5 @@
-desc "Print out guide details"
-task print_guide_details: :environment do
+desc "Print the change history for all published guides"
+task print_change_history_for_published_guides: :environment do
   Guide.live.find_each do |guide|
     editions = guide.editions.published.major
     if editions.any?
@@ -17,5 +17,4 @@ task print_guide_details: :environment do
       puts ""
     end
   end
-
 end


### PR DESCRIPTION
Some of the guides do not have correct change notes as they were created before the history feature was added. This rake task outputs details of all the published guides and details about their major changes. This will allow us to locate which change notes need to be updated.