### PR TITLE
Allow redirecting to topic sections (by anchor)

### DIFF
--- a/app/helpers/redirect_destination_helper.rb
+++ b/app/helpers/redirect_destination_helper.rb
@@ -14,7 +14,7 @@ private
   end
 
   def topic_select_options
-    Topic.order(:path)
+    Topic.includes(:topic_sections).order(:path)
       .flat_map { |topic| paths_for_topic_and_its_sections(topic) }
   end
 

--- a/app/helpers/redirect_destination_helper.rb
+++ b/app/helpers/redirect_destination_helper.rb
@@ -14,6 +14,15 @@ private
   end
 
   def topic_select_options
-    Topic.order(:path).pluck(:path)
+    Topic.order(:path)
+      .flat_map { |topic| paths_for_topic_and_its_sections(topic) }
+  end
+
+  def paths_for_topic_and_its_sections(topic)
+    topic_sections = topic.topic_sections.order(:title).where("title <> ''").map do |section|
+      ["#{topic.path} → #{section.title}", "#{topic.path}##{section.title.parameterize}"]
+    end
+
+    [topic.path, *topic_sections]
   end
 end

--- a/app/helpers/redirect_destination_helper.rb
+++ b/app/helpers/redirect_destination_helper.rb
@@ -1,16 +1,19 @@
 module RedirectDestinationHelper
   def redirect_destination_select_options
-    guide_select_options = Guide
-      .live
-      .order(:slug).pluck(:slug)
-
-    topic_select_options = Topic
-      .order(:path).pluck(:path)
-
     {
       "Other" => ["/service-manual", "/service-manual/service-standard"],
       "Topics" => topic_select_options,
       "Guides" => guide_select_options,
     }
+  end
+
+private
+
+  def guide_select_options
+    Guide.live.order(:slug).pluck(:slug)
+  end
+
+  def topic_select_options
+    Topic.order(:path).pluck(:path)
   end
 end

--- a/spec/helpers/redirect_destination_helper_spec.rb
+++ b/spec/helpers/redirect_destination_helper_spec.rb
@@ -31,14 +31,21 @@ RSpec.describe RedirectDestinationHelper, '#redirect_destination_select_options'
     create(:topic_section, title: "Working with agile methods", topic: topic)
     create(:topic_section, title: "Governing agile services", topic: topic)
 
-    create(:topic_section, title: "", topic: topic)
-
     expect(helper.redirect_destination_select_options).to include(
       "Topics" => [
         "/service-manual/agile-delivery",
         ["/service-manual/agile-delivery → Governing agile services", "/service-manual/agile-delivery#governing-agile-services"],
         ["/service-manual/agile-delivery → Working with agile methods", "/service-manual/agile-delivery#working-with-agile-methods"],
       ]
+    )
+  end
+
+  it 'should exclude topic sections without titles' do
+    topic = create(:topic, path: "/service-manual/agile-delivery")
+    create(:topic_section, title: "", topic: topic)
+
+    expect(helper.redirect_destination_select_options).to include(
+      "Topics" => ["/service-manual/agile-delivery"]
     )
   end
 end

--- a/spec/helpers/redirect_destination_helper_spec.rb
+++ b/spec/helpers/redirect_destination_helper_spec.rb
@@ -26,11 +26,19 @@ RSpec.describe RedirectDestinationHelper, '#redirect_destination_select_options'
     )
   end
 
-  it 'should include all topics' do
-    create(:topic, path: "/service-manual/agile-delivery")
+  it 'should include all topics with sub sections' do
+    topic = create(:topic, path: "/service-manual/agile-delivery")
+    create(:topic_section, title: "Working with agile methods", topic: topic)
+    create(:topic_section, title: "Governing agile services", topic: topic)
+
+    create(:topic_section, title: "", topic: topic)
 
     expect(helper.redirect_destination_select_options).to include(
-      "Topics" => ["/service-manual/agile-delivery"]
+      "Topics" => [
+        "/service-manual/agile-delivery",
+        ["/service-manual/agile-delivery → Governing agile services", "/service-manual/agile-delivery#governing-agile-services"],
+        ["/service-manual/agile-delivery → Working with agile methods", "/service-manual/agile-delivery#working-with-agile-methods"],
+      ]
     )
   end
 end

--- a/spec/helpers/redirect_destination_helper_spec.rb
+++ b/spec/helpers/redirect_destination_helper_spec.rb
@@ -1,15 +1,36 @@
 require 'rails_helper'
 
 RSpec.describe RedirectDestinationHelper, '#redirect_destination_select_options', type: :helper do
-  it 'should return all available slugs' do
-    topic = create(:topic)
-    create(:guide, :has_been_unpublished, topic: topic)
-    guide = create(:guide, :with_published_edition, topic: topic)
+  it 'should include all published guides ordered by slug' do
+    create(:guide, :with_published_edition,
+      slug: "/service-manual/agile-delivery/team-wall"
+    )
+    create(:guide, :with_published_edition,
+      slug: "/service-manual/agile-delivery/core-principles-agile"
+    )
 
-    expect(helper.redirect_destination_select_options).to match(
+    create(:guide, :has_been_unpublished)
+    create(:guide, :with_draft_edition)
+
+    expect(helper.redirect_destination_select_options).to include(
+      "Guides" => [
+        "/service-manual/agile-delivery/core-principles-agile",
+        "/service-manual/agile-delivery/team-wall"
+      ]
+    )
+  end
+
+  it 'should include the homepage and the service standard' do
+    expect(helper.redirect_destination_select_options).to include(
       "Other" => ["/service-manual", "/service-manual/service-standard"],
-      "Topics" => include(topic.path),
-      "Guides" => [guide.slug]
+    )
+  end
+
+  it 'should include all topics' do
+    create(:topic, path: "/service-manual/agile-delivery")
+
+    expect(helper.redirect_destination_select_options).to include(
+      "Topics" => ["/service-manual/agile-delivery"]
     )
   end
 end


### PR DESCRIPTION
Break topics down to include ‘anchor’ link options for all sub topics as well as a link option for the topic itself.

![screen shot 2016-11-22 at 10 16 50](https://cloud.githubusercontent.com/assets/121939/20519922/d0f700ca-b09c-11e6-99a2-fdf7a2ae9873.png)

This allows us to redirect old parts of the manual to a specific sub topic within a topic, even though it has no page of its own.