### PR TITLE
Re-enable tests

### DIFF
--- a/spec/features/preventing_loss_of_changes_spec.rb
+++ b/spec/features/preventing_loss_of_changes_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Preventing users from losing unsaved changes in the form", type:
     stub_const("PUBLISHING_API", publishing_api)
   end
 
-  xit "asks the user for confirmation when navigating away via 'Request review'", js: true do
+  it "asks the user for confirmation when navigating away via 'Request review'", js: true do
     guide = create(:guide, :with_draft_edition, slug: "/service-manual/topic-name/test")
     visit edit_guide_path(guide)
     fill_in "Body", with: "This has changed"
@@ -28,7 +28,7 @@ RSpec.describe "Preventing users from losing unsaved changes in the form", type:
     visit edit_guide_path(guide)
   end
 
-  xit "does not notify the user when navigating away via 'Save'", js: true do
+  it "does not notify the user when navigating away via 'Save'", js: true do
     guide = create(:guide, :with_draft_edition, slug: "/service-manual/topic-name/test")
     visit edit_guide_path(guide)
     fill_in "Body", with: "This has changed"


### PR DESCRIPTION
These tests were temporarily disabled in
https://github.com/alphagov/service-manual-publisher/pull/1517

Trello: https://trello.com/c/7FTvIbPD/3589-re-enable-tests-disabled-due-to-unable-to-find-modal-dialog-error

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
