### PR TITLE
Revert send update type with put content

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     diff-lcs (1.3)
     diffy (3.1.0)
     docile (1.1.5)
-    domain_name (0.5.20170404)
+    domain_name (0.5.20160615)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
@@ -96,13 +96,13 @@ GEM
     fuubar (2.1.1)
       rspec (~> 3.0)
       ruby-progressbar (~> 1.4)
-    gds-api-adapters (47.2.0)
+    gds-api-adapters (32.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek (>= 1.9.0)
       rack-cache
-      rest-client (~> 2.0)
+      rest-client (~> 1.8.0)
     gds-sso (13.2.0)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
@@ -132,7 +132,7 @@ GEM
     hashie (3.5.1)
     highline (1.7.8)
     htmlentities (4.3.4)
-    http-cookie (1.0.3)
+    http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.8.0)
     jasmine (2.4.0)
@@ -170,9 +170,7 @@ GEM
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
     method_source (0.8.2)
-    mime-types (3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
+    mime-types (2.99.3)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
     multi_json (1.12.1)
@@ -202,7 +200,7 @@ GEM
       ast (~> 2.2)
     pg (0.18.4)
     phantomjs (2.1.1.0)
-    plek (2.0.0)
+    plek (1.12.0)
     poltergeist (1.10.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -217,8 +215,8 @@ GEM
     pry-remote (0.1.8)
       pry (~> 0.9)
       slop (~> 3.0)
-    rack (2.0.3)
-    rack-cache (1.7.0)
+    rack (2.0.1)
+    rack-cache (1.6.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -254,10 +252,10 @@ GEM
     rake (10.5.0)
     redcarpet (3.3.4)
     request_store (1.3.1)
-    rest-client (2.0.2)
+    rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rinku (2.0.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -326,7 +324,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.4)
+    unf_ext (0.0.7.2)
     unicode-display_width (1.1.0)
     unicorn (5.1.0)
       kgio (~> 2.6)
@@ -393,4 +391,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.1
+   1.10.6

--- a/app/models/guide_manager.rb
+++ b/app/models/guide_manager.rb
@@ -28,7 +28,7 @@ class GuideManager
       edition = build_clone_of_latest_edition
       edition.state = 'published'
       edition.save!
-      PUBLISHING_API.publish(guide.content_id)
+      PUBLISHING_API.publish(guide.content_id, edition.update_type)
 
       unless edition.notification_subscribers == [user]
         NotificationMailer.published(guide, user).deliver_now

--- a/app/models/guide_republisher.rb
+++ b/app/models/guide_republisher.rb
@@ -12,7 +12,7 @@ class GuideRepublisher
 
       publishing_api.put_content(guide.content_id, guide_for_publication.content_payload)
       publishing_api.patch_links(guide.content_id, guide_for_publication.links_payload)
-      publishing_api.publish(guide.content_id, "republish")
+      publishing_api.publish(guide.content_id)
     end
   end
 

--- a/app/models/guide_republisher.rb
+++ b/app/models/guide_republisher.rb
@@ -12,7 +12,7 @@ class GuideRepublisher
 
       publishing_api.put_content(guide.content_id, guide_for_publication.content_payload)
       publishing_api.patch_links(guide.content_id, guide_for_publication.links_payload)
-      publishing_api.publish(guide.content_id)
+      publishing_api.publish(guide.content_id, "minor")
     end
   end
 

--- a/app/models/guide_search_indexer.rb
+++ b/app/models/guide_search_indexer.rb
@@ -26,7 +26,7 @@ class GuideSearchIndexer
   end
 
   def delete
-    RUMMAGER_API.delete_content(guide.slug)
+    RUMMAGER_API.delete_content!(guide.slug)
   end
 
 private

--- a/app/models/homepage_search_indexer.rb
+++ b/app/models/homepage_search_indexer.rb
@@ -20,6 +20,6 @@ class HomepageSearchIndexer
   end
 
   def delete
-    RUMMAGER_API.delete_content(@service_standard[:base_path])
+    RUMMAGER_API.delete_content!(@service_standard[:base_path])
   end
 end

--- a/app/models/redirect_publisher.rb
+++ b/app/models/redirect_publisher.rb
@@ -8,7 +8,6 @@ class RedirectPublisher
       schema_name: "redirect",
       document_type: "redirect",
       base_path: old_path,
-      update_type: "major",
       publishing_app: "service-manual-publisher",
       redirects: [
         {
@@ -19,6 +18,6 @@ class RedirectPublisher
       ]
     }
     @publishing_api.put_content(content_id, data)
-    @publishing_api.publish(content_id)
+    @publishing_api.publish(content_id, "major")
   end
 end

--- a/app/models/service_standard_publisher.rb
+++ b/app/models/service_standard_publisher.rb
@@ -38,10 +38,10 @@ private
   end
 
   def publish_email_alert_signup
-    PUBLISHING_API.publish(email_alert_signup.content_id)
+    PUBLISHING_API.publish(email_alert_signup.content_id, 'major')
   end
 
   def publish_service_standard
-    PUBLISHING_API.publish(service_standard.content_id)
+    PUBLISHING_API.publish(service_standard.content_id, 'major')
   end
 end

--- a/app/models/service_standard_search_indexer.rb
+++ b/app/models/service_standard_search_indexer.rb
@@ -20,6 +20,6 @@ class ServiceStandardSearchIndexer
   end
 
   def delete
-    RUMMAGER_API.delete_content(@service_standard[:base_path])
+    RUMMAGER_API.delete_content!(@service_standard[:base_path])
   end
 end

--- a/app/models/topic_publisher.rb
+++ b/app/models/topic_publisher.rb
@@ -20,8 +20,8 @@ class TopicPublisher
 
   def publish
     save_catching_gds_api_errors do
-      publishing_api.publish(topic.content_id)
-      publishing_api.publish(topic.email_alert_signup_content_id)
+      publishing_api.publish(topic.content_id, topic.update_type)
+      publishing_api.publish(topic.email_alert_signup_content_id, topic.update_type)
     end
   end
 

--- a/app/presenters/service_standard_email_alert_signup_presenter.rb
+++ b/app/presenters/service_standard_email_alert_signup_presenter.rb
@@ -8,7 +8,6 @@ class ServiceStandardEmailAlertSignupPresenter
   def content_payload
     {
       base_path: '/service-manual/service-standard/email-signup',
-      update_type: 'major',
       details: {
         summary: "You'll receive an email whenever the Digital Service Standard is updated.",
         subscriber_list: {

--- a/app/presenters/service_standard_presenter.rb
+++ b/app/presenters/service_standard_presenter.rb
@@ -9,7 +9,6 @@ class ServiceStandardPresenter
     {
       base_path: '/service-manual/service-standard',
       document_type: 'service_manual_service_standard',
-      update_type: 'major',
       locale: 'en',
       phase: 'beta',
       publishing_app: 'service-manual-publisher',

--- a/app/presenters/topic_email_alert_signup_presenter.rb
+++ b/app/presenters/topic_email_alert_signup_presenter.rb
@@ -10,7 +10,6 @@ class TopicEmailAlertSignupPresenter
   def content_payload
     {
       base_path: path,
-      update_type: 'major',
       details: {
         summary: summary,
         subscriber_list: subscriber_list_definition

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -14,7 +14,7 @@ class TopicPresenter
       schema_name: "service_manual_topic",
       document_type: "service_manual_topic",
       locale: "en",
-      update_type: "major",
+      update_type: "minor",
       base_path: topic.path,
       title: topic.title,
       description: topic.description,

--- a/spec/features/guide_history_spec.rb
+++ b/spec/features/guide_history_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe "Guide history", type: :feature do
     allow(publishing_api).to receive(:patch_links)
       .with(an_instance_of(String), an_instance_of(Hash))
     allow(publishing_api).to receive(:publish)
-      .with(an_instance_of(String))
+      .with(an_instance_of(String), an_instance_of(String))
   end
 
   def stub_rummager

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "Creating a guide", type: :feature do
       .with(an_instance_of(String), an_instance_of(Hash))
     expect(api_double).to receive(:publish)
       .once
-      .with(an_instance_of(String))
+      .with(an_instance_of(String), 'major')
     stub_any_rummager_post
 
     create(:guide_community, title: 'Technology Community')

--- a/spec/features/topic_spec.rb
+++ b/spec/features/topic_spec.rb
@@ -96,10 +96,10 @@ RSpec.describe "Topics", type: :feature do
 
     # expect to publish both the topic and the email alert signup for the topic
     expect(api_double).to receive(:publish)
-      .once.with(topic.content_id)
+      .once.with(topic.content_id, 'major')
 
     expect(api_double).to receive(:publish)
-      .once.with(topic.email_alert_signup_content_id)
+      .once.with(topic.email_alert_signup_content_id, 'major')
 
     # Expect that the topic is attempted to be indexed for search
     topic_search_indexer = double(:topic_search_indexer)

--- a/spec/models/change_note_migrator_spec.rb
+++ b/spec/models/change_note_migrator_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe ChangeNoteMigrator do
         aggregate_failures do
           expect(publishing_api).to receive(:put_content)
           expect(publishing_api).to receive(:patch_links)
-          expect(publishing_api).to receive(:publish).with(guide.content_id, "republish")
+          expect(publishing_api).to receive(:publish).with(guide.content_id)
         end
 
         subject.update_change_note(major_edition.id, change_note)
@@ -72,7 +72,7 @@ RSpec.describe ChangeNoteMigrator do
         aggregate_failures do
           expect(publishing_api).to receive(:put_content)
           expect(publishing_api).to receive(:patch_links)
-          expect(publishing_api).to receive(:publish).with(guide.content_id, "republish")
+          expect(publishing_api).to receive(:publish).with(guide.content_id)
         end
 
         subject.make_major(minor_edition.id, change_note)
@@ -94,7 +94,7 @@ RSpec.describe ChangeNoteMigrator do
         aggregate_failures do
           expect(publishing_api).to receive(:put_content)
           expect(publishing_api).to receive(:patch_links)
-          expect(publishing_api).to receive(:publish).with(guide.content_id, "republish")
+          expect(publishing_api).to receive(:publish).with(guide.content_id)
         end
 
         subject.make_minor(major_edition.id)

--- a/spec/models/change_note_migrator_spec.rb
+++ b/spec/models/change_note_migrator_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe ChangeNoteMigrator do
         aggregate_failures do
           expect(publishing_api).to receive(:put_content)
           expect(publishing_api).to receive(:patch_links)
-          expect(publishing_api).to receive(:publish).with(guide.content_id)
+          expect(publishing_api).to receive(:publish).with(guide.content_id, "minor")
         end
 
         subject.update_change_note(major_edition.id, change_note)
@@ -72,7 +72,7 @@ RSpec.describe ChangeNoteMigrator do
         aggregate_failures do
           expect(publishing_api).to receive(:put_content)
           expect(publishing_api).to receive(:patch_links)
-          expect(publishing_api).to receive(:publish).with(guide.content_id)
+          expect(publishing_api).to receive(:publish).with(guide.content_id, "minor")
         end
 
         subject.make_major(minor_edition.id, change_note)
@@ -94,7 +94,7 @@ RSpec.describe ChangeNoteMigrator do
         aggregate_failures do
           expect(publishing_api).to receive(:put_content)
           expect(publishing_api).to receive(:patch_links)
-          expect(publishing_api).to receive(:publish).with(guide.content_id)
+          expect(publishing_api).to receive(:publish).with(guide.content_id, "minor")
         end
 
         subject.make_minor(major_edition.id)

--- a/spec/models/guide_republisher_spec.rb
+++ b/spec/models/guide_republisher_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe GuideRepublisher, "#republish" do
       .with(guide.content_id, hash_including(base_path: "/service-manual/topic/guide"))
     expect(publishing_api).to receive(:patch_links)
       .with(guide.content_id, hash_including(links: kind_of(Hash)))
-    expect(publishing_api).to receive(:publish).with(guide.content_id)
+    expect(publishing_api).to receive(:publish).with(guide.content_id, "minor")
 
     described_class.new(guide, publishing_api: publishing_api).republish
   end
@@ -34,6 +34,6 @@ RSpec.describe GuideRepublisher, "#republish" do
 
     described_class.new(guide).republish
 
-    assert_publishing_api_publish(guide.content_id)
+    assert_publishing_api_publish(guide.content_id, update_type: "minor")
   end
 end

--- a/spec/models/guide_republisher_spec.rb
+++ b/spec/models/guide_republisher_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe GuideRepublisher, "#republish" do
       .with(guide.content_id, hash_including(base_path: "/service-manual/topic/guide"))
     expect(publishing_api).to receive(:patch_links)
       .with(guide.content_id, hash_including(links: kind_of(Hash)))
-    expect(publishing_api).to receive(:publish).with(guide.content_id, "republish")
+    expect(publishing_api).to receive(:publish).with(guide.content_id)
 
     described_class.new(guide, publishing_api: publishing_api).republish
   end

--- a/spec/models/redirect_publisher_spec.rb
+++ b/spec/models/redirect_publisher_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe RedirectPublisher, type: :model do
 
     expected_redirect = {
       schema_name: "redirect",
-      update_type: "major",
       document_type: "redirect",
       publishing_app: "service-manual-publisher",
       base_path: old_path,
@@ -25,7 +24,7 @@ RSpec.describe RedirectPublisher, type: :model do
     expect(api).to receive(:put_content)
       .with(content_id, expected_redirect)
     expect(api).to receive(:publish)
-      .once.with(content_id)
+      .once.with(content_id, 'major')
 
     RedirectPublisher.new(api).process(
       content_id: content_id,
@@ -43,7 +42,7 @@ RSpec.describe RedirectPublisher, type: :model do
     expect(api).to receive(:put_content)
       .with(an_instance_of(String), be_valid_against_schema('redirect'))
     expect(api).to receive(:publish)
-      .once.with(content_id)
+      .once.with(content_id, 'major')
 
     RedirectPublisher.new(api).process(
       content_id: content_id,

--- a/spec/models/service_standard_publisher_spec.rb
+++ b/spec/models/service_standard_publisher_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe ServiceStandardPublisher, '#publish' do
 
     described_class.new.publish
 
-    assert_publishing_api_publish('4a94ae54-5a47-40c1-b9aa-ff47dcaace85')
+    assert_publishing_api_publish('4a94ae54-5a47-40c1-b9aa-ff47dcaace85', "update_type" => "major")
   end
 
   it 'publishes the service standard' do
@@ -56,6 +56,6 @@ RSpec.describe ServiceStandardPublisher, '#publish' do
 
     described_class.new.publish
 
-    assert_publishing_api_publish('00f693d4-866a-4fe6-a8d6-09cd7db8980b')
+    assert_publishing_api_publish('00f693d4-866a-4fe6-a8d6-09cd7db8980b', "update_type" => "major")
   end
 end

--- a/spec/models/topic_publisher_spec.rb
+++ b/spec/models/topic_publisher_spec.rb
@@ -93,10 +93,10 @@ RSpec.describe TopicPublisher, '#publish' do
 
     # expect to publish both the topic and the email alert signup for the topic
     expect(publishing_api).to receive(:publish)
-      .once.with(topic.content_id)
+      .once.with(topic.content_id, topic.update_type)
 
     expect(publishing_api).to receive(:publish)
-      .once.with(topic.email_alert_signup_content_id)
+      .once.with(topic.email_alert_signup_content_id, topic.update_type)
 
     described_class.new(topic: topic, publishing_api: publishing_api)
       .publish

--- a/spec/presenters/service_standard_presenter_spec.rb
+++ b/spec/presenters/service_standard_presenter_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe ServiceStandardPresenter, "#content_payload" do
       ],
       schema_name: 'service_manual_service_standard',
       title: 'Digital Service Standard',
-      update_type: 'major',
       description: "The Digital Service Standard is a set of 18 criteria to help government create and run good digital services.",
       details: {
         body: "All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use.",

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -19,12 +19,11 @@ RSpec.describe TopicPresenter, "#content_payload" do
       description: "Topic description",
       path: "/service-manual/test-topic"
     )
-
     topic_presenter = described_class.new(topic)
 
     expect(topic_presenter.content_payload).to include(
       description: "Topic description",
-      update_type: "major",
+      update_type: "minor",
       phase: "beta",
       schema_name: "service_manual_topic",
       document_type: "service_manual_topic",


### PR DESCRIPTION
Until we fix the issue with gds-api-adapters where we are expecting an openstruct rather than a hash.