### PR TITLE
Finish upgrade to frontend 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem "redcarpet"
 gem "rinku", require: "rails_rinku"
 gem "select2-rails"
 gem "sprockets-rails"
-gem "uglifier"
+gem "terser"
 
 group :development do
   gem "better_errors"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -713,12 +713,12 @@ GEM
       sprockets (>= 3.0.0)
     statsd-ruby (1.5.0)
     stringio (3.1.1)
+    terser (1.2.3)
+      execjs (>= 0.3.0, < 3)
     thor (1.3.2)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (2.5.0)
     uri (0.13.0)
     useragent (0.16.10)
@@ -783,7 +783,7 @@ DEPENDENCIES
   select2-rails
   simplecov
   sprockets-rails
-  uglifier
+  terser
   webmock
 
 BUNDLED WITH


### PR DESCRIPTION
These changes wrap up the upgrade to FE5.

- Replace uglifier with terser.
- There was no need to separate out ES6 modules components since this app does not use any. In the future, such components would need to be imported separately. Follow instructions in the [documentation](https://docs.google.com/document/d/1uwip7pzQwM7t5ghn9_8KrsWXLePSRUltFPZ5fYw6Ab8/edit#heading=h.r2y7qlyvg991). See also [example PR](https://github.com/alphagov/manuals-publisher/pull/2484/files).

[Trello card](https://trello.com/c/vbqszQXq/2762-update-publishing-apps-to-govukpublishingcomponents-v4000)
