### PR TITLE
Insert missed slug migrations

### DIFF
--- a/db/migrate/20161208103043_insert_missed_slug_migrations.rb
+++ b/db/migrate/20161208103043_insert_missed_slug_migrations.rb
@@ -1,0 +1,16 @@
+class InsertMissedSlugMigrations < ActiveRecord::Migration
+  def change
+    return say("Skipping slug creation in test environment") if Rails.env.test?
+
+    OLD_SLUGS.each do |s|
+      execute "INSERT INTO slug_migrations (slug, created_at, updated_at, content_id) VALUES ('#{s}', now(), now(), '#{SecureRandom.uuid}')"
+    end
+  end
+
+  OLD_SLUGS = [
+    "/service-manual/user-centred-design/resources/patterns/question-pages.html",
+    "/service-manual/user-centred-design/resources/patterns/question-pages",
+    "/service-manual/user-centred-design/resources/patterns/check-your-answers-pages.html",
+    "/service-manual/user-centred-design/resources/patterns/check-your-answers-pages"
+  ]
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -841,3 +841,5 @@ INSERT INTO schema_migrations (version) VALUES ('20160729100003');
 
 INSERT INTO schema_migrations (version) VALUES ('20160816150906');
 
+INSERT INTO schema_migrations (version) VALUES ('20161208103043');
+


### PR DESCRIPTION
These pages were added to the old service manual after the list of migrations was generated.

https://github.com/alphagov/government-service-design-manual/compare/version-151...master

We need to add them to the list so that they can be redirected.