### PR TITLE
Add very basic file upload functionality

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -16,6 +16,17 @@ class UploadsController < ApplicationController
           render text: e.message, status: :unprocessable_entity
         end
       end
+
+      format.html do
+        file = params[:file]
+
+        begin
+          response = ASSET_API.create_asset(file: file)
+          redirect_to new_upload_path, notice: "Uploaded successfully to #{response.file_url}"
+        rescue GdsApi::BaseError => e
+          render text: e.message, status: :unprocessable_entity
+        end
+      end
     end
   end
 end

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -1,0 +1,7 @@
+<h2>Upload File</h2>
+
+<%= form_tag uploads_path, multipart: true do %>
+  <%= file_field_tag 'file' %>
+  <hr />
+  <%= submit_tag 'Upload' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
   end
 
   resources :comments
-  resources :uploads, only: [:create]
+  resources :uploads, only: [:create, :new]
   resources :topics
 
   resources :slug_migrations

--- a/spec/controllers/uploads_controller_spec.rb
+++ b/spec/controllers/uploads_controller_spec.rb
@@ -4,30 +4,49 @@ RSpec.describe UploadsController, type: :controller do
   before { login_as build(:user) }
 
   describe "#create" do
-    it "rejects non-image files" do
-      test_pdf = ActionDispatch::Http::UploadedFile.new(
-        filename: 'some.pdf',
-        type: 'application/pdf',
-        tempfile: Object.new
-      )
-      post :create, format: :js, file: test_pdf
+    context "when uploading via javascript" do
+      it "rejects non-image files" do
+        test_pdf = ActionDispatch::Http::UploadedFile.new(
+          filename: 'some.pdf',
+          type: 'application/pdf',
+          tempfile: Object.new
+        )
+        post :create, format: :js, file: test_pdf
 
-      expect(response.status).to eq 422
-      expect(response.body).to include "does not seem to be an image"
+        expect(response.status).to eq 422
+        expect(response.body).to include "does not seem to be an image"
+      end
+
+      it "accepts image files and response with their URL" do
+        test_png = ActionDispatch::Http::UploadedFile.new(
+          filename: 'some.pdf',
+          type: 'image/png',
+          tempfile: Object.new
+        )
+        expect(ASSET_API).to receive(:create_asset).and_return(OpenStruct.new(file_url: 'http://uploaded.file/1.png'))
+
+        post :create, format: :js, file: test_png
+
+        expect(response.status).to eq 201
+        expect(response.body).to eq 'http://uploaded.file/1.png'
+      end
     end
 
-    it "accepts image files and response with their URL" do
-      test_png = ActionDispatch::Http::UploadedFile.new(
-        filename: 'some.pdf',
-        type: 'image/png',
-        tempfile: Object.new
-      )
-      expect(ASSET_API).to receive(:create_asset).and_return(OpenStruct.new(file_url: 'http://uploaded.file/1.png'))
+    context "when uploading via form upload" do
+      it "accepts any file and responds with its URL" do
+        test_pdf = ActionDispatch::Http::UploadedFile.new(
+          filename: 'some.pdf',
+          type: 'application/pdf',
+          tempfile: Object.new
+        )
 
-      post :create, format: :js, file: test_png
+        expect(ASSET_API).to receive(:create_asset)
+          .and_return(OpenStruct.new(file_url: 'http://uploaded.file/1.png'))
 
-      expect(response.status).to eq 201
-      expect(response.body).to eq 'http://uploaded.file/1.png'
+        post :create, file: test_pdf
+
+        expect(response).to redirect_to(new_upload_path)
+      end
     end
   end
 end


### PR DESCRIPTION
We need to upload some job descriptions that were previously hosted by the old service manual repository.

There is currently only support for uploading images when editing guides, so we need a way to allow any file type to be uploaded.

This is intentionally a very bare bones implementation designed to solve a last minute problem – it’s not discoverable within the application other than going directly to the URL. In an ideal world, this would be a rake task or similar – but then we’d need a way to get the files onto the server where that task is which defeats the point somewhat.