### PR TITLE
Change /service-toolkit rendering app to frontend

### DIFF
--- a/app/presenters/service_toolkit_presenter.rb
+++ b/app/presenters/service_toolkit_presenter.rb
@@ -19,7 +19,7 @@ class ServiceToolkitPresenter
       document_type: "service_manual_service_toolkit",
       schema_name: "service_manual_service_toolkit",
       publishing_app: "service-manual-publisher",
-      rendering_app: "government-frontend",
+      rendering_app: "frontend",
       locale: "en",
     }
   end

--- a/spec/presenters/service_toolkit_presenter_spec.rb
+++ b/spec/presenters/service_toolkit_presenter_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe ServiceToolkitPresenter, "#content_payload" do
       document_type: "service_manual_service_toolkit",
       schema_name: "service_manual_service_toolkit",
       publishing_app: "service-manual-publisher",
-      rendering_app: "government-frontend",
+      rendering_app: "frontend",
       locale: "en",
     )
   end


### PR DESCRIPTION
## What / Why
- Change the `/service-toolkit` rendering app to `frontend` as it has been migrated from `government-frontend` in https://github.com/alphagov/frontend/pull/4713
- Trello card: https://trello.com/c/JlzWbXwM/546-move-service-toolkit-from-government-frontend-to-frontend

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
