### PR TITLE
Re-enable Sass CSS compression

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,11 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress CSS using a preprocessor.
-  config.assets.css_compressor = :sass
+  # config.assets.css_compressor = :sass
+
+  # Rather than use a CSS compressor, use the SASS style to perform compression
+  config.sass.style = :compressed
+  config.sass.line_comments = false
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false


### PR DESCRIPTION
Accidentally removed during Rails 7 upgrade and was causing errors in production.

Originally added here: https://github.com/alphagov/service-manual-publisher/commit/23690ae327362dd5feace4167c089801cb13ef07

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️