### PR TITLE
Add page description to browser titles

### DIFF
--- a/app/views/edition_changes/show.html.erb
+++ b/app/views/edition_changes/show.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :page_title, "Compare changes" %>
+
 <%= render 'editions/header_with_navigation', edition: @edition, guide: @edition.guide %>
 <div class="row">
   <%= render 'editions/old_edition_alert', edition: @edition, guide: @edition.guide %>

--- a/app/views/editions/index.html.erb
+++ b/app/views/editions/index.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :page_title, "Comments and history" %>
+
 <%= render 'editions/header_with_navigation', edition: @current_edition, guide: @guide %>
 <%= render 'editions/old_edition_alert', edition: @current_edition, guide: @guide %>
 

--- a/app/views/guides/edit.html.erb
+++ b/app/views/guides/edit.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :page_title, "Edit #{@guide_form.guide.model_name.human.downcase}" %>
+
 <%= render 'editions/header_with_navigation', edition: @guide_form.edition, guide: @guide_form.guide %>
 
 <div class="row">

--- a/app/views/guides/index.html.erb
+++ b/app/views/guides/index.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :page_title, "Guides" %>
+
 <div class="row">
   <div class="col-md-3">
     <p>

--- a/app/views/guides/new.html.erb
+++ b/app/views/guides/new.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :page_title, "Add #{@guide_form.guide.model_name.human.downcase}" %>
+
 <div class="row">
   <%= render 'form', guide_form: @guide_form %>
 </div>

--- a/app/views/guides/unpublish.html.erb
+++ b/app/views/guides/unpublish.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :page_title, "Unpublish #{@guide.title}" %>
+
 <%= render 'shared/form_error_summary', full_messages: @errors || [] %>
 
 <div class='well'>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tag %>
 <% end %>
+<% content_for :page_title, " | GOV.UK Service Manual Publisher" %>
 <% content_for :app_title do %>GOV.UK Service Manual Publisher<% end %>
 
 <% if current_user %>

--- a/app/views/slug_migrations/edit.html.erb
+++ b/app/views/slug_migrations/edit.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :page_title, "Edit slug migration" %>
+
 <div class='well'>
   <%= form_for @slug_migration do |f| %>
     <h2>Slug Migration <small><%= @slug_migration.slug %></small></h2>

--- a/app/views/slug_migrations/index.html.erb
+++ b/app/views/slug_migrations/index.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :page_title, "Slug migrations" %>
+
 <div class="row">
   <div class="col-md-2">
     <div class="slug-filters well sidebar-nav">

--- a/app/views/slug_migrations/show.html.erb
+++ b/app/views/slug_migrations/show.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :page_title, "Slug migration" %>
+
 <div class='well'>
   <h2>Slug Migration <small><%= @slug_migration.slug %></small></h2>
   <% if @slug_migration.completed? %>

--- a/app/views/topics/edit.html.erb
+++ b/app/views/topics/edit.html.erb
@@ -1,1 +1,3 @@
+<%= content_for :page_title, "Edit #{@topic.title}" %>
+
 <%= render 'form', topic: @topic %>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :page_title, "Topics" %>
+
 <div class="row">
   <div class="col-md-3">
     <p>

--- a/app/views/topics/new.html.erb
+++ b/app/views/topics/new.html.erb
@@ -1,1 +1,3 @@
+<%= content_for :page_title, "New topic" %>
+
 <%= render 'form', topic: @topic %>


### PR DESCRIPTION
### Description

When you navigate through a service the browser title should be descriptive of the primary function of the page you’re on.

This adds a browser title for each view and ensures that the format follows the `page title | service name` pattern. For example

|Before|After
|------------|------------|
|<img width="757" alt="image" src="https://user-images.githubusercontent.com/42515961/153900928-18a77d58-3c6d-4204-a6a8-319760890bd8.png">|<img width="769" alt="image" src="https://user-images.githubusercontent.com/42515961/153900104-35d9fb4d-7aa0-4b59-86e0-c40d34032e91.png">|

### Trello card 

https://trello.com/c/5EBSgwl4/361-browser-title-is-not-descriptive-of-pages-function

### Guidance to review

It's probably easiest to just run the branch locally and click around checking that the browser titles for each page (new/edit/index/show for guides, slugs and topics make sense).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️