### PR TITLE
Add rake task to unpublish email signup pages

### DIFF
--- a/lib/tasks/unpublish_email_signup.rake
+++ b/lib/tasks/unpublish_email_signup.rake
@@ -1,0 +1,22 @@
+desc "Unpublish all email signup pages"
+task unpublish_email_signup: :environment do
+  Topic.find_each do |topic|
+    presenter = TopicPresenter.new(topic)
+    email_signup_presenter = TopicEmailAlertSignupPresenter.new(topic)
+
+    RedirectPublisher.new.process(
+      content_id: topic.email_alert_signup_content_id,
+      old_path: email_signup_presenter.content_payload[:base_path],
+      new_path: presenter.content_payload[:base_path],
+    )
+  end
+
+  service_standard_presenter = ServiceStandardPresenter.new
+  service_standard_email_presenter = ServiceStandardEmailAlertSignupPresenter.new
+
+  RedirectPublisher.new.process(
+    content_id: service_standard_email_presenter.content_id,
+    old_path: service_standard_email_presenter.content_payload[:base_path],
+    new_path: service_standard_presenter.content_payload[:base_path],
+  )
+end


### PR DESCRIPTION
https://trello.com/c/KNWv9Dgx/258-deprecate-and-remove-legacy-email-signup-pages

Depends on: https://github.com/alphagov/service-manual-frontend/pull/728

This is because the frontend no longer links to them, and uses the
generic functionality of Email Alert Frontend Instead.

Future work:

- [x] Test this on Integration
- [ ] Run the task
- [ ] Remove the code to publish the legacy pages
- [ ] Remove the task
- [ ] Remove inaccurate content store examples