### PR TITLE
Remove unnecessary redirect to Verify site

### DIFF
--- a/app/presenters/service_toolkit_presenter.rb
+++ b/app/presenters/service_toolkit_presenter.rb
@@ -140,7 +140,7 @@ class ServiceToolkitPresenter
           },
           {
             "title": "GOV.UK Verify",
-            "url": "https://govuk-verify.cloudapps.digital",
+            "url": "https://www.verify.service.gov.uk",
             "description": "Let users prove their identity to you securely and conveniently"
           },
           {


### PR DESCRIPTION
This URL now redirects to the real Verify site, so we don't have to link to the cloudapps domain.