### PR TITLE
Update incorrect url in service_toolkit_presenter.rb

### DIFF
--- a/app/presenters/service_toolkit_presenter.rb
+++ b/app/presenters/service_toolkit_presenter.rb
@@ -36,7 +36,7 @@ class ServiceToolkitPresenter
         "links": [
           {
             "title": "Technology Code of Practice",
-            "url": "https://www.gov.uk/service-manual/service-standard",
+            "url": "https://www.gov.uk/guidance/the-technology-code-of-practice",
             "description": "The standard you must meet to get approval to spend money on technology or a service",
           },
           {


### PR DESCRIPTION
'Technology Code of Practice' link currently points to the Service Standard url, which is a mistake. I've updated it to point to the correct url.

I can't run the app locally, so apologies for any mistakes.