### PR TITLE
Add content_store_document_type to Guide & Topic

### DIFF
--- a/app/models/guide_search_indexer.rb
+++ b/app/models/guide_search_indexer.rb
@@ -14,6 +14,7 @@ class GuideSearchIndexer
         type,
         id,
         format:            "service_manual_guide",
+        content_store_document_type: "service_manual_guide",
         description:       live_edition.description,
         indexable_content: live_edition.body,
         title:             live_edition.title,

--- a/app/models/topic_search_indexer.rb
+++ b/app/models/topic_search_indexer.rb
@@ -11,6 +11,7 @@ class TopicSearchIndexer
       type,
       id,
       format:            "service_manual_topic",
+      content_store_document_type: "service_manual_topic",
       description:       topic.description,
       indexable_content: topic.title + "\n\n" + topic.description,
       title:             topic.title,

--- a/spec/models/guide_search_indexer_spec.rb
+++ b/spec/models/guide_search_indexer_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe GuideSearchIndexer, '#index' do
       _type:             'service_manual_guide',
       _id:               '/service-manual/topic/some-slug',
       format:            'service_manual_guide',
+      content_store_document_type: "service_manual_guide",
       description:       'Description',
       indexable_content: "It's my published guide content",
       title:             'My guide',

--- a/spec/models/topic_search_indexer_spec.rb
+++ b/spec/models/topic_search_indexer_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe TopicSearchIndexer do
       _type:              "service_manual_topic",
       _id:                "/service-manual/topic1",
       format:             "service_manual_topic",
+      content_store_document_type: "service_manual_topic",
       description:        "The Topic Description",
       indexable_content:  "The Topic Title\n\nThe Topic Description",
       title:              "The Topic Title",


### PR DESCRIPTION
Finding Things has been working into adding a new field in rummager
called `content_store_document_type`. This commit does exactly that in
both GuideSearchIndexer & TopicSearchIndexer.

Trello:
https://trello.com/c/iMotNdUv/461-add-more-document-type-to-search