### PR TITLE
Rename standard

### DIFF
--- a/app/presenters/homepage_presenter.rb
+++ b/app/presenters/homepage_presenter.rb
@@ -9,7 +9,7 @@ class HomepagePresenter
     {
       base_path: '/service-manual',
       title: 'Service Manual',
-      description: 'Helping government teams create and run great digital services that meet the Government Service Standard.',
+      description: 'Helping government teams create and run great digital services that meet the Service Standard.',
       details: {},
       routes: [
         { type: 'exact', path: '/service-manual' }

--- a/app/presenters/homepage_presenter.rb
+++ b/app/presenters/homepage_presenter.rb
@@ -9,7 +9,7 @@ class HomepagePresenter
     {
       base_path: '/service-manual',
       title: 'Service Manual',
-      description: 'Helping government teams create and run great digital services that meet the Digital Service Standard.',
+      description: 'Helping government teams create and run great digital services that meet the Government Service Standard.',
       details: {},
       routes: [
         { type: 'exact', path: '/service-manual' }

--- a/app/presenters/service_standard_email_alert_signup_presenter.rb
+++ b/app/presenters/service_standard_email_alert_signup_presenter.rb
@@ -10,7 +10,7 @@ class ServiceStandardEmailAlertSignupPresenter
       base_path: '/service-manual/service-standard/email-signup',
       update_type: 'major',
       details: {
-        summary: "You'll receive an email whenever the Digital Service Standard is updated.",
+        summary: "You'll receive an email whenever the Government Service Standard is updated.",
         subscriber_list: {
           document_type: 'service_manual_guide',
           links: {

--- a/app/presenters/service_standard_email_alert_signup_presenter.rb
+++ b/app/presenters/service_standard_email_alert_signup_presenter.rb
@@ -10,7 +10,7 @@ class ServiceStandardEmailAlertSignupPresenter
       base_path: '/service-manual/service-standard/email-signup',
       update_type: 'major',
       details: {
-        summary: "You'll receive an email whenever the Government Service Standard is updated.",
+        summary: "You'll receive an email whenever the Service Standard is updated.",
         subscriber_list: {
           document_type: 'service_manual_guide',
           links: {

--- a/app/presenters/service_standard_presenter.rb
+++ b/app/presenters/service_standard_presenter.rb
@@ -18,8 +18,8 @@ class ServiceStandardPresenter
         { type: 'exact', path: '/service-manual/service-standard' }
       ],
       schema_name: 'service_manual_service_standard',
-      title: 'Digital Service Standard',
-      description: "The Digital Service Standard is a set of 18 criteria to help government create and run good digital services.",
+      title: 'Government Service Standard',
+      description: "The Government Service Standard is a set of 14 criteria to help government create and run good digital services.",
       details: {
         body: "All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use.",
       }

--- a/app/presenters/service_standard_presenter.rb
+++ b/app/presenters/service_standard_presenter.rb
@@ -18,10 +18,10 @@ class ServiceStandardPresenter
         { type: 'exact', path: '/service-manual/service-standard' }
       ],
       schema_name: 'service_manual_service_standard',
-      title: 'Government Service Standard',
-      description: "The Government Service Standard is a set of 14 criteria to help government create and run good digital services.",
+      title: 'Service Standard',
+      description: "The Service Standard is a set of 14 criteria to help government create and run good digital services.",
       details: {
-        body: "All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use.",
+        body: "<p>All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use.</p><p>Aenean lacinia bibendum nulla sed consectetur. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui.</p>",
       }
     }
   end

--- a/app/presenters/service_toolkit_presenter.rb
+++ b/app/presenters/service_toolkit_presenter.rb
@@ -38,7 +38,7 @@ class ServiceToolkitPresenter
           {
             "title": "Service Manual",
             "url": "https://www.gov.uk/service-manual",
-            "description": "Guidance on how to research, design and build services that meet the Digital Service Standard"
+            "description": "Guidance on how to research, design and build services that meet the Government Service Standard"
           },
           {
             "title": "API technical and data standards",

--- a/app/presenters/service_toolkit_presenter.rb
+++ b/app/presenters/service_toolkit_presenter.rb
@@ -31,9 +31,9 @@ class ServiceToolkitPresenter
         "description": "Standards for creating and running government services",
         "links": [
           {
-            "title": "Digital Service Standard",
+            "title": "Government Service Standard",
             "url": "https://www.gov.uk/service-manual/service-standard",
-            "description": "The 18-point standard that government services must meet"
+            "description": "The 14-point standard that government services must meet"
           },
           {
             "title": "Service Manual",

--- a/app/presenters/service_toolkit_presenter.rb
+++ b/app/presenters/service_toolkit_presenter.rb
@@ -31,14 +31,14 @@ class ServiceToolkitPresenter
         "description": "Standards for creating and running government services",
         "links": [
           {
-            "title": "Government Service Standard",
+            "title": "Service Standard",
             "url": "https://www.gov.uk/service-manual/service-standard",
             "description": "The 14-point standard that government services must meet"
           },
           {
             "title": "Service Manual",
             "url": "https://www.gov.uk/service-manual",
-            "description": "Guidance on how to research, design and build services that meet the Government Service Standard"
+            "description": "Guidance on how to research, design and build services that meet the Service Standard"
           },
           {
             "title": "API technical and data standards",

--- a/spec/presenters/homepage_presenter_spec.rb
+++ b/spec/presenters/homepage_presenter_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe HomepagePresenter, "#content_payload" do
     payload = described_class.new.content_payload
 
     expect(payload).to include \
-      description: 'Helping government teams create and run great digital services that meet the Digital Service Standard.'
+      description: 'Helping government teams create and run great digital services that meet the Government Service Standard.'
   end
 
   it 'includes a base path and exact route for the service manual' do

--- a/spec/presenters/homepage_presenter_spec.rb
+++ b/spec/presenters/homepage_presenter_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe HomepagePresenter, "#content_payload" do
     payload = described_class.new.content_payload
 
     expect(payload).to include \
-      description: 'Helping government teams create and run great digital services that meet the Government Service Standard.'
+      description: 'Helping government teams create and run great digital services that meet the Service Standard.'
   end
 
   it 'includes a base path and exact route for the service manual' do

--- a/spec/presenters/service_standard_email_alert_signup_presenter_spec.rb
+++ b/spec/presenters/service_standard_email_alert_signup_presenter_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe ServiceStandardEmailAlertSignupPresenter, '#content_payload' do
     presenter = described_class.new
 
     expect(presenter.content_payload[:details]).to include(
-      summary: "You'll receive an email whenever the Government Service Standard is updated."
+      summary: "You'll receive an email whenever the Service Standard is updated."
     )
   end
 

--- a/spec/presenters/service_standard_email_alert_signup_presenter_spec.rb
+++ b/spec/presenters/service_standard_email_alert_signup_presenter_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe ServiceStandardEmailAlertSignupPresenter, '#content_payload' do
     presenter = described_class.new
 
     expect(presenter.content_payload[:details]).to include(
-      summary: "You'll receive an email whenever the Digital Service Standard is updated."
+      summary: "You'll receive an email whenever the Government Service Standard is updated."
     )
   end
 

--- a/spec/presenters/service_standard_presenter_spec.rb
+++ b/spec/presenters/service_standard_presenter_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe ServiceStandardPresenter, "#content_payload" do
         { type: 'exact', path: '/service-manual/service-standard' }
       ],
       schema_name: 'service_manual_service_standard',
-      title: 'Government Service Standard',
+      title: 'Service Standard',
       update_type: 'major',
-      description: "The Government Service Standard is a set of 14 criteria to help government create and run good digital services.",
+      description: "The Service Standard is a set of 14 criteria to help government create and run good digital services.",
       details: {
         body: "All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use.",
       }

--- a/spec/presenters/service_standard_presenter_spec.rb
+++ b/spec/presenters/service_standard_presenter_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe ServiceStandardPresenter, "#content_payload" do
         { type: 'exact', path: '/service-manual/service-standard' }
       ],
       schema_name: 'service_manual_service_standard',
-      title: 'Digital Service Standard',
+      title: 'Government Service Standard',
       update_type: 'major',
-      description: "The Digital Service Standard is a set of 18 criteria to help government create and run good digital services.",
+      description: "The Government Service Standard is a set of 14 criteria to help government create and run good digital services.",
       details: {
         body: "All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use.",
       }


### PR DESCRIPTION
The Digital Service Standard is being renamed the Government Service Standard and being reduced to 14 points.

The title and description of the Standard aren't things the Service Manual content team can change using the Service Manual Publisher interface.

This PR changes the title and description where they're set in Service Manual Publisher.

It'll probably need more work.

