### PR TITLE
Minor doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Service-manual-publisher
 
-Service Manual Publisher is used for publishing and maintaining https://gov.uk
-/service-manual. This application, together with
+Service Manual Publisher is used for publishing and maintaining https://gov.uk/service-manual. This application, together with
 [service-manual-frontend](https://github.com/alphagov/service-manual-frontend)
 replaced the previous Jekyll-based
 [service manual](https://github.com/alphagov/government-service-design-manual).

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ replaced the previous Jekyll-based
 
 ## Technical documentation
 
-PostgreSQL-backed Rails 4 "Publishing 2.0" application for internal use, with no
+PostgreSQL-backed Rails publishing application for internal use, with no
 public facing aspect.
 
 There is some [disparity between the content as it appears in the database, and


### PR DESCRIPTION
Fix link to live site.

Remove reference to specific rails version in the readme. It's contained in the Gemfile anyway and just goes out of date here.

Remove "Publishing 2.0" since it probably makes no sense to most of the developers on GOV.UK at the moment and adds nothing to the understanding of the application.