### PR TITLE
Update GOV.UK Prototype Kit URL in Service Toolkit

### DIFF
--- a/app/presenters/service_toolkit_presenter.rb
+++ b/app/presenters/service_toolkit_presenter.rb
@@ -73,7 +73,7 @@ class ServiceToolkitPresenter
           },
           {
             "title": "GOV.UK Prototype Kit",
-            "url": "https://govuk-prototype-kit.herokuapp.com/docs",
+            "url": "https://prototype-kit.service.gov.uk/",
             "description": "Create rapid prototypes of GOV.UK services",
           },
         ],


### PR DESCRIPTION
Part of https://github.com/alphagov/govuk-prototype-kit-docs/issues/316

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

> [!NOTE]
> 
> For this change to be applied I think the service toolkit page needs to be republished using [this rake task](https://github.com/alphagov/service-manual-publisher/blob/641960e4fbe8567e35a4471af4dc05378ce74b9b/lib/tasks/republish.rake#L34-L38).