### PR TITLE
Remove redundant environment variable setting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,6 @@ node {
       setupDb()
 
       govuk.contentSchemaDependency(env.SCHEMA_BRANCH)
-      govuk.setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")
 
       govuk.precompileAssets()
     }


### PR DESCRIPTION
The govuk.contentSchemaDependency method [already sets GOVUK_CONTENT_SCHEMAS_PATH for us](https://github.com/alphagov/govuk-puppet/blob/ccae2121912bdcd45c4e3ac24cd148df5d2907a0/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy#L156).