### PR TITLE
GOVSI-484: Add "GOV.UK Sign in" to the service toolkit

### DIFF
--- a/app/presenters/service_toolkit_presenter.rb
+++ b/app/presenters/service_toolkit_presenter.rb
@@ -143,11 +143,6 @@ class ServiceToolkitPresenter
             "description": "Take and process payments - a simple experience for users and easy integration for you",
           },
           {
-            "title": "GOV.UK Verify",
-            "url": "https://www.verify.service.gov.uk",
-            "description": "Let users prove their identity to you securely and conveniently",
-          },
-          {
             "title": "GOV.UK Platform as a Service",
             "url": "https://www.cloud.service.gov.uk",
             "description": "Host your service on a government cloud platform without having to build and manage your own infrastructure",

--- a/app/presenters/service_toolkit_presenter.rb
+++ b/app/presenters/service_toolkit_presenter.rb
@@ -152,6 +152,11 @@ class ServiceToolkitPresenter
             "url": "https://www.cloud.service.gov.uk",
             "description": "Host your service on a government cloud platform without having to build and manage your own infrastructure",
           },
+          {
+            "title": "GOV.UK Sign in",
+            "url": "https://www.sign-in.service.gov.uk",
+            "description": "Let your users sign in quickly, easily and securely to your service",
+          },
         ],
       },
       {

--- a/app/presenters/service_toolkit_presenter.rb
+++ b/app/presenters/service_toolkit_presenter.rb
@@ -153,9 +153,9 @@ class ServiceToolkitPresenter
             "description": "Host your service on a government cloud platform without having to build and manage your own infrastructure",
           },
           {
-            "title": "GOV.UK Sign in",
+            "title": "GOV.UK Sign in (beta)",
             "url": "https://www.sign-in.service.gov.uk",
-            "description": "Let your users sign in quickly, easily and securely to your service",
+            "description": "Let users sign in to your service quickly, easily and securely. Register for the private beta.",
           },
         ],
       },


### PR DESCRIPTION
Digital Identity are starting a beta programme for the GOV.UK Sign in product. Add the link to the product page to the service toolkit.