### PR TITLE
Add error handler for Notify BadRequestError

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,8 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   before_action :set_authenticated_user_header
 
+  rescue_from Notifications::Client::BadRequestError, with: :notify_bad_request
+
   def preview_content_model_url(content_model)
     [Plek.new.external_url_for("draft-origin"), content_model.slug].join("")
   end
@@ -16,5 +18,9 @@ class ApplicationController < ActionController::Base
     if current_user && GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user].nil?
       GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, current_user.uid)
     end
+  end
+
+  def notify_bad_request(_exception)
+    render plain: "Error: One or more recipients not in GOV.UK Notify team (code: 400)", status: :bad_request
   end
 end


### PR DESCRIPTION
When using a Notify service with an e-mail address allow list, or in trial mode, submitting an email-addresses that is not included in the team will trigger a Notifications::Client::BadRequestError with the message Can't send to this recipient using a team-only API key.

This PR will allow the app to gracefully handle this error.

[Trello](https://trello.com/c/lLISrn5R/2182-3-handle-not-in-team-notify-error-in-service-manual-publisher)