### PR TITLE
Add a link to the file upload page

### DIFF
--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -67,7 +67,10 @@
         <%= f.error_list :body %>
         <%= file_field_tag 'attachment', multiple: true, class: "js-markdown-file-input hidden" %>
         <p class="help-block">
-          To insert images either <a class="js-markdown-file-input-trigger" href="javascript:void(0);">click here</a>, or drag and drop them into the text area below
+          To insert images either <a class="js-markdown-file-input-trigger" href="javascript:void(0);">click here</a>, or drag and drop them into the text area below.
+        </p>
+        <p class="help-block">
+          To add an attachment, first <%= link_to "upload the file (opens in new tab)", new_upload_path, target: "_blank" %>. 
         </p>
         <%= f.text_area :body, disabled: disable_inputs, class: 'js-markdown-image-upload input-md-12 form-control markdown-textarea text-area-auto-size text-area-auto-size-large js-text-area-auto-size', rows: 14 %>
       </div>


### PR DESCRIPTION
## What

Add a link to the file upload page.
It opens in a new tab so publishers don't lose changes to the document.
The image upload doesn't allow non-image files.

#### Before

<kbd><img width="624" alt="Screenshot 2023-11-03 at 14 52 48" src="https://github.com/alphagov/service-manual-publisher/assets/38078064/e6ed61e6-137d-421e-8dca-b426c47eb088"></kbd>

#### After

<kbd><img width="615" alt="Screenshot 2023-11-03 at 15 17 27" src="https://github.com/alphagov/service-manual-publisher/assets/38078064/00bfdd9f-70ed-42ce-ab74-83e16ddce69f"></kbd>

## Why

When Editors want to add new attachments they need to be first uploaded to the Asset Manager. There is functionality to do it in the app but there's no link to that page. Editors were asking in Slack for developers to add the file to the Asset manager.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
