### PR TITLE
Add primary publishing organisation to each new or updated guide

### DIFF
--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -30,6 +30,7 @@ class GuidePresenter
   def links_payload
     links = {
       organisations: [ServiceManualPublisher::GDS_ORGANISATION_CONTENT_ID],
+      primary_publishing_organisation: [ServiceManualPublisher::GDS_ORGANISATION_CONTENT_ID]
     }
 
     if guide.topic

--- a/spec/presenters/guide_presenter_spec.rb
+++ b/spec/presenters/guide_presenter_spec.rb
@@ -138,6 +138,14 @@ RSpec.describe GuidePresenter do
         expect(presenter.links_payload[:links][:content_owners])
           .to eq(['c5eb647c-7943-49dd-8362-1920d330696f'])
       end
+
+      it 'includes the GDS Organisation ID as the primary publishing organisation' do
+        guide = create(:guide)
+        presenter = described_class.new(guide, guide.latest_edition)
+
+        expect(presenter.links_payload[:links][:primary_publishing_organisation])
+          .to eq ['af07d5a5-df63-4ddc-9383-6a666845ebe9']
+      end
     end
 
     context 'for a guide community' do


### PR DESCRIPTION
Add a primary publishing org field to links so that we can track primary orgs in the publishing api