### PR TITLE
Point service manual homepage rendering to frontend

### DIFF
--- a/app/presenters/homepage_presenter.rb
+++ b/app/presenters/homepage_presenter.rb
@@ -17,7 +17,7 @@ class HomepagePresenter
       document_type: "service_manual_homepage",
       schema_name: "service_manual_homepage",
       publishing_app: "service-manual-publisher",
-      rendering_app: "government-frontend",
+      rendering_app: "frontend",
       locale: "en",
     }
   end

--- a/spec/presenters/homepage_presenter_spec.rb
+++ b/spec/presenters/homepage_presenter_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe HomepagePresenter, "#content_payload" do
 
     expect(payload).to include \
       publishing_app: "service-manual-publisher",
-      rendering_app: "government-frontend"
+      rendering_app: "frontend"
   end
 
   it "includes the document and schema type" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Change the rendering app of the service manual homepage from `government-frontend` to `frontend`.

## Why
- part of the route migration of https://www.gov.uk/service-manual from government-frontend to frontend
- see also https://github.com/alphagov/frontend/pull/4689


Trello card: https://trello.com/c/ANPt33UZ/508-move-route-service-manual-homepage-only-from-government-frontend-to-frontend