### PR TITLE
Change the frontend rendering target to be Government Frontend

### DIFF
--- a/app/helpers/public_routes_helper.rb
+++ b/app/helpers/public_routes_helper.rb
@@ -1,6 +1,6 @@
 module PublicRoutesHelper
   def document_preview_url(base_path)
-    frontend_host = Rails.env.production? ? Plek.new.external_url_for("draft-origin") : Plek.new.external_url_for("service-manual-frontend")
+    frontend_host = Rails.env.production? ? Plek.new.external_url_for("draft-origin") : Plek.new.external_url_for("government-frontend")
     [frontend_host, base_path].join
   end
 end

--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -9,7 +9,7 @@ class GuidePresenter
   def content_payload
     {
       publishing_app: "service-manual-publisher",
-      rendering_app: "service-manual-frontend",
+      rendering_app: "government-frontend",
       schema_name: "service_manual_guide",
       document_type: "service_manual_guide",
       locale: "en",

--- a/app/presenters/homepage_presenter.rb
+++ b/app/presenters/homepage_presenter.rb
@@ -17,7 +17,7 @@ class HomepagePresenter
       document_type: "service_manual_homepage",
       schema_name: "service_manual_homepage",
       publishing_app: "service-manual-publisher",
-      rendering_app: "service-manual-frontend",
+      rendering_app: "government-frontend",
       locale: "en",
     }
   end

--- a/app/presenters/service_standard_presenter.rb
+++ b/app/presenters/service_standard_presenter.rb
@@ -13,7 +13,7 @@ class ServiceStandardPresenter
       locale: "en",
       phase: "beta",
       publishing_app: "service-manual-publisher",
-      rendering_app: "service-manual-frontend",
+      rendering_app: "government-frontend",
       routes: [
         { type: "exact", path: "/service-manual/service-standard" },
       ],

--- a/app/presenters/service_toolkit_presenter.rb
+++ b/app/presenters/service_toolkit_presenter.rb
@@ -19,7 +19,7 @@ class ServiceToolkitPresenter
       document_type: "service_manual_service_toolkit",
       schema_name: "service_manual_service_toolkit",
       publishing_app: "service-manual-publisher",
-      rendering_app: "service-manual-frontend",
+      rendering_app: "government-frontend",
       locale: "en",
     }
   end

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -8,7 +8,7 @@ class TopicPresenter
   def content_payload
     {
       publishing_app: "service-manual-publisher",
-      rendering_app: "service-manual-frontend",
+      rendering_app: "government-frontend",
       schema_name: "service_manual_topic",
       document_type: "service_manual_topic",
       locale: "en",

--- a/spec/presenters/homepage_presenter_spec.rb
+++ b/spec/presenters/homepage_presenter_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe HomepagePresenter, "#content_payload" do
 
     expect(payload).to include \
       publishing_app: "service-manual-publisher",
-      rendering_app: "service-manual-frontend"
+      rendering_app: "government-frontend"
   end
 
   it "includes the document and schema type" do

--- a/spec/presenters/service_standard_presenter_spec.rb
+++ b/spec/presenters/service_standard_presenter_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ServiceStandardPresenter, "#content_payload" do
       locale: "en",
       phase: "beta",
       publishing_app: "service-manual-publisher",
-      rendering_app: "service-manual-frontend",
+      rendering_app: "government-frontend",
       routes: [
         { type: "exact", path: "/service-manual/service-standard" },
       ],

--- a/spec/presenters/service_toolkit_presenter_spec.rb
+++ b/spec/presenters/service_toolkit_presenter_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe ServiceToolkitPresenter, "#content_payload" do
       document_type: "service_manual_service_toolkit",
       schema_name: "service_manual_service_toolkit",
       publishing_app: "service-manual-publisher",
-      rendering_app: "service-manual-frontend",
+      rendering_app: "government-frontend",
       locale: "en",
     )
   end

--- a/spec/support/common_service_manual_draft_payload.rb
+++ b/spec/support/common_service_manual_draft_payload.rb
@@ -13,8 +13,8 @@ shared_examples "common service manual draft payload" do
     expect(payload).to include(publishing_app: "service-manual-publisher")
   end
 
-  it "is rendering by the service-manual-frontend" do
-    expect(payload).to include(rendering_app: "service-manual-frontend")
+  it "is rendering by the government-frontend" do
+    expect(payload).to include(rendering_app: "government-frontend")
   end
 
   it "is in locale en" do


### PR DESCRIPTION
Done as part of the migration away from Service Manuals Frontend

**!!Do Not Merge!!** It requires work from another card to Government Frontend. See Trello cards for details.

Card for this: https://trello.com/c/Xuink3mi/470-change-service-manual-publisher-rendering-app-s
Reliance: https://trello.com/c/1gPCngv0/1136-migrate-service-manual-frontend-templates-into-government-frontend-m

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️