### PR TITLE
Update Registers to GOV.UK Registers

### DIFF
--- a/app/presenters/service_toolkit_presenter.rb
+++ b/app/presenters/service_toolkit_presenter.rb
@@ -103,7 +103,7 @@ class ServiceToolkitPresenter
             "description": "Host your service on a government cloud platform without having to build and manage your own infrastructure"
           },
           {
-            "title": "Registers",
+            "title": "GOV.UK Registers",
             "url": "https://registers.cloudapps.digital",
             "description": "Get authoritative datasets your service can rely on"
           }


### PR DESCRIPTION
`Registers` is now officially known as `GOV.UK Registers`.