### PR TITLE
Add primary publishing org to service_standards and topics

### DIFF
--- a/app/presenters/service_standard_presenter.rb
+++ b/app/presenters/service_standard_presenter.rb
@@ -30,8 +30,9 @@ class ServiceStandardPresenter
     {
       links: {
         email_alert_signup: [
-          ServiceStandardEmailAlertSignupPresenter::SERVICE_STANDARD_EMAIL_ALERT_SIGNUP_CONTENT_ID
-        ]
+          ServiceStandardEmailAlertSignupPresenter::SERVICE_STANDARD_EMAIL_ALERT_SIGNUP_CONTENT_ID,
+        ],
+        primary_publishing_organisation: [ServiceManualPublisher::GDS_ORGANISATION_CONTENT_ID]
       }
     }
   end

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -36,6 +36,7 @@ class TopicPresenter
         linked_items: topic.guides.map(&:content_id),
         content_owners: content_owner_content_ids,
         organisations: [ServiceManualPublisher::GDS_ORGANISATION_CONTENT_ID],
+        primary_publishing_organisation: [ServiceManualPublisher::GDS_ORGANISATION_CONTENT_ID],
         parent: parents
       }
     }

--- a/spec/models/service_standard_publisher_spec.rb
+++ b/spec/models/service_standard_publisher_spec.rb
@@ -37,7 +37,10 @@ RSpec.describe ServiceStandardPublisher, '#save_draft' do
 
     assert_publishing_api_patch_links(
       '00f693d4-866a-4fe6-a8d6-09cd7db8980b',
-      links: { email_alert_signup: ["4a94ae54-5a47-40c1-b9aa-ff47dcaace85"] }
+      links: {
+        email_alert_signup: ["4a94ae54-5a47-40c1-b9aa-ff47dcaace85"],
+        primary_publishing_organisation: [ServiceManualPublisher::GDS_ORGANISATION_CONTENT_ID]
+      }
     )
   end
 end

--- a/spec/presenters/service_standard_presenter_spec.rb
+++ b/spec/presenters/service_standard_presenter_spec.rb
@@ -51,4 +51,14 @@ RSpec.describe ServiceStandardPresenter, '#links_payload' do
       email_alert_signup: ["4a94ae54-5a47-40c1-b9aa-ff47dcaace85"]
     )
   end
+
+  it 'includes the GDS Organisation ID as the primary publishing organisation' do
+    presented_service_standard = described_class.new
+
+    links = presented_service_standard.links_payload[:links]
+
+    expect(links).to include(
+      primary_publishing_organisation: ['af07d5a5-df63-4ddc-9383-6a666845ebe9']
+    )
+  end
 end

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -167,6 +167,15 @@ RSpec.describe TopicPresenter, "#links_payload" do
     ).to eq([])
   end
 
+  it 'includes the GDS Organisation ID as the primary publishing organisation' do
+    guide_community = create(:guide_community)
+    topic = create_topic_in_groups([[guide_community]])
+    presenter = described_class.new(topic)
+
+    expect(presenter.links_payload[:links][:primary_publishing_organisation])
+      .to eq ['af07d5a5-df63-4ddc-9383-6a666845ebe9']
+  end
+
   context 'when the topic should be included on the homepage' do
     it "includes the homepage as a parent" do
       topic = create(:topic, include_on_homepage: true)


### PR DESCRIPTION
Add a primary publishing org field to links so that we can track primary orgs in the publishing api