### PR TITLE
Improve sorting of sections and guides

### DIFF
--- a/app/assets/javascripts/topics.js
+++ b/app/assets/javascripts/topics.js
@@ -1,10 +1,11 @@
 $(function() {
   var $topics = $(".js-topic-section-list");
 
-  $topics.on("click", ".js-delete-list-group-item", function() {
+  $topics.on("click", ".js-delete-list-group-item", function(e) {
     $item = $(this).parents(".list-group-item");
     $item.find(".js-destroy").val("1");
     $item.hide();
+    e.preventDefault();
   });
 
   // Set up dragula on the overall section list

--- a/app/assets/stylesheets/topic-section-list.scss
+++ b/app/assets/stylesheets/topic-section-list.scss
@@ -1,26 +1,29 @@
 .topic-section-list {
-  .list-group {
-    min-height: 30px;
-  }
-
   .list-group-item {
     margin-bottom: 10px;
   }
+}
 
-  .left {
-    display: inline;
-  }
+.guide-list {
+  margin-bottom: 0;
+}
 
-  .right {
-    display: inline;
-  }
-
-  .glyphicon {
+.topic-section {
+  .section-handle {
+    float: left;
     cursor: pointer;
   }
 
-  .glyphicon-trash {
-    color: $brand-danger;
+  .section-body {
+    margin-left: 22px;
   }
 }
 
+.guide {
+  .guide-handle {
+    display: inline-block;
+    float: left;
+    margin-right: 8px;
+    cursor: pointer;
+  }
+}

--- a/app/views/topics/_form.html.erb
+++ b/app/views/topics/_form.html.erb
@@ -57,54 +57,61 @@
       </div>
 
       <div class="well">
-        <h3>Grouping</h3>
+        <h3>Sections</h3>
+        <p>Use the drag handles <span class="text-muted">(<span class="glyphicon glyphicon-move js-guide-handle"></span>)</span> to drag sections and guides into the required order.</p>
         <ul class="list-group topic-section-list js-topic-section-list">
           <%= f.fields_for :topic_sections, f.object.topic_sections.sort_by(&:position) do |topic_section_form| %>
             <% section_is_deletable = topic_section_form.object.topic_section_guides.empty? %>
-            <li class="list-group-item">
+            <li class="list-group-item topic-section">
               <%= topic_section_form.hidden_field :position, class: 'js-section-position' %>
             <% if section_is_deletable %>
               <%= topic_section_form.hidden_field :_destroy, value: "0", class: "js-destroy" %>
             <% end %>
-              <div class="left">
+              <div class="section-handle">
                 <span class="glyphicon glyphicon-move js-topic-section-handle"></span>
-              <% if section_is_deletable %>
-                <span class="glyphicon glyphicon-trash js-delete-list-group-item"></span>
-              <% end %>
               </div>
 
-              <div class="right">
+              <div class="section-body">
                 <div class="form-group">
-                  <%= topic_section_form.text_field :title, class: "form-control", placeholder: "Heading Title" %>
+                  <%= topic_section_form.label :title, "Section title" %>
+                  <%= topic_section_form.text_field :title, class: "form-control" %>
                 </div>
-                <%= topic_section_form.text_field :description, class: "form-control", placeholder: "Heading Description" %>
-              </div>
+                <div class="form-group">
+                  <%= topic_section_form.label :description, "Section description" %>
+                  <%= topic_section_form.text_field :description, class: "form-control" %>
+                </div>
 
-              <h3> Guides: </h3>
-              <div class="panel panel-default">
-                <div class="panel-heading">
-                  Drag and drop headings and guides into the required order.
-                </div>
-                <div class="panel-body">
-                  <ul class="list-group js-guide-list">
-                    <%= topic_section_form.fields_for(
-                      :topic_section_guides,
-                      topic_section_form.object.topic_section_guides.sort_by(&:position)
-                    ) do |topic_section_guide_form| %>
-                      <li class="list-group-item">
-                        <%= topic_section_guide_form.hidden_field :position, class: 'js-guide-position' %>
-                          <div class="left">
-                            <span class="glyphicon glyphicon-move js-guide-handle"></span>
-                          </div>
-                          <div class="right">
-                            <%= topic_section_guide_form.object.guide.title %>
-                          </div>
-                      </li>
-                    <% end %>
-                  </ul>
-                </div>
+                <% if topic_section_form.object.topic_section_guides.any? %>
+                  <div class="panel panel-default">
+                    <div class="panel-heading">
+                      <h4 class="panel-title">Guides</h4>
+                    </div>
+                    <div class="panel-body">
+                      <ul class="list-group guide-list js-guide-list">
+                        <%= topic_section_form.fields_for(
+                          :topic_section_guides,
+                          topic_section_form.object.topic_section_guides.sort_by(&:position)
+                        ) do |topic_section_guide_form| %>
+                          <li class="list-group-item guide">
+                            <%= topic_section_guide_form.hidden_field :position, class: 'js-guide-position' %>
+                              <div class="guide-handle">
+                                <span class="glyphicon glyphicon-move js-guide-handle"></span>
+                              </div>
+                              <div class="guide-body">
+                                <%= topic_section_guide_form.object.guide.title %>
+                              </div>
+                          </li>
+                        <% end %>
+                      </ul>
+                    </div>
+                  </div>
+                <% end %>
+                <% if section_is_deletable %>
+                  <a href="#" class="link-muted js-delete-list-group-item">
+                    Remove Empty Section
+                  </button>
+                <% end %>
               </div>
-
             </li>
           <% end %>
         </ul>

--- a/spec/features/topic_spec.rb
+++ b/spec/features/topic_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe "Topics", type: :feature do
     check "Collapsed"
     uncheck "Include on homepage?"
     click_button "Add Heading"
-    fill_in "Heading Title", with: "The heading title"
-    fill_in "Heading Description", with: "The heading description"
+    fill_in "Section title", with: "The section title"
+    fill_in "Section description", with: "The section description"
     click_button "Save"
 
     expect(page).to have_field('Title', with: 'The title')
@@ -49,8 +49,8 @@ RSpec.describe "Topics", type: :feature do
     expect(page).to have_checked_field('Collapsed')
     expect(page).to have_unchecked_field('Include on homepage?')
 
-    expect(page).to have_field "Heading Title", with: "The heading title"
-    expect(page).to have_field "Heading Description", with: "The heading description"
+    expect(page).to have_field "Section title", with: "The section title"
+    expect(page).to have_field "Section description", with: "The section description"
   end
 
   it "links to a preview from a saved draft" do


### PR DESCRIPTION
- Move label for section title and descriptions out of placeholder and into <label>
- Replace bin glyphicon with ‘Remove Empty Section’ link
- Move repeated instructions to top of section and revise copy
- Design tweaks to better associate handle with sections

## Before
![screen shot 2017-02-14 at 16 42 09](https://cloud.githubusercontent.com/assets/121939/22938764/a8e9804c-f2d4-11e6-91d9-2bf8591211cb.png)

## After
![screen shot 2017-02-14 at 16 42 49](https://cloud.githubusercontent.com/assets/121939/22938767/ac057f9c-f2d4-11e6-9372-28f891b16453.png)

https://trello.com/c/EadHh3tP/299-add-labels-on-topics-edit-pages-in-the-pub-app