### PR TITLE
Add toolkit presenter and rake task to publish it

### DIFF
--- a/app/presenters/service_toolkit_presenter.rb
+++ b/app/presenters/service_toolkit_presenter.rb
@@ -10,7 +10,9 @@ class ServiceToolkitPresenter
       base_path: '/service-toolkit',
       title: 'Service Toolkit',
       description: 'All you need to design, build and run services that meet government standards.',
-      details: {},
+      details: {
+        collections: collections
+      },
       routes: [
         { type: 'exact', path: '/service-toolkit' }
       ],
@@ -20,5 +22,115 @@ class ServiceToolkitPresenter
       rendering_app: 'service-manual-frontend',
       locale: 'en'
     }
+  end
+
+  def collections
+    [
+      {
+        "title": "Standards",
+        "description": "Meet the standards for government services",
+        "links": [
+          {
+            "title": "The Digital Service Standard",
+            "url": "https://www.gov.uk/service-manual/service-standard",
+            "description": "Learn about the 18 point standard that government services must meet"
+          },
+          {
+            "title": "Service Manual",
+            "url": "https://www.gov.uk/service-manual",
+            "description": "How to build a service that meets the standard: agile delivery, technology, user research, accessibility, training options and more"
+          },
+          {
+            "title": "Technology Code of Practice",
+            "url": "https://www.gov.uk/government/publications/technology-code-of-practice/technology-code-of-practice",
+            "description": "Guidelines for designing, building or buying government technology"
+          }
+        ]
+      },
+      {
+        "title": "Design and style",
+        "description": "Resources for interface and content design",
+        "links": [
+          {
+            "title": "Design principles",
+            "url": "https://www.gov.uk/design-principles",
+            "description": "Principles to follow as you design your service"
+          },
+          {
+            "title": "Design patterns",
+            "url": "https://www.gov.uk/service-manual/user-centred-design/resources/patterns",
+            "description": "Reusable code and standards to solve common design problems"
+          },
+          {
+            "title": "Reusable frontend code",
+            "url": "https://www.gov.uk/service-manual/design#working-with-frontend",
+            "description": "Build accessible, responsive web interfaces for government"
+          },
+          {
+            "title": "GOV.UK Prototype Kit",
+            "url": "https://govuk-prototype-kit.herokuapp.com/docs",
+            "description": "Make HTML prototypes for user research and service design"
+          },
+          {
+            "title": "Style guide",
+            "url": "https://www.gov.uk/guidance/style-guide",
+            "description": "Style, spelling and grammar conventions for GOV.UK"
+          }
+        ]
+      },
+      {
+        "title": "Components",
+        "description": "Technologies to help you build your service more easily",
+        "links": [
+          {
+            "title": "GOV.UK Notify",
+            "url": "https://www.gov.uk/notify",
+            "description": "Send secure text messages, emails or letters to users"
+          },
+          {
+            "title": "GOV.UK Pay",
+            "url": "https://www.gov.uk/pay",
+            "description": "Make it simple to make payments online"
+          },
+          {
+            "title": "GOV.UK Verify",
+            "url": "https://www.gov.uk/verify",
+            "description": "Let users prove their identity online"
+          },
+          {
+            "title": "GOV.UK Platform as a Service",
+            "url": "https://gov.uk/paas",
+            "description": "Host your applications on a government Cloud platform"
+          },
+          {
+            "title": "Registers",
+            "url": "https://www.gov.uk/registers",
+            "description": "Get up-to-date and accurate common data sets"
+          }
+        ]
+      },
+      {
+        "title": "Monitoring",
+        "description": "Get the data you need to improve your service",
+        "links": [
+          {
+            "title": "Performance platform",
+            "url": "https://www.gov.uk/performance",
+            "description": "Create a performance dashboard for your service"
+          }
+        ]
+      },
+      {
+        "title": "Buying",
+        "description": "Extra skills, people and technology to help build your service",
+        "links": [
+          {
+            "title": "Digital Marketplace",
+            "url": "https://www.gov.uk/digital-marketplace",
+            "description": "Buy cloud technology and specialist services for digital projects"
+          }
+        ]
+      }
+    ]
   end
 end

--- a/app/presenters/service_toolkit_presenter.rb
+++ b/app/presenters/service_toolkit_presenter.rb
@@ -1,0 +1,24 @@
+class ServiceToolkitPresenter
+  TOOLKIT_CONTENT_ID = "7397b402-57cd-4208-9d6b-1f59245f3c75".freeze
+
+  def content_id
+    TOOLKIT_CONTENT_ID
+  end
+
+  def content_payload
+    {
+      base_path: '/service-toolkit',
+      title: 'Service Toolkit',
+      description: 'All you need to design, build and run services that meet government standards.',
+      details: {},
+      routes: [
+        { type: 'exact', path: '/service-toolkit' }
+      ],
+      document_type: 'service_manual_service_toolkit',
+      schema_name: 'service_manual_service_toolkit',
+      publishing_app: 'service-manual-publisher',
+      rendering_app: 'service-manual-frontend',
+      locale: 'en'
+    }
+  end
+end

--- a/lib/tasks/publish_service_toolkit.rake
+++ b/lib/tasks/publish_service_toolkit.rake
@@ -1,0 +1,14 @@
+namespace :publish do
+  desc "Publish the Service Toolkit"
+  task service_toolkit: :environment do
+    toolkit = ServiceToolkitPresenter.new
+
+    puts "Creating service toolkit..."
+    PUBLISHING_API.put_content(toolkit.content_id, toolkit.content_payload)
+
+    puts "Publishing the service toolkit..."
+    PUBLISHING_API.publish(toolkit.content_id, "major")
+
+    puts "Done."
+  end
+end

--- a/spec/presenters/service_toolkit_presenter_spec.rb
+++ b/spec/presenters/service_toolkit_presenter_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe ServiceToolkitPresenter, "#content_id" do
+  let(:content_id) { described_class.new.content_id }
+
+  it "returns a preassigned UUID" do
+    expect(content_id).to eq "7397b402-57cd-4208-9d6b-1f59245f3c75"
+  end
+end
+
+RSpec.describe ServiceToolkitPresenter, "#content_payload" do
+  let(:payload) { described_class.new.content_payload }
+
+  it "returns a payload that validates against the service toolkit schema" do
+    expect(payload).to be_valid_against_schema 'service_manual_service_toolkit'
+  end
+
+  it 'includes in the payload a base path of /service-toolkit' do
+    expect(payload[:base_path]).to eq '/service-toolkit'
+  end
+
+  it 'includes in the payload an exact route for /service-toolkit' do
+    expect(payload[:routes]).to eq [
+      { type: 'exact', path: '/service-toolkit' }
+    ]
+  end
+
+  it 'includes in the payload the title "Service Toolkit"' do
+    expect(payload[:title]).to eq "Service Toolkit"
+  end
+
+  it 'includes in the payload a suitable description' do
+    expect(payload[:description]).to eq(
+      "All you need to design, build and run services that meet government standards."
+    )
+  end
+
+  it 'includes in the payload all other necessary metadata' do
+    expect(payload).to include(
+      document_type: 'service_manual_service_toolkit',
+      schema_name: 'service_manual_service_toolkit',
+      publishing_app: 'service-manual-publisher',
+      rendering_app: 'service-manual-frontend',
+      locale: 'en'
+    )
+  end
+end

--- a/spec/presenters/service_toolkit_presenter_spec.rb
+++ b/spec/presenters/service_toolkit_presenter_spec.rb
@@ -44,4 +44,26 @@ RSpec.describe ServiceToolkitPresenter, "#content_payload" do
       locale: 'en'
     )
   end
+
+  it 'includes a list of collections' do
+    expect(payload[:details]).to have_key(:collections)
+  end
+
+  it 'includes a title, description and valid list of links for every collection' do
+    collections = payload[:details][:collections]
+
+    a_valid_link = {
+      title: an_instance_of(String),
+      description: an_instance_of(String),
+      url: an_instance_of(String)
+    }
+
+    a_valid_collection = {
+      title: an_instance_of(String),
+      description: an_instance_of(String),
+      links: (all include a_valid_link)
+    }
+
+    expect(collections).to all include a_valid_collection
+  end
 end


### PR DESCRIPTION
Relies on alphagov/govuk-content-schemas#473 being merged before this will pass on CI.

https://trello.com/c/GHY41UJi/546-create-service-toolkit-page