### PR TITLE
Use PostgreSQL 13 in Continuous Integration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,4 +4,7 @@ library("govuk")
 
 node {
   govuk.buildProject()
+
+  // Run against the PostgreSQL 13 Docker instance on GOV.UK CI
+  govuk.setEnvar("TEST_DATABASE_URL", "postgresql://postgres@127.0.0.1:54313/service-manual-publisher_test")
 }


### PR DESCRIPTION
In CI, [PostgreSQL 13 is available at port 54313](https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-on-jenkins-ci.html#specifying-which-database-to-use).

Previously we were using the default port of 5432, which is running PostgreSQL 9.6.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[Trello card](https://trello.com/c/zVdVJqFM)