### PR TITLE
Update PaaS link on Service Toolkit

### DIFF
--- a/app/presenters/service_toolkit_presenter.rb
+++ b/app/presenters/service_toolkit_presenter.rb
@@ -99,7 +99,7 @@ class ServiceToolkitPresenter
           },
           {
             "title": "GOV.UK Platform as a Service",
-            "url": "https://govuk-paas.cloudapps.digital",
+            "url": "https://www.cloud.service.gov.uk",
             "description": "Host your service on a government cloud platform without having to build and manage your own infrastructure"
           },
           {


### PR DESCRIPTION
PaaS is now on their "proper" service.gov.uk domain, so we can go ahead
and update the link on the Service Toolkit :tada:.