### PR TITLE
Reinstate missing GOV.UK Notify configuration

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,6 +66,12 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  #  Use GOVUK Notify to send emails
+  config.action_mailer.delivery_method = :notify
+  config.action_mailer.notify_settings = {
+    api_key: ENV["GOVUK_NOTIFY_API_KEY"],
+  }
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
This important piece of configuration was lost during the upgrade to Rails 7.1 in 86182ba87f41fa19b9b14e91398860d2460a68c4

Trello: https://trello.com/c/tG6dm3GY
