### PR TITLE
This sets the asset path to include the application name.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -38,6 +38,10 @@ module ServiceManualPublisher
     # https://github.com/alphagov/govuk-frontend/issues/1350
     config.assets.css_compressor = nil
 
+    # Set asset path to be application specific so that we can put all GOV.UK
+    # assets into an S3 bucket and distinguish app by path.
+    config.assets.prefix = "/assets/service-manual-publisher"
+
     config.active_record.belongs_to_required_by_default = false
 
     ActiveSupport.to_time_preserves_timezone = false

--- a/spec/support/jasmine-browser.json
+++ b/spec/support/jasmine-browser.json
@@ -1,5 +1,5 @@
 {
-   "srcDir": "public/assets",
+   "srcDir": "public/assets/service-manual-publisher",
    "srcFiles": [
      "govuk-admin-template-*.js",
      "application-*.js"


### PR DESCRIPTION
Background to this change can be found here:
https://github.com/alphagov/manuals-publisher/pull/2004

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
