### PR TITLE
Update responses to behave like a hash

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -11,7 +11,7 @@ class UploadsController < ApplicationController
 
         begin
           response = ASSET_API.create_asset(file: file)
-          render body: response.file_url, status: 201
+          render body: response[:file_url], status: 201
         rescue GdsApi::BaseError => e
           render body: e.message, status: :unprocessable_entity
         end
@@ -22,7 +22,7 @@ class UploadsController < ApplicationController
 
         begin
           response = ASSET_API.create_asset(file: file)
-          redirect_to new_upload_path, notice: "Uploaded successfully to #{response.file_url}"
+          redirect_to new_upload_path, notice: "Uploaded successfully to #{response[:file_url]}"
         rescue GdsApi::BaseError => e
           render body: e.message, status: :unprocessable_entity
         end

--- a/spec/controllers/uploads_controller_spec.rb
+++ b/spec/controllers/uploads_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe UploadsController, type: :controller do
         test_png = fixture_file_upload('fake.file', 'image/png')
 
         expect(ASSET_API).to receive(:create_asset)
-          .and_return(OpenStruct.new(file_url: 'http://uploaded.file/1.png'))
+          .and_return(file_url: 'http://uploaded.file/1.png')
 
         post :create, params: {
           format: :js,
@@ -38,7 +38,7 @@ RSpec.describe UploadsController, type: :controller do
         test_pdf = fixture_file_upload('fake.file', 'application/pdf')
 
         expect(ASSET_API).to receive(:create_asset)
-          .and_return(OpenStruct.new(file_url: 'http://uploaded.file/1.png'))
+          .and_return(file_url: 'http://uploaded.file/1.png')
 
         post :create, params: { file: test_pdf }
 


### PR DESCRIPTION
Following on from the gds-api-adapters upgrade to 47.2, OpenStruct responses
are now longer supported and must now be hashes.