### PR TITLE
Add primary publishing org to homepage and toolkit

### DIFF
--- a/app/presenters/homepage_presenter.rb
+++ b/app/presenters/homepage_presenter.rb
@@ -21,4 +21,10 @@ class HomepagePresenter
       locale: 'en'
     }
   end
+
+  def links_payload
+    {
+      primary_publishing_organisation: [ServiceManualPublisher::GDS_ORGANISATION_CONTENT_ID]
+    }
+  end
 end

--- a/app/presenters/service_toolkit_presenter.rb
+++ b/app/presenters/service_toolkit_presenter.rb
@@ -133,4 +133,10 @@ class ServiceToolkitPresenter
       }
     ]
   end
+
+  def links_payload
+    {
+      primary_publishing_organisation: [ServiceManualPublisher::GDS_ORGANISATION_CONTENT_ID]
+    }
+  end
 end

--- a/lib/tasks/migrate_homepage.rake
+++ b/lib/tasks/migrate_homepage.rake
@@ -23,6 +23,11 @@ task migrate_homepage: :environment do
     homepage.content_payload
   )
 
+  PUBLISHING_API.patch_links(
+    homepage.content_id,
+    homepage.links_payload
+  )
+
   # Republish all topics (as children of the homepage)
   Topic.find_each do |topic|
     puts "Republishing #{topic.title}..."

--- a/lib/tasks/publish_service_toolkit.rake
+++ b/lib/tasks/publish_service_toolkit.rake
@@ -6,6 +6,8 @@ namespace :publish do
     puts "Creating service toolkit..."
     PUBLISHING_API.put_content(toolkit.content_id, toolkit.content_payload)
 
+    PUBLISHING_API.patch_links(toolkit.content_id, toolkit.links_payload)
+
     puts "Publishing the service toolkit..."
     PUBLISHING_API.publish(toolkit.content_id, "major")
 

--- a/spec/presenters/homepage_presenter_spec.rb
+++ b/spec/presenters/homepage_presenter_spec.rb
@@ -8,6 +8,15 @@ RSpec.describe HomepagePresenter, "#content_id" do
   end
 end
 
+RSpec.describe HomepagePresenter, "#links_payload" do
+  it "includes the GDS Organisation ID as the primary publishing organisation" do
+    homepage_presenter = described_class.new
+
+    expect(homepage_presenter.links_payload).to include \
+      primary_publishing_organisation: ['af07d5a5-df63-4ddc-9383-6a666845ebe9']
+  end
+end
+
 RSpec.describe HomepagePresenter, "#content_payload" do
   it "conforms to the schema" do
     homepage_presenter = described_class.new

--- a/spec/presenters/service_toolkit_presenter_spec.rb
+++ b/spec/presenters/service_toolkit_presenter_spec.rb
@@ -8,6 +8,13 @@ RSpec.describe ServiceToolkitPresenter, "#content_id" do
   end
 end
 
+RSpec.describe ServiceToolkitPresenter, "#links_payload" do
+  let(:payload) { described_class.new.links_payload }
+  it "includes the GDS Organisation ID as the primary publishing organisation" do
+    expect(payload[:primary_publishing_organisation]).to eq ['af07d5a5-df63-4ddc-9383-6a666845ebe9']
+  end
+end
+
 RSpec.describe ServiceToolkitPresenter, "#content_payload" do
   let(:payload) { described_class.new.content_payload }
 


### PR DESCRIPTION
Add links payload to both homepage and toolkit and include in it the primary publishing org which
is set to the GDS content id.

Add patch_links with the new links payload in the respective rake tasks to create homepage and toolkit.