### PR TITLE
Change service_manual_guide rendering app to frontend

### DIFF
--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -9,7 +9,7 @@ class GuidePresenter
   def content_payload
     {
       publishing_app: "service-manual-publisher",
-      rendering_app: "government-frontend",
+      rendering_app: "frontend",
       schema_name: "service_manual_guide",
       document_type: "service_manual_guide",
       locale: "en",
@@ -17,7 +17,6 @@ class GuidePresenter
       base_path: guide.slug,
       title: edition.title,
       description: edition.description,
-      phase: edition.phase,
       routes: [
         { type: "exact", path: guide.slug },
       ],

--- a/spec/presenters/guide_presenter_spec.rb
+++ b/spec/presenters/guide_presenter_spec.rb
@@ -16,14 +16,15 @@ RSpec.describe GuidePresenter do
         presenter.content_payload
       end
 
-      include_examples "common service manual draft payload"
+      include_examples "common service manual draft payload" do
+        let(:rendering_app) { "frontend" }
+      end
     end
 
     it "exports all necessary metadata" do
       guide = create(
         :guide,
         edition: {
-          phase: "beta",
           update_type: "major",
           description: "Description",
         },
@@ -34,7 +35,6 @@ RSpec.describe GuidePresenter do
       expect(presenter.content_payload).to include(
         description: "Description",
         update_type: "major",
-        phase: "beta",
         schema_name: "service_manual_guide",
         document_type: "service_manual_guide",
         base_path: "/service-manual/test-topic/the-title",

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe TopicPresenter, "#content_payload" do
   describe "common service manual draft payload" do
     let(:payload) { described_class.new(build(:topic)).content_payload }
 
-    include_examples "common service manual draft payload"
+    include_examples "common service manual draft payload" do
+      let(:rendering_app) { "government-frontend" }
+    end
   end
 
   it "exports all necessary metadata" do

--- a/spec/support/common_service_manual_draft_payload.rb
+++ b/spec/support/common_service_manual_draft_payload.rb
@@ -13,8 +13,8 @@ shared_examples "common service manual draft payload" do
     expect(payload).to include(publishing_app: "service-manual-publisher")
   end
 
-  it "is rendering by the government-frontend" do
-    expect(payload).to include(rendering_app: "government-frontend")
+  it "is rendering by the correct rendering app" do
+    expect(payload).to include(rendering_app: rendering_app)
   end
 
   it "is in locale en" do


### PR DESCRIPTION
- Switches the `service_manual_guide` rendering app from `government-frontend` to `frontend`
- To do this I had to introduce a `rendering_app` variable on some shared tests
- Also removes the `phase` as we're getting rid of the beta banner
- Related to https://github.com/alphagov/frontend/pull/4852 & https://trello.com/c/88enzZXt/675-move-servicemanualguide-from-government-frontend-to-frontend


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
