### PR TITLE
Fix bug where clicking in empty section removes it

### DIFF
--- a/app/views/topics/_form.html.erb
+++ b/app/views/topics/_form.html.erb
@@ -109,7 +109,7 @@
                 <% if section_is_deletable %>
                   <a href="#" class="link-muted js-delete-list-group-item">
                     Remove Empty Section
-                  </button>
+                  </a>
                 <% end %>
               </div>
             </li>


### PR DESCRIPTION
Somehow this invalid HTML (closing a link as if it’s a button) causes a weird issue where clicking into the title field of the section causes it to be removed from the DOM.