### PR TITLE
Add change note migrator

### DIFF
--- a/app/models/change_note_migrator.rb
+++ b/app/models/change_note_migrator.rb
@@ -1,0 +1,84 @@
+class ChangeNoteMigrator
+  def initialize(dry_run: true, publishing_api: PUBLISHING_API)
+    @dry_run = dry_run
+    @publishing_api = publishing_api
+  end
+
+  def update_change_note(edition_id, change_note)
+    transaction do
+      edition = load_edition(edition_id)
+      update_edition(edition, change_note: change_note)
+      publish!(edition)
+    end
+  end
+
+  def make_minor(edition_id)
+    transaction do
+      edition = load_edition(edition_id)
+      update_edition(edition, update_type: 'minor')
+      publish!(edition)
+    end
+  end
+
+  def make_major(edition_id, change_note)
+    transaction do
+      edition = load_edition(edition_id)
+      update_edition(edition, update_type: 'major', change_note: change_note)
+      publish!(edition)
+    end
+  end
+
+private
+
+  attr_reader :dry_run, :publishing_api
+
+  def load_edition(edition_id)
+    Edition.published.find(edition_id).tap do |e|
+      log "Loaded edition with ID #{e.id} (version #{e.version} of #{e.guide.slug})", :green
+    end
+  end
+
+  def update_edition(edition, changes)
+    log_changes(edition, changes)
+
+    return if dry_run
+    log "  Updating database"
+    edition.update!(changes)
+    log "  Database updated", :bold
+  end
+
+  def log_changes(edition, changes)
+    log "  Change summary:"
+    no_changes = edition
+                  .attributes
+                  .select { |k, _| changes.keys.map(&:to_s).include?(k) }
+                  .select { |k, v| changes.with_indifferent_access[k] != v }
+                  .each { |k, v| log "  Old value of #{k} is #{v}, new value is #{changes.with_indifferent_access[k]}", :yellow }
+                  .empty?
+
+    log "  Nothing to change", :yellow if no_changes
+  end
+
+  def publish!(edition)
+    return if dry_run
+    log "  Updating Publishing API"
+    GuideRepublisher.new(edition.guide, publishing_api: publishing_api).republish
+    log "  Publishing API updated", :bold
+  end
+
+  def log(line, *colors)
+    return if Rails.env.test?
+    @_cli ||= HighLine.new
+    @_cli.say(@_cli.color(line, *colors))
+  end
+
+  def transaction
+    ActiveRecord::Base.transaction do
+      yield
+    end
+  rescue => e
+    log "  #{e.class}: #{e.message}", :red
+    log "  No database changes made, check state of Publishing API", :bold unless dry_run
+    raise
+  end
+end

--- a/lib/tasks/migrate_change_notes.rake
+++ b/lib/tasks/migrate_change_notes.rake
@@ -1,0 +1,8 @@
+task migrate_change_notes: :environment do
+  edition_id = Edition.published.take.id
+  migrator = ChangeNoteMigrator.new(dry_run: !ENV.key?('PERFORM_AGAINST_DATABASE_AND_PUBLISHING_API'))
+
+  # migrator.update_change_note(edition_id, change_note)
+  # migrator.make_minor(edition_id)
+  # migrator.make_major(edition_id, change_note)
+end

--- a/spec/models/change_note_migrator_spec.rb
+++ b/spec/models/change_note_migrator_spec.rb
@@ -7,80 +7,98 @@ RSpec.describe ChangeNoteMigrator do
   let(:minor_edition) { create(:edition, :published, update_type: "minor", version: 2, guide: guide) }
   let(:unpublished_edition) { create(:edition, :draft, guide: guide) }
   let(:change_note) { "I am a change note" }
-  subject { described_class.new(publishing_api: publishing_api, dry_run: false) }
 
-  before do
-    allow(publishing_api).to receive(:put_content)
-    allow(publishing_api).to receive(:patch_links)
-    allow(publishing_api).to receive(:publish)
-  end
+  context "with dry_run mode enabled" do
+    subject { described_class.new(publishing_api: publishing_api, dry_run: true) }
 
-  describe "#update_change_note" do
-    it "does not load non-published editions" do
-      expect { subject.update_change_note(unpublished_edition.id, "foo") }.to raise_exception ActiveRecord::RecordNotFound
-    end
-
-    it "updates the edition's change note" do
+    it "does not call the publishing API" do
       subject.update_change_note(major_edition.id, change_note)
-      major_edition.reload
-      expect(major_edition.change_note).to eq(change_note)
-    end
+      subject.make_major(minor_edition.id, change_note)
+      subject.make_minor(major_edition.id)
 
-    it "updates the guide in the publishing API" do
       aggregate_failures do
-        expect(publishing_api).to receive(:put_content)
-        expect(publishing_api).to receive(:patch_links)
-        expect(publishing_api).to receive(:publish).with(guide.content_id, "minor")
+        expect(publishing_api).to_not receive(:put_content)
+        expect(publishing_api).to_not receive(:patch_links)
+        expect(publishing_api).to_not receive(:publish)
       end
-
-      subject.update_change_note(major_edition.id, change_note)
     end
   end
 
-  describe "#make_major" do
-    it "does not load non-published editions" do
-      expect { subject.make_major(unpublished_edition.id, "foo") }.to raise_exception ActiveRecord::RecordNotFound
+  context "with dry_run mode disabled" do
+    subject { described_class.new(publishing_api: publishing_api, dry_run: false) }
+    before do
+      allow(publishing_api).to receive(:put_content)
+      allow(publishing_api).to receive(:patch_links)
+      allow(publishing_api).to receive(:publish)
     end
 
-    it "updates the edition's update type and change note" do
-      subject.make_major(minor_edition.id, change_note)
-      minor_edition.reload
-      aggregate_failures do
-        expect(minor_edition.update_type).to eq "major"
-        expect(minor_edition.change_note).to eq change_note
+    describe "#update_change_note" do
+      it "does not load non-published editions" do
+        expect { subject.update_change_note(unpublished_edition.id, "foo") }.to raise_exception ActiveRecord::RecordNotFound
+      end
+
+      it "updates the edition's change note" do
+        subject.update_change_note(major_edition.id, change_note)
+        major_edition.reload
+        expect(major_edition.change_note).to eq(change_note)
+      end
+
+      it "updates the guide in the publishing API" do
+        aggregate_failures do
+          expect(publishing_api).to receive(:put_content)
+          expect(publishing_api).to receive(:patch_links)
+          expect(publishing_api).to receive(:publish).with(guide.content_id, "minor")
+        end
+
+        subject.update_change_note(major_edition.id, change_note)
       end
     end
 
-    it "updates the guide in the publishing API" do
-      aggregate_failures do
-        expect(publishing_api).to receive(:put_content)
-        expect(publishing_api).to receive(:patch_links)
-        expect(publishing_api).to receive(:publish).with(guide.content_id, "minor")
+    describe "#make_major" do
+      it "does not load non-published editions" do
+        expect { subject.make_major(unpublished_edition.id, "foo") }.to raise_exception ActiveRecord::RecordNotFound
       end
 
-      subject.make_major(minor_edition.id, change_note)
-    end
-  end
-
-  describe "#make_minor" do
-    it "does not load non-published editions" do
-      expect { subject.make_minor(unpublished_edition.id) }.to raise_exception ActiveRecord::RecordNotFound
-    end
-
-    it "updates the edition's update type" do
-      subject.make_minor(major_edition.id)
-      major_edition.reload
-      expect(major_edition.update_type).to eq "minor"
-    end
-
-    it "updates the guide in the publishing API" do
-      aggregate_failures do
-        expect(publishing_api).to receive(:put_content)
-        expect(publishing_api).to receive(:patch_links)
-        expect(publishing_api).to receive(:publish).with(guide.content_id, "minor")
+      it "updates the edition's update type and change note" do
+        subject.make_major(minor_edition.id, change_note)
+        minor_edition.reload
+        aggregate_failures do
+          expect(minor_edition.update_type).to eq "major"
+          expect(minor_edition.change_note).to eq change_note
+        end
       end
 
-      subject.make_minor(major_edition.id)
+      it "updates the guide in the publishing API" do
+        aggregate_failures do
+          expect(publishing_api).to receive(:put_content)
+          expect(publishing_api).to receive(:patch_links)
+          expect(publishing_api).to receive(:publish).with(guide.content_id, "minor")
+        end
+
+        subject.make_major(minor_edition.id, change_note)
+      end
+    end
+
+    describe "#make_minor" do
+      it "does not load non-published editions" do
+        expect { subject.make_minor(unpublished_edition.id) }.to raise_exception ActiveRecord::RecordNotFound
+      end
+
+      it "updates the edition's update type" do
+        subject.make_minor(major_edition.id)
+        major_edition.reload
+        expect(major_edition.update_type).to eq "minor"
+      end
+
+      it "updates the guide in the publishing API" do
+        aggregate_failures do
+          expect(publishing_api).to receive(:put_content)
+          expect(publishing_api).to receive(:patch_links)
+          expect(publishing_api).to receive(:publish).with(guide.content_id, "minor")
+        end
+
+        subject.make_minor(major_edition.id)
+      end
     end
   end
 end

--- a/spec/models/change_note_migrator_spec.rb
+++ b/spec/models/change_note_migrator_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+RSpec.describe ChangeNoteMigrator do
+  let(:publishing_api) { double(:publishing_api) }
+  let(:guide) { create(:guide) }
+  let(:major_edition) { create(:edition, :published, update_type: "major", version: 2, guide: guide) }
+  let(:minor_edition) { create(:edition, :published, update_type: "minor", version: 2, guide: guide) }
+  let(:unpublished_edition) { create(:edition, :draft, guide: guide) }
+  let(:change_note) { "I am a change note" }
+  subject { described_class.new(publishing_api: publishing_api, dry_run: false) }
+
+  before do
+    allow(publishing_api).to receive(:put_content)
+    allow(publishing_api).to receive(:patch_links)
+    allow(publishing_api).to receive(:publish)
+  end
+
+  describe "#update_change_note" do
+    it "does not load non-published editions" do
+      expect { subject.update_change_note(unpublished_edition.id, "foo") }.to raise_exception ActiveRecord::RecordNotFound
+    end
+
+    it "updates the edition's change note" do
+      subject.update_change_note(major_edition.id, change_note)
+      major_edition.reload
+      expect(major_edition.change_note).to eq(change_note)
+    end
+
+    it "updates the guide in the publishing API" do
+      aggregate_failures do
+        expect(publishing_api).to receive(:put_content)
+        expect(publishing_api).to receive(:patch_links)
+        expect(publishing_api).to receive(:publish).with(guide.content_id, "minor")
+      end
+
+      subject.update_change_note(major_edition.id, change_note)
+    end
+  end
+
+  describe "#make_major" do
+    it "does not load non-published editions" do
+      expect { subject.make_major(unpublished_edition.id, "foo") }.to raise_exception ActiveRecord::RecordNotFound
+    end
+
+    it "updates the edition's update type and change note" do
+      subject.make_major(minor_edition.id, change_note)
+      minor_edition.reload
+      aggregate_failures do
+        expect(minor_edition.update_type).to eq "major"
+        expect(minor_edition.change_note).to eq change_note
+      end
+    end
+
+    it "updates the guide in the publishing API" do
+      aggregate_failures do
+        expect(publishing_api).to receive(:put_content)
+        expect(publishing_api).to receive(:patch_links)
+        expect(publishing_api).to receive(:publish).with(guide.content_id, "minor")
+      end
+
+      subject.make_major(minor_edition.id, change_note)
+    end
+  end
+
+  describe "#make_minor" do
+    it "does not load non-published editions" do
+      expect { subject.make_minor(unpublished_edition.id) }.to raise_exception ActiveRecord::RecordNotFound
+    end
+
+    it "updates the edition's update type" do
+      subject.make_minor(major_edition.id)
+      major_edition.reload
+      expect(major_edition.update_type).to eq "minor"
+    end
+
+    it "updates the guide in the publishing API" do
+      aggregate_failures do
+        expect(publishing_api).to receive(:put_content)
+        expect(publishing_api).to receive(:patch_links)
+        expect(publishing_api).to receive(:publish).with(guide.content_id, "minor")
+      end
+
+      subject.make_minor(major_edition.id)
+    end
+  end
+end


### PR DESCRIPTION
This adds a `ChangeNoteMigrator` class, which is designed to enable us
to update the change notes on existing editions where en masse where
they've been populated with the wrong data erroneously.

In short, it updates change notes for an edition, or makes an edition
minor or major, then republishes via the `GuideRepublisher` class,
providing some pretty console output along the way.

Also included is an example rake task which can be used for running the
thing.