### PR TITLE
Update GTM container ID [WHIT-3365]

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,9 @@
   <%= csrf_meta_tag %>
 <% end %>
 
-<% render "layouts/google_tag_manager" %>
+<% render "layouts/google_tag_manager", {
+  gtm_id: "GTM-KHZP7S7Q",
+} %>
 
 <% content_for :page_title, " | GOV.UK Service Manual Publisher" %>
 <% content_for :app_title do %>GOV.UK Service Manual Publisher<% end %>


### PR DESCRIPTION
## What

Update GTM container ID.

## Why

Request from PAs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
