### PR TITLE
Remove reason for change

### DIFF
--- a/app/forms/base_guide_form.rb
+++ b/app/forms/base_guide_form.rb
@@ -4,7 +4,7 @@ class BaseGuideForm
   include ActiveModel::Model
 
   attr_reader :guide, :edition, :user, :version
-  attr_accessor :author_id, :body, :reason_for_change, :change_note, :content_owner_id, :description,
+  attr_accessor :author_id, :body, :change_note, :content_owner_id, :description,
     :fingerprint_when_started_editing, :slug, :title, :title_slug, :type, :update_type
 
   delegate :persisted?, to: :guide
@@ -26,7 +26,6 @@ class BaseGuideForm
 
     self.author_id = next_author_id
     self.body = edition.body
-    self.reason_for_change = edition.reason_for_change
     self.change_note = edition.change_note
     self.content_owner_id = edition.content_owner_id
     self.description = edition.description
@@ -42,7 +41,6 @@ class BaseGuideForm
     load_custom_attributes
 
     if edition.published?
-      self.reason_for_change = nil
       self.change_note = nil
     end
   end
@@ -51,7 +49,6 @@ class BaseGuideForm
     guide.slug = slug
     edition.author_id = author_id
     edition.body = body
-    edition.reason_for_change = reason_for_change
     edition.change_note = first_or_supplied_changed_note
     edition.content_owner_id = content_owner_id
     edition.created_by_id = user.id

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -24,7 +24,6 @@ class Edition < ActiveRecord::Base
   validates_presence_of [:state, :phase, :description, :title, :update_type, :body, :author]
   validates_inclusion_of :state, in: STATES
   validates_inclusion_of :update_type, in: ['major'], if: :first_version?, message: 'must be major'
-  validates :reason_for_change, presence: true, if: :major_and_not_first_version?
   validates :change_note, presence: true, if: :major?
   validates :version, presence: true
   validates :created_by, presence: true

--- a/app/presenters/guide_presenter/change_history_presenter.rb
+++ b/app/presenters/guide_presenter/change_history_presenter.rb
@@ -8,8 +8,7 @@ class GuidePresenter::ChangeHistoryPresenter
     major_editions.map do |edition|
       {
         public_timestamp: edition.created_at.iso8601,
-        note: edition.change_note,
-        reason_for_change: edition.reason_for_change || ""
+        note: edition.change_note
       }
     end
   end

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -85,43 +85,32 @@
 
     <% if guide_form.version > 1 %>
       <div class="well">
-        <h2>About this update</h2>
+        <h2>To save this document please complete the following</h2>
 
         <div class='form-group'>
-          <label>Impact of the update</label>
+          <label>Select an option:</label>
           <%= f.error_list :update_type %>
           <div class="radio">
             <%= label_tag do %>
               <%= f.radio_button :update_type, "minor", {disabled: disable_inputs, class: 'update-type-select'} %>
-              Minor update
-              <span class='text-muted'>e.g. spelling or typographic corrections.</span>
+              <strong>Update the document silently</strong>
+              – For minor changes like fixes to typos, links, GOV.UK style or metadata
             <% end %>
           </div>
           <div class="radio">
             <%= label_tag do %>
               <%= f.radio_button :update_type, "major", {disabled: disable_inputs, class: 'update-type-select'} %>
-              Major update
-              <span class='text-muted'>e.g. updates that change the meaning of the guidance.</span>
+              <strong>Alert the public to what's changed</strong>
+              – For important changes to the content or attached files
             <% end %>
           </div>
         </div>
 
         <div class="form-group change-note-form-group">
-          <%= f.label :change_note, "Summary of change" %>
-          <div class="help-block">What is being changed in this update</div>
-          <%= f.text_field :change_note, disabled: disable_inputs, class: 'input-md-12 form-control', rows: 5 %>
+          <%= f.label :change_note, "Public change note" %>
+          <div class="help-block">Input text to display publicly on the live site and in email alerts</div>
+          <%= f.text_area :change_note, disabled: disable_inputs, class: 'input-md-12 form-control', rows: 5 %>
         </div>
-
-        <div class="form-group change-note-form-group">
-          <%= f.label :reason_for_change, "Why the change is being made" %>
-          <div class="help-block">Include any evidence from research and links to any related discussions</div>
-          <%= f.text_area :reason_for_change, disabled: disable_inputs, class: 'input-md-12 form-control text-area-auto-size js-text-area-auto-size', rows: 5 %>
-        </div>
-
-        <p class="text-strong change-note-form-group">
-          <span class="glyphicon glyphicon-warning-sign text-warning" aria-hidden="true"></span>
-          <strong>These notes will be made visible to the public and subscribed users will receive an email update when this guide is published.</strong>
-        </p>
       </div>
     <% end %>
 

--- a/db/migrate/20170131103912_remove_reason_for_change_from_editions.rb
+++ b/db/migrate/20170131103912_remove_reason_for_change_from_editions.rb
@@ -1,0 +1,5 @@
+class RemoveReasonForChangeFromEditions < ActiveRecord::Migration
+  def change
+    remove_column :editions, :reason_for_change, :text
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -128,7 +128,6 @@ CREATE TABLE editions (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     state text,
-    reason_for_change text,
     change_note text,
     content_owner_id integer,
     version integer,
@@ -845,4 +844,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160816150906');
 INSERT INTO schema_migrations (version) VALUES ('20160914133843');
 
 INSERT INTO schema_migrations (version) VALUES ('20161208103043');
+
+INSERT INTO schema_migrations (version) VALUES ('20170131103912');
 

--- a/lib/tasks/print_change_history_for_published_guides.rake
+++ b/lib/tasks/print_change_history_for_published_guides.rake
@@ -10,7 +10,6 @@ task print_change_history_for_published_guides: :environment do
       editions.each do |edition|
         puts "### #{edition.updated_at.to_formatted_s}"
         puts "Change note: '#{edition.change_note}'"
-        puts "Reason for change: '#{edition.reason_for_change}'"
         puts ""
       end
 

--- a/spec/factories/edition.rb
+++ b/spec/factories/edition.rb
@@ -18,7 +18,6 @@ FactoryGirl.define do
     phase "beta"
     description "Description"
     update_type "major"
-    reason_for_change "This is the reason for the change"
     change_note "A summary of the changes in this edition"
     body "Heading"
     version 1

--- a/spec/features/guide_compare_changes_spec.rb
+++ b/spec/features/guide_compare_changes_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe "Guide compare changes", type: :feature do
       visit edit_guide_path(guide)
       fill_in "Title", with: "Second version"
       fill_in "Body", with: "## Hi"
-      fill_in "Summary of change", with: "Better greeting"
-      fill_in "Why the change is being made", with: "It was causing offense"
+      fill_in "Public change note", with: "Better greeting"
       click_first_button 'Save'
       click_link "Compare changes"
 

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -150,10 +150,9 @@ RSpec.describe "Creating a guide", type: :feature do
     # Prove that we're looking at the form
     expect(page).to have_field("Title")
 
-    expect(page).to_not have_field("Major update")
-    expect(page).to_not have_field("Minor update")
-    expect(page).to_not have_field("Summary of change")
-    expect(page).to_not have_field("Why the change is being made")
+    expect(page).to_not have_field("Alert the public to what's changed")
+    expect(page).to_not have_field("Update the document silently")
+    expect(page).to_not have_field("Public change note")
   end
 
 private
@@ -193,8 +192,7 @@ RSpec.describe "Updating a guide", type: :feature do
       end
 
       fill_in "Title", with: "Agile"
-      fill_in "Summary of change", with: "Updated the title"
-      fill_in "Why the change is being made", with: "Because the user's demand it"
+      fill_in "Public change note", with: "Updated the title"
       click_first_button 'Save'
 
       expect(guide.editions.count).to eq(5)
@@ -209,8 +207,7 @@ RSpec.describe "Updating a guide", type: :feature do
         click_link "A guide to agile"
       end
 
-      expect(find_field("Why the change is being made").value).to be_blank
-      expect(find_field("Major update")).to be_checked
+      expect(find_field("Alert the public to what's changed")).to be_checked
     end
 
     it "prevents users from editing the url slug" do
@@ -323,8 +320,7 @@ RSpec.describe "Updating a guide", type: :feature do
 
       visit edit_guide_path(guide)
       fill_in "Title", with: "Updated Title"
-      fill_in "Summary of change", with: "Update Title"
-      fill_in "Why the change is being made", with: "It was out of date"
+      fill_in "Public change note", with: "Update Title"
       click_first_button 'Save'
 
       within ".full-error-list" do

--- a/spec/features/unpublishing_guides_spec.rb
+++ b/spec/features/unpublishing_guides_spec.rb
@@ -156,10 +156,9 @@ RSpec.describe 'Once a guide has been unpublished', type: :feature do
     expect(page).to_not have_field("Body")
     expect(page).to_not have_field("Community")
 
-    expect(page).to_not have_field("Minor update")
-    expect(page).to_not have_field("Major update")
-    expect(page).to_not have_field("Summary of change")
-    expect(page).to_not have_field("Why the change is being made")
+    expect(page).to_not have_field("Update the document silently")
+    expect(page).to_not have_field("Alert the public to what's changed")
+    expect(page).to_not have_field("Public change note")
 
     expect(page).to_not have_field("Author")
   end

--- a/spec/forms/guide_form_spec.rb
+++ b/spec/forms/guide_form_spec.rb
@@ -93,13 +93,12 @@ RSpec.describe GuideForm, "#initialize" do
     end
 
     it "loads the change note and summary" do
-      edition = build(:edition, change_note: "summary", reason_for_change: "note")
+      edition = build(:edition, change_note: "summary")
       guide = create(:guide, editions: [edition])
 
       guide_form = described_class.new(guide: guide, edition: edition, user: User.new)
 
       expect(guide_form.change_note).to eq("summary")
-      expect(guide_form.reason_for_change).to eq("note")
     end
 
     it "loads the topic_section_id" do
@@ -158,7 +157,7 @@ RSpec.describe GuideForm, "#initialize" do
         build(:edition, state: "draft", title: title, update_type: "major"),
         build(:edition, state: "review_requested", title: title, update_type: "major"),
         build(:edition, state: "ready", title: title, update_type: "major"),
-        build(:edition, state: "published", title: title, update_type: "major", change_note: "summary", reason_for_change: "note"),
+        build(:edition, state: "published", title: title, update_type: "major", change_note: "summary"),
       ])
       edition = guide.editions.build(guide.latest_edition.dup.attributes)
       user = User.new
@@ -166,7 +165,6 @@ RSpec.describe GuideForm, "#initialize" do
       guide_form = described_class.new(guide: guide, edition: edition, user: user)
 
       expect(guide_form.change_note).to eq(nil)
-      expect(guide_form.reason_for_change).to eq(nil)
     end
 
     it "defaults the author_id to represent the current user again" do
@@ -175,7 +173,7 @@ RSpec.describe GuideForm, "#initialize" do
         build(:edition, state: "draft", title: title, update_type: "major"),
         build(:edition, state: "review_requested", title: title, update_type: "major"),
         build(:edition, state: "ready", title: title, update_type: "major"),
-        build(:edition, state: "published", title: title, update_type: "major", change_note: "summary", reason_for_change: "note"),
+        build(:edition, state: "published", title: title, update_type: "major", change_note: "summary"),
       ])
       edition = guide.editions.build(guide.latest_edition.dup.attributes)
       user = User.new(id: 8)
@@ -291,19 +289,17 @@ RSpec.describe GuideForm, "#save" do
       expect(edition.change_note).to eq('Guidance first published')
     end
 
-    it "assigns the change_note and reason_for_change to the edition for later editions" do
+    it "assigns the change_note to the edition for later editions" do
       guide = Guide.new
       edition = guide.editions.build(version: 2)
       user = User.new
       guide_form = described_class.new(guide: guide, edition: edition, user: user)
       guide_form.assign_attributes(
-        change_note: "X happened",
-        reason_for_change: "This happened because of X.",
+        change_note: "X happened"
       )
       guide_form.save
 
       expect(edition.change_note).to eq("X happened")
-      expect(edition.reason_for_change).to eq("This happened because of X.")
     end
   end
 

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -110,29 +110,9 @@ RSpec.describe Edition, type: :model do
       end
     end
 
-    describe "reason_for_change" do
-      it "is allowed to be empty if the update_type is 'major' and it is the first version" do
-        edition = build(:edition, update_type: "major", reason_for_change: "")
-        edition.valid?
-        expect(edition.errors.full_messages_for(:reason_for_change)).to be_empty
-      end
-
-      it "is not allowed to be empty if the update_type is 'major' and it is not the first version" do
-        edition = build(:edition, update_type: "major", reason_for_change: "", version: 2)
-        edition.valid?
-        expect(edition.errors.full_messages_for(:reason_for_change)).to eq ["Reason for change can't be blank"]
-      end
-
-      it "is allowed to be empty if the update_type is 'minor'" do
-        edition = build(:edition, update_type: "minor", reason_for_change: "")
-        edition.valid?
-        expect(edition.errors.full_messages_for(:reason_for_change)).to be_empty
-      end
-    end
-
     describe "update_type" do
       it "cannot be minor for the first edition" do
-        edition = build(:edition, update_type: "minor", reason_for_change: "")
+        edition = build(:edition, update_type: "minor")
         edition.valid?
         expect(edition.errors.full_messages_for(:update_type)).to include 'Update type must be major'
       end

--- a/spec/presenters/guide_presenter/change_history_presenter_spec.rb
+++ b/spec/presenters/guide_presenter/change_history_presenter_spec.rb
@@ -5,13 +5,11 @@ RSpec.describe GuidePresenter::ChangeHistoryPresenter do
     editions = [
       *published_edition(
         change_note: "Guidance first published",
-        reason_for_change: nil,
         update_type: "major",
         created_at: "2016-06-25T14:16:21Z"
       ),
       *published_edition(
         change_note: "Big content change",
-        reason_for_change: "Needed updating",
         update_type: "major",
         created_at: "2016-06-28T14:16:21Z"
       )
@@ -23,13 +21,11 @@ RSpec.describe GuidePresenter::ChangeHistoryPresenter do
     expect(presenter.change_history).to eq [
       {
         public_timestamp: "2016-06-28T14:16:21Z",
-        note: "Big content change",
-        reason_for_change: "Needed updating"
+        note: "Big content change"
       },
       {
         public_timestamp: "2016-06-25T14:16:21Z",
-        note: "Guidance first published",
-        reason_for_change: ""
+        note: "Guidance first published"
       }
     ]
   end
@@ -38,13 +34,11 @@ RSpec.describe GuidePresenter::ChangeHistoryPresenter do
     editions = [
       *published_edition(
         change_note: "Guidance first published",
-        reason_for_change: nil,
         update_type: "major",
         created_at: "2016-06-25T14:16:21Z"
       ),
       *draft_edition(
         change_note: "Big content change",
-        reason_for_change: "Needed updating",
         update_type: "major",
         created_at: "2016-06-28T14:16:21Z"
       )
@@ -56,13 +50,11 @@ RSpec.describe GuidePresenter::ChangeHistoryPresenter do
     expect(presenter.change_history).to eq [
       {
         public_timestamp: "2016-06-28T14:16:21Z",
-        note: "Big content change",
-        reason_for_change: "Needed updating"
+        note: "Big content change"
       },
       {
         public_timestamp: "2016-06-25T14:16:21Z",
-        note: "Guidance first published",
-        reason_for_change: ""
+        note: "Guidance first published"
       }
     ]
   end
@@ -71,13 +63,11 @@ RSpec.describe GuidePresenter::ChangeHistoryPresenter do
     editions = [
       *published_edition(
         change_note: "Guidance first published",
-        reason_for_change: nil,
         update_type: "major",
         created_at: "2016-06-25T14:16:21Z"
       ),
       *draft_edition(
         change_note: "",
-        reason_for_change: "",
         update_type: "minor",
         created_at: "2016-06-28T14:16:21Z",
         version: 2
@@ -90,29 +80,7 @@ RSpec.describe GuidePresenter::ChangeHistoryPresenter do
     expect(presenter.change_history).to eq [
       {
         public_timestamp: "2016-06-25T14:16:21Z",
-        note: "Guidance first published",
-        reason_for_change: ""
-      }
-    ]
-  end
-
-  it 'assigns the reason_for_change an empty string if the reason_for_change is nil' \
-    ' because the definition in the content schema requires it' do
-    editions = published_edition(
-      change_note: "Guidance first published",
-      reason_for_change: nil,
-      update_type: "major",
-      created_at: "2016-06-25T14:16:21Z"
-    )
-
-    guide = create(:guide, editions: editions)
-    presenter = described_class.new(guide, guide.latest_edition)
-
-    expect(presenter.change_history).to eq [
-      {
-        public_timestamp: "2016-06-25T14:16:21Z",
-        note: "Guidance first published",
-        reason_for_change: ""
+        note: "Guidance first published"
       }
     ]
   end

--- a/spec/presenters/guide_presenter_spec.rb
+++ b/spec/presenters/guide_presenter_spec.rb
@@ -44,8 +44,7 @@ RSpec.describe GuidePresenter do
       guide = create(:guide,
         edition: {
           created_at: "2016-06-28T14:16:21Z".to_time,
-          change_note: "Add a new guide 'The Title'",
-          reason_for_change: "We added this guide so we can test the presenter"
+          change_note: "Add a new guide 'The Title'"
         }
       )
       presenter = described_class.new(guide, guide.latest_edition)
@@ -54,8 +53,7 @@ RSpec.describe GuidePresenter do
         change_history: [
           {
             public_timestamp: "2016-06-28T14:16:21Z",
-            note: "Add a new guide 'The Title'",
-            reason_for_change: "We added this guide so we can test the presenter"
+            note: "Add a new guide 'The Title'"
           }
         ]
       )


### PR DESCRIPTION
This PR:
- Removes the "reason for change" field from editions
- Updates the change note UI when editing a guide to match Whitehall Publisher