### PR TITLE
Point service manual topic rendering to frontend

### DIFF
--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -8,7 +8,7 @@ class TopicPresenter
   def content_payload
     {
       publishing_app: "service-manual-publisher",
-      rendering_app: "government-frontend",
+      rendering_app: "frontend",
       schema_name: "service_manual_topic",
       document_type: "service_manual_topic",
       locale: "en",
@@ -16,7 +16,6 @@ class TopicPresenter
       base_path: topic.path,
       title: topic.title,
       description: topic.description,
-      phase: "beta",
       routes: [
         { type: "exact", path: topic.path },
       ],

--- a/spec/presenters/guide_presenter_spec.rb
+++ b/spec/presenters/guide_presenter_spec.rb
@@ -16,9 +16,7 @@ RSpec.describe GuidePresenter do
         presenter.content_payload
       end
 
-      include_examples "common service manual draft payload" do
-        let(:rendering_app) { "frontend" }
-      end
+      include_examples "common service manual draft payload"
     end
 
     it "exports all necessary metadata" do

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -10,9 +10,7 @@ RSpec.describe TopicPresenter, "#content_payload" do
   describe "common service manual draft payload" do
     let(:payload) { described_class.new(build(:topic)).content_payload }
 
-    include_examples "common service manual draft payload" do
-      let(:rendering_app) { "government-frontend" }
-    end
+    include_examples "common service manual draft payload"
   end
 
   it "exports all necessary metadata" do
@@ -27,7 +25,6 @@ RSpec.describe TopicPresenter, "#content_payload" do
     expect(topic_presenter.content_payload).to include(
       description: "Topic description",
       update_type: "major",
-      phase: "beta",
       schema_name: "service_manual_topic",
       document_type: "service_manual_topic",
       base_path: "/service-manual/test-topic",

--- a/spec/support/common_service_manual_draft_payload.rb
+++ b/spec/support/common_service_manual_draft_payload.rb
@@ -13,8 +13,8 @@ shared_examples "common service manual draft payload" do
     expect(payload).to include(publishing_app: "service-manual-publisher")
   end
 
-  it "is rendering by the correct rendering app" do
-    expect(payload).to include(rendering_app: rendering_app)
+  it "is rendered by frontend" do
+    expect(payload).to include(rendering_app: "frontend")
   end
 
   it "is in locale en" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Change the rendering app of service manual topic pages from `government-frontend` to `frontend`.

## Why
- part of the route migration of sm topic pages from government-frontend to frontend
- see also https://github.com/alphagov/frontend/pull/4847


Trello card: https://trello.com/c/FtdZwYL0/684-move-servicemanualtopic-from-government-frontend-to-frontend
