### PR TITLE
Use `rubocop-govuk` instead of `govuk-lint`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
-AllCops:
-  TargetRubyVersion: 2.6
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
 
 Metrics/BlockLength:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -35,8 +35,8 @@ group :development, :test do
   gem "pry"
   gem "pry-nav"
   gem "pry-remote"
-  gem "rubocop-govuk"
   gem "rspec-rails", "~> 3.9"
+  gem "rubocop-govuk"
   gem "simplecov", require: false
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -31,11 +31,11 @@ end
 group :development, :test do
   gem "byebug"
   gem "fuubar"
-  gem "govuk-lint"
   gem "jasmine"
   gem "pry"
   gem "pry-nav"
   gem "pry-remote"
+  gem "rubocop-govuk"
   gem "rspec-rails", "~> 3.9"
   gem "simplecov", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,11 +132,6 @@ GEM
       sanitize (~> 5)
     govuk-content-schema-test-helpers (1.6.1)
       json-schema (~> 2.8.0)
-    govuk-lint (4.3.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_admin_template (6.7.0)
       bootstrap-sass (= 3.4.1)
       jquery-rails (~> 4.3.1)
@@ -248,8 +243,8 @@ GEM
     omniauth-oauth2 (1.3.1)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
-    parallel (1.18.0)
-    parser (2.6.5.0)
+    parallel (1.19.1)
+    parser (2.7.0.4)
       ast (~> 2.4.0)
     pg (1.2.2)
     phantomjs (2.1.1.0)
@@ -301,9 +296,6 @@ GEM
     rainbow (3.0.0)
     raindrops (0.19.1)
     rake (13.0.1)
-    rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
-      ffi (~> 1.0)
     redcarpet (3.5.0)
     regexp_parser (1.6.0)
     request_store (1.5.0)
@@ -332,17 +324,21 @@ GEM
       rspec-mocks (~> 3.9.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
-    rubocop (0.76.0)
+    rubocop (0.77.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-rails (2.3.2)
+    rubocop-govuk (2.0.0)
+      rubocop (= 0.77)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
+    rubocop-rails (2.4.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
-    rubocop-rspec (1.36.0)
+    rubocop-rspec (1.38.1)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     rubyzip (2.0.0)
@@ -351,11 +347,6 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.8.0)
       nokogumbo (~> 2.0)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.2.1)
@@ -366,8 +357,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     select2-rails (4.0.3)
       thor (~> 0.14)
     selenium-webdriver (3.142.6)
@@ -398,7 +387,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.6)
-    unicode-display_width (1.6.0)
+    unicode-display_width (1.6.1)
     unicorn (5.5.3)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -439,7 +428,6 @@ DEPENDENCIES
   gds-sso
   govspeak
   govuk-content-schema-test-helpers
-  govuk-lint
   govuk_admin_template
   govuk_app_config (~> 2.0.3)
   govuk_test
@@ -457,6 +445,7 @@ DEPENDENCIES
   redcarpet
   rinku
   rspec-rails (~> 3.9)
+  rubocop-govuk
   sass-rails
   select2-rails
   simplecov
@@ -464,4 +453,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.2
+   1.17.2

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,5 +1,0 @@
-desc "Run the linter"
-task :lint do
-  sh "bundle exec govuk-lint-ruby --diff --cached --format clang app lib spec test"
-  sh "bundle exec govuk-lint-sass app"
-end


### PR DESCRIPTION
- This only enables Ruby cops as there were a lot more errors from the Rails cops. See commits for more details.
- Part of the GOV.UK Developer Tooling group: https://trello.com/c/pR7GEFfU/128-make-all-current-govuk-repos-use-rubocop-govuk-instead-of-govuk-lint