### PR TITLE
Service manual service standard migration

### DIFF
--- a/app/presenters/service_standard_presenter.rb
+++ b/app/presenters/service_standard_presenter.rb
@@ -13,7 +13,7 @@ class ServiceStandardPresenter
       locale: "en",
       phase: "beta",
       publishing_app: "service-manual-publisher",
-      rendering_app: "government-frontend",
+      rendering_app: "frontend",
       routes: [
         { type: "exact", path: "/service-manual/service-standard" },
       ],

--- a/app/presenters/service_standard_presenter.rb
+++ b/app/presenters/service_standard_presenter.rb
@@ -11,7 +11,6 @@ class ServiceStandardPresenter
       document_type: "service_manual_service_standard",
       update_type: "major",
       locale: "en",
-      phase: "beta",
       publishing_app: "service-manual-publisher",
       rendering_app: "frontend",
       routes: [

--- a/spec/presenters/service_standard_presenter_spec.rb
+++ b/spec/presenters/service_standard_presenter_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ServiceStandardPresenter, "#content_payload" do
       locale: "en",
       phase: "beta",
       publishing_app: "service-manual-publisher",
-      rendering_app: "government-frontend",
+      rendering_app: "frontend",
       routes: [
         { type: "exact", path: "/service-manual/service-standard" },
       ],

--- a/spec/presenters/service_standard_presenter_spec.rb
+++ b/spec/presenters/service_standard_presenter_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe ServiceStandardPresenter, "#content_payload" do
       base_path: "/service-manual/service-standard",
       document_type: "service_manual_service_standard",
       locale: "en",
-      phase: "beta",
       publishing_app: "service-manual-publisher",
       rendering_app: "frontend",
       routes: [


### PR DESCRIPTION
- Migrates `service_manual_service_standard`'s publishing app to `frontend`
- Removes `phase` so the phase banner component will no longer render.
- Related to https://github.com/alphagov/frontend/pull/4796