### PR TITLE
Publish homepage using exact route, not prefix

### DIFF
--- a/app/presenters/homepage_presenter.rb
+++ b/app/presenters/homepage_presenter.rb
@@ -12,7 +12,7 @@ class HomepagePresenter
       description: 'Helping government teams create and run great digital services that meet the Digital Service Standard.',
       details: {},
       routes: [
-        { type: 'prefix', path: '/service-manual' }
+        { type: 'exact', path: '/service-manual' }
       ],
       document_type: 'service_manual_homepage',
       schema_name: 'service_manual_homepage',

--- a/lib/tasks/republish.rake
+++ b/lib/tasks/republish.rake
@@ -27,4 +27,14 @@ namespace :republish do
       publisher.publish
     end
   end
+
+  desc "republish homepage"
+  task homepage: :environment do
+    homepage = HomepagePresenter.new
+
+    # Save a draft of the homepage
+    puts "Republishing homepage..."
+    PUBLISHING_API.put_content(homepage.content_id, homepage.content_payload)
+    PUBLISHING_API.publish(homepage.content_id, "minor")
+  end
 end

--- a/spec/presenters/homepage_presenter_spec.rb
+++ b/spec/presenters/homepage_presenter_spec.rb
@@ -28,13 +28,13 @@ RSpec.describe HomepagePresenter, "#content_payload" do
       description: 'Helping government teams create and run great digital services that meet the Digital Service Standard.'
   end
 
-  it 'includes a base path and prefix route for the service manual' do
+  it 'includes a base path and exact route for the service manual' do
     payload = described_class.new.content_payload
 
     expect(payload).to include \
       base_path: '/service-manual',
       routes: [
-        { type: 'prefix', path: '/service-manual' }
+        { type: 'exact', path: '/service-manual' }
       ]
   end
 


### PR DESCRIPTION
This fixes a bug introduced by a [recent change][1] which means the content store redirects requests for routes within a prefix to their base path. In practise, this means that requests for non existent routes (e.g. [/service-manual/nonexistent-page](https://www.gov.uk/service-manual/nonexistent-page) are 303 redirected to the content store item for the homepage (/service-manual). The Service Manual frontend follows these redirects and then renders the homepage rather than returning a 404 as you’d expect.

We [originally chose to use a prefix route][2] because it meant ‘that requests for anything starting with /service-manual will be routed to our application, so we’ll be able to see 404s etc in our logs.’ This might have made some sense previously, but this behaviour now exhibited outweighs any such benefit.

[1]: alphagov/content-store#269
[2]: https://github.com/alphagov/service-manual-publisher/commit/0f1f3a4a051c0446103b53972e125b6d9631d8ca