### PR TITLE
Don't require unused parts of Rails

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,18 @@
 require_relative 'boot'
 
-require 'rails/all'
+require "rails"
+
+# Pick the frameworks you want:
+require "active_model/railtie"
+require "active_record/railtie"
+require "action_controller/railtie"
+require "action_view/railtie"
+require "sprockets/railtie"
+require "action_mailer/railtie"
+# require "active_job/railtie"
+# require "active_storage/engine"
+# require "action_cable/engine"
+# require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
This is mostly to avoid requiring but not using activestorage, as that
requires the SECRET_KEY_BASE when precompiling assets in the
production environment (which breaks the GOV.UK Mini Environment
Admin).