### PR TITLE
Allow a guides topic to change until it is published

### DIFF
--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -134,7 +134,7 @@ private
 
   def slug_cant_be_changed
     if slug_changed?
-      errors.add(:slug, "can't be changed if guide has a published edition")
+      errors.add(:slug, "can't be changed as this guide has been published")
     end
   end
 
@@ -165,7 +165,7 @@ private
     new_section = TopicSection.find(to)
 
     if old_section.topic_id != new_section.topic_id
-      errors.add(:topic_section, "cannot change to a different topic")
+      errors.add(:topic_section, "can't be changed to a different topic as this guide has been published")
     end
   end
 end

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -4,7 +4,7 @@ class Guide < ActiveRecord::Base
   validate :slug_cant_be_changed, if: :has_any_published_editions?
   validate :new_edition_has_content_owner, if: :requires_content_owner?
   validate :must_have_topic, if: :requires_topic?
-  validate :topic_cannot_change, if: :requires_topic?
+  validate :topic_cannot_change, if: [:requires_topic?, :has_any_published_editions?]
 
   has_many :editions, dependent: :destroy
   has_many :topic_section_guides, dependent: :destroy, autosave: true

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -1,7 +1,7 @@
 class Guide < ActiveRecord::Base
   include ContentIdentifiable
   validate :slug_format
-  validate :slug_cant_be_changed_if_an_edition_has_been_published
+  validate :slug_cant_be_changed, if: :has_any_published_editions?
   validate :new_edition_has_content_owner, if: :requires_content_owner?
   validate :must_have_topic, if: :requires_topic?
   validate :topic_cannot_change, if: :requires_topic?
@@ -132,8 +132,8 @@ private
     end
   end
 
-  def slug_cant_be_changed_if_an_edition_has_been_published
-    if slug_changed? && has_any_published_editions?
+  def slug_cant_be_changed
+    if slug_changed?
       errors.add(:slug, "can't be changed if guide has a published edition")
     end
   end

--- a/spec/factories/guide.rb
+++ b/spec/factories/guide.rb
@@ -30,6 +30,7 @@ FactoryGirl.define do
       # a guide can't exist without an edition, so by default include one draft
       states [:draft]
       topic nil
+      topic_section nil
       requires_topic true
     end
 
@@ -66,7 +67,9 @@ FactoryGirl.define do
     end
 
     after(:build) do |guide, evaluator|
-      if evaluator.requires_topic
+      if evaluator.topic_section
+        guide.topic_section_guides.build(topic_section: evaluator.topic_section)
+      elsif evaluator.requires_topic
         topic_section = build(:topic_section, topic: evaluator.topic || build(:topic))
         guide.topic_section_guides.build(topic_section: topic_section)
       end

--- a/spec/factory_specs/guide_spec.rb
+++ b/spec/factory_specs/guide_spec.rb
@@ -27,6 +27,19 @@ RSpec.describe ":guide" do
     expect(Topic.count).to eq(2)
     expect(TopicSection.count).to eq(2)
   end
+
+  it "can be associated with a supplied topic section" do
+    topic_section = create(:topic_section)
+    guide = create(:guide, topic_section: topic_section)
+
+    expect(guide.topic).to eq(topic_section.topic)
+    expect(topic_section.guides).to include(guide)
+
+    # Check we haven't produced any extra topics or topic sections.
+    # We should have 2 of each for both the guide and the guide community.
+    expect(Topic.count).to eq(2)
+    expect(TopicSection.count).to eq(2)
+  end
 end
 
 RSpec.describe ":point" do

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -235,7 +235,9 @@ RSpec.describe "Updating a guide", type: :feature do
       click_first_button "Save"
 
       within(".full-error-list") do
-        expect(page).to have_content("Topic section cannot change to a different topic")
+        expect(page).to have_content(
+          "Topic section can't be changed to a different topic as this guide has been published"
+        )
       end
     end
   end
@@ -267,14 +269,14 @@ RSpec.describe "Updating a guide", type: :feature do
         title: "Original Section",
         topic: create(:topic, title: "Original Topic")
       )
-      different_topic_section = create(:topic_section,
+      create(:topic_section,
         title: "Another Section",
         topic: create(:topic, title: "Another Topic")
       )
       guide = create(:guide, topic_section: original_topic_section)
 
       visit edit_guide_path(guide)
-      
+
       select "Another Topic -> Another Section", from: "Topic section", exact: true
       click_first_button "Save"
 

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -220,6 +220,24 @@ RSpec.describe "Updating a guide", type: :feature, js: true do
 
       expect(find('input.guide-slug')['disabled']).to be_present
     end
+
+    it "prevents users from changing the topic" do
+      create(:topic_section,
+        topic: create(:topic, title: "Another Topic"),
+        title: "Section One"
+      )
+
+      guide = create(:guide, :with_published_edition)
+
+      visit edit_guide_path(guide)
+
+      select "Another Topic -> Section One", from: "Topic section"
+      click_first_button "Save"
+
+      within(".full-error-list") do
+        expect(page).to have_content("Topic section cannot change to a different topic")
+      end
+    end
   end
 
   context "when the guide has never previously been published" do

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -220,26 +220,6 @@ RSpec.describe "Updating a guide", type: :feature do
 
       expect(find('input.guide-slug')['disabled']).to be_present
     end
-
-    it "prevents users from changing the topic" do
-      create(:topic_section,
-        topic: create(:topic, title: "Another Topic"),
-        title: "Section One"
-      )
-
-      guide = create(:guide, :with_published_edition)
-
-      visit edit_guide_path(guide)
-
-      select "Another Topic -> Section One", from: "Topic section"
-      click_first_button "Save"
-
-      within(".full-error-list") do
-        expect(page).to have_content(
-          "Topic section can't be changed to a different topic as this guide has been published"
-        )
-      end
-    end
   end
 
   context "when the guide has never previously been published" do
@@ -252,36 +232,6 @@ RSpec.describe "Updating a guide", type: :feature do
 
       visit edit_guide_path(guide)
       expect(find('input.guide-slug')['disabled']).not_to be_present
-      fill_in "Slug", with: "changed"
-      click_first_button "Save"
-
-      visit edit_guide_path(guide)
-
-      expect(page).to have_field("Slug", with: "changed")
-      expect(page).to have_field("Final URL", with: "/service-manual/test-topic/changed")
-    end
-
-    it "allows users to change the topic" do
-      stub_any_publishing_api_put_content
-      stub_any_publishing_api_patch_links
-
-      original_topic_section = create(:topic_section,
-        title: "Original Section",
-        topic: create(:topic, title: "Original Topic")
-      )
-      create(:topic_section,
-        title: "Another Section",
-        topic: create(:topic, title: "Another Topic")
-      )
-      guide = create(:guide, topic_section: original_topic_section)
-
-      visit edit_guide_path(guide)
-
-      select "Another Topic -> Another Section", from: "Topic section", exact: true
-      click_first_button "Save"
-
-      visit edit_guide_path(guide)
-      expect(page).to have_select("Topic section", selected: "Another Topic -> Another Section")
     end
   end
 

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -169,7 +169,7 @@ private
   end
 end
 
-RSpec.describe "Updating a guide", type: :feature, js: true do
+RSpec.describe "Updating a guide", type: :feature do
   let(:api_double) { double(:publishing_api) }
 
   context "when the guide has previously been published" do
@@ -241,7 +241,7 @@ RSpec.describe "Updating a guide", type: :feature, js: true do
   end
 
   context "when the guide has never previously been published" do
-    it "allows the user to edit the url slug" do
+    it "allows the user to edit the url slug", js: true do
       stub_any_publishing_api_put_content
       stub_any_publishing_api_patch_links
 
@@ -257,6 +257,29 @@ RSpec.describe "Updating a guide", type: :feature, js: true do
 
       expect(page).to have_field("Slug", with: "changed")
       expect(page).to have_field("Final URL", with: "/service-manual/test-topic/changed")
+    end
+
+    it "allows users to change the topic" do
+      stub_any_publishing_api_put_content
+      stub_any_publishing_api_patch_links
+
+      original_topic_section = create(:topic_section,
+        title: "Original Section",
+        topic: create(:topic, title: "Original Topic")
+      )
+      different_topic_section = create(:topic_section,
+        title: "Another Section",
+        topic: create(:topic, title: "Another Topic")
+      )
+      guide = create(:guide, topic_section: original_topic_section)
+
+      visit edit_guide_path(guide)
+      
+      select "Another Topic -> Another Section", from: "Topic section", exact: true
+      click_first_button "Save"
+
+      visit edit_guide_path(guide)
+      expect(page).to have_select("Topic section", selected: "Another Topic -> Another Section")
     end
   end
 

--- a/spec/models/guide_community_spec.rb
+++ b/spec/models/guide_community_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe GuideCommunity do
+  describe "#valid?" do
+    describe "when validating the content owner" do
+      it "is valid for the latest edition not to have a content owner" do
+        edition = build(:edition, content_owner: nil)
+        point = build(:guide_community, editions: [edition])
+        expect(point).to be_valid
+      end
+    end
+  end
+end

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Guide do
       end
 
       it "isn't possible to change the topic for a published guide" do
-        original_topic_section = create(:topic_section, 
+        original_topic_section = create(:topic_section,
           topic: create(:topic, path: "/service-manual/original-topic")
         )
         different_topic_section = create(:topic_section,
@@ -132,14 +132,14 @@ RSpec.describe Guide do
 
         expect(
           guide.errors.full_messages_for(:topic_section)
-        ).to include("Topic section cannot change to a different topic")
+        ).to include("Topic section can't be changed to a different topic as this guide has been published")
 
         expect(original_topic_section.reload.guides).to include guide
         expect(different_topic_section.reload.guides).to_not include guide
       end
 
       it "is possible to change the topic for a draft guide" do
-        original_topic_section = create(:topic_section, 
+        original_topic_section = create(:topic_section,
           topic: create(:topic, path: "/service-manual/original-topic")
         )
         different_topic_section = create(:topic_section,
@@ -166,7 +166,9 @@ RSpec.describe Guide do
         guide = create(:guide, :with_published_edition)
         guide.slug = "/service-manual/topic-name/something-else"
         guide.valid?
-        expect(guide.errors.full_messages_for(:slug)).to eq ["Slug can't be changed if guide has a published edition"]
+        expect(guide.errors.full_messages_for(:slug)).to eq [
+          "Slug can't be changed as this guide has been published"
+        ]
       end
     end
   end

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -115,13 +115,17 @@ RSpec.describe Guide do
         expect(original_topic_section.reload.guides).to_not include guide
       end
 
-      it "isn't possible to change the topic" do
-        original_topic = create(:topic, path: "/service-manual/original-topic")
-        original_topic_section = create(:topic_section, topic: original_topic)
-        different_topic = create(:topic, path: "/service-manual/different-topic")
-        different_topic_section = create(:topic_section, topic: different_topic)
-        guide = create(:guide, :with_published_edition)
-        original_topic_section.guides << guide
+      it "isn't possible to change the topic for a published guide" do
+        original_topic_section = create(:topic_section, 
+          topic: create(:topic, path: "/service-manual/original-topic")
+        )
+        different_topic_section = create(:topic_section,
+          topic: create(:topic, path: "/service-manual/different-topic")
+        )
+
+        guide = create(:guide, :with_published_edition,
+          topic_section:  original_topic_section
+        )
 
         guide.topic_section_guides[0].topic_section_id = different_topic_section.id
         guide.save
@@ -132,6 +136,28 @@ RSpec.describe Guide do
 
         expect(original_topic_section.reload.guides).to include guide
         expect(different_topic_section.reload.guides).to_not include guide
+      end
+
+      it "is possible to change the topic for a draft guide" do
+        original_topic_section = create(:topic_section, 
+          topic: create(:topic, path: "/service-manual/original-topic")
+        )
+        different_topic_section = create(:topic_section,
+          topic: create(:topic, path: "/service-manual/different-topic")
+        )
+
+        guide = create(:guide,
+          topic_section:  original_topic_section
+        )
+        guide.topic_section_guides[0].topic_section_id = different_topic_section.id
+        guide.save
+
+        expect(
+          guide.errors.full_messages_for(:topic_section)
+        ).to be_empty
+
+        expect(original_topic_section.reload.guides).not_to include guide
+        expect(different_topic_section.reload.guides).to include guide
       end
     end
 

--- a/spec/models/point_spec.rb
+++ b/spec/models/point_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Point do
+  describe "#valid?" do
+    describe "when validating the slug" do
+      it "is valid for no topic to appear in the slug" do
+        point = build(:point, slug: "/service-manual/an-excellent-point")
+        expect(point).not_to be_valid
+      end
+    end
+
+    describe "when validating the content owner" do
+      it "is valid for the latest edition not to have a content owner" do
+        edition = build(:edition, content_owner: nil)
+        point = build(:guide_community, editions: [edition])
+        expect(point).to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/CgDRSwG8/440-allow-a-guide-s-topic-to-be-changed-until-it-is-published