### PR TITLE
Tiny edit on style guide desc

### DIFF
--- a/app/presenters/service_toolkit_presenter.rb
+++ b/app/presenters/service_toolkit_presenter.rb
@@ -74,7 +74,7 @@ class ServiceToolkitPresenter
           {
             "title": "Style guide",
             "url": "https://www.gov.uk/guidance/style-guide",
-            "description": "Style, spelling and grammar conventions for GOV.UK"
+            "description": "Style, spelling and grammar conventions for government"
           }
         ]
       },


### PR DESCRIPTION
Changed 'gov.uk' to 'government' as it helps our colleagues out in depts to argue the use of it