### PR TITLE
Update govuk_app_config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,6 @@ gem 'pg'
 gem 'sass-rails'
 gem 'uglifier'
 
-gem 'unicorn'
-gem 'logstasher'
 gem 'plek'
 
 gem 'govuk_admin_template'
@@ -17,7 +15,7 @@ gem 'diffy'
 gem 'gds-api-adapters'
 gem 'gds-sso'
 gem 'govspeak'
-gem "govuk_app_config", "~> 0.2.0"
+gem "govuk_app_config", "~> 1.3.0"
 gem 'highline'
 gem 'kaminari'
 gem 'redcarpet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,9 +136,11 @@ GEM
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 4.3.1)
       rails (>= 3.2.0)
-    govuk_app_config (0.2.0)
-      sentry-raven (~> 2.6.3)
+    govuk_app_config (1.3.0)
+      logstasher (~> 1.2.2)
+      sentry-raven (~> 2.7.1)
       statsd-ruby (~> 1.4.0)
+      unicorn (~> 5.4.0)
     hashdiff (0.3.7)
     hashie (3.5.6)
     highline (1.7.10)
@@ -173,7 +175,7 @@ GEM
       activerecord
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
-    kgio (2.11.0)
+    kgio (2.11.2)
     kramdown (1.15.0)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -282,7 +284,8 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     redcarpet (3.4.0)
-    request_store (1.3.2)
+    request_store (1.4.0)
+      rack (>= 1.4)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -334,7 +337,7 @@ GEM
       sass (~> 3.5.3)
     select2-rails (4.0.3)
       thor (~> 0.14)
-    sentry-raven (2.6.3)
+    sentry-raven (2.7.2)
       faraday (>= 0.7.6, < 1.0)
     simplecov (0.15.1)
       docile (~> 1.1.0)
@@ -363,7 +366,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.4)
     unicode-display_width (1.3.0)
-    unicorn (5.3.1)
+    unicorn (5.4.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
     uniform_notifier (1.10.0)
@@ -402,12 +405,11 @@ DEPENDENCIES
   govuk-content-schema-test-helpers
   govuk-lint
   govuk_admin_template
-  govuk_app_config (~> 0.2.0)
+  govuk_app_config (~> 1.3.0)
   highline
   jasmine
   kaminari
   launchy
-  logstasher
   pg
   plek
   poltergeist
@@ -424,7 +426,6 @@ DEPENDENCIES
   simplecov
   simplecov-rcov
   uglifier
-  unicorn
   webmock
 
 BUNDLED WITH

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,8 +1,4 @@
 Rails.application.configure do
-  config.logstasher.enabled = true
-  config.logstasher.logger = Logger.new(Rails.root.join("log/production.json.log"))
-  config.logstasher.suppress_app_log = true
-
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
@@ -52,7 +48,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  # config.log_level = :debug
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]

--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -1,8 +1,0 @@
-if Object.const_defined?('LogStasher') && LogStasher.enabled
-  LogStasher.add_custom_fields do |fields|
-    # Mirrors Nginx request logging, e.g GET /path/here HTTP/1.1
-    fields[:request] = "#{request.request_method} #{request.fullpath} #{request.headers['SERVER_PROTOCOL']}"
-    # Pass request Id to logging
-    fields[:govuk_request_id] = request.headers['GOVUK-Request-Id']
-  end
-end

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,0 +1,2 @@
+require "govuk_app_config"
+GovukUnicorn.configure(self)


### PR DESCRIPTION
It's worth checking the [govuk_app_config changelog](https://github.com/alphagov/govuk_app_config/blob/master/CHANGELOG.md) which contains details of what I should have done.

By updating this gem and the associated config, we'll get the standard GOV.UK settings for logstasher, statsd, unicorn and sentry.

In particular, this update sets default logstasher config, so that the [deployment dashboard](https://grafana.publishing.service.gov.uk/dashboard/file/deployment_service-manual-publisher.json?refresh=5s&orgId=1) for this app will work better.  This is a first port of call for support engineers troubleshooting problems.

It also helps ensure that there's a consistent feel across applications when we look at [Kibana](https://reliability-engineering.cloudapps.digital/manuals/logit-io-joiners-and-leavers.html#content) for application logs.