### PR TITLE
Remove GOV.UK PaaS

### DIFF
--- a/app/presenters/service_toolkit_presenter.rb
+++ b/app/presenters/service_toolkit_presenter.rb
@@ -143,11 +143,6 @@ class ServiceToolkitPresenter
             "description": "Take and process payments - a simple experience for users and easy integration for you",
           },
           {
-            "title": "GOV.UK Platform as a Service",
-            "url": "https://www.cloud.service.gov.uk",
-            "description": "Host your service on a government cloud platform without having to build and manage your own infrastructure",
-          },
-          {
             "title": "GOV.UK Sign in (beta)",
             "url": "https://www.sign-in.service.gov.uk",
             "description": "Let users sign in to your service quickly, easily and securely. Register for the private beta.",


### PR DESCRIPTION
As PaaS is being [decommissioned](https://gds.blog.gov.uk/2022/07/12/why-weve-decided-to-decommission-gov-uk-paas-platform-as-a-service/) we shouldn't be recommending it any more.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️